### PR TITLE
Added AutoCodePaste

### DIFF
--- a/Modix/ModixBotHooks.cs
+++ b/Modix/ModixBotHooks.cs
@@ -9,6 +9,7 @@ using Discord.Commands;
 using Discord.WebSocket;
 using Modix.Data.Models;
 using Serilog;
+using Modix.Services.AutoCodePaste;
 
 namespace Modix
 {
@@ -46,6 +47,8 @@ namespace Modix
             var user = ((messageParam as SocketUserMessage)?.Author as SocketGuildUser);
 
             if (user == null) return;
+
+            await CodePasteHandler.MessageReceived(messageParam);
 
             //var msg = new DiscordMessage()
             //{

--- a/Modix/Modules/ReplModule.cs
+++ b/Modix/Modules/ReplModule.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using Modix.Data.Models;
 using System.Threading;
 using Discord.WebSocket;
+using Modix.Utilities;
 
 namespace Modix.Modules
 {
@@ -58,7 +59,7 @@ namespace Modix.Modules
             var guildUser = Context.User as SocketGuildUser;
             var message = await Context.Channel.SendMessageAsync("Working...");
 
-            var content = BuildContent(code);
+            var content = FormatUtilities.BuildContent(code);
 
             HttpResponseMessage res;
             try
@@ -94,14 +95,6 @@ namespace Modix.Modules
             });
 
             await Context.Message.DeleteAsync();
-        }
-
-        private StringContent BuildContent(string code)
-        {
-            var cleanCode = code.Replace("```csharp", string.Empty).Replace("```cs", string.Empty).Replace("```", string.Empty);
-            cleanCode = Regex.Replace(cleanCode.Trim(), "^`|`$", string.Empty); //strip out the ` characters from the beginning and end of the string
-
-            return new StringContent(cleanCode, Encoding.UTF8, "text/plain");
         }
 
         private EmbedBuilder BuildEmbed(SocketGuildUser guildUser, Result parsedResult)

--- a/Modix/Services/AutoCodePaste/CodePasteHandler.cs
+++ b/Modix/Services/AutoCodePaste/CodePasteHandler.cs
@@ -1,0 +1,42 @@
+﻿using Discord;
+using Discord.WebSocket;
+using Modix.Utilities;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Modix.Services.AutoCodePaste
+{
+    public class CodePasteHandler
+    {
+        const string Header = @"/*
+    ______ _                       _   _____   _  _   
+    |  _  (_)                     | | /  __ \_| || |_ 
+    | | | |_ ___  ___ ___  _ __ __| | | /  \/_  __  _|
+    | | | | / __|/ __/ _ \| '__/ _` | | |    _| || |_ 
+    | |/ /| \__ \ (_| (_) | | | (_| | | \__/\_  __  _|
+    |___/ |_|___/\___\___/|_|  \__,_|  \____/ |_||_|  
+    
+    Written By: {0} in #{1}
+    Posted on {2}
+    Message ID: {3}
+*/
+
+{4}";
+        internal static async Task MessageReceived(SocketMessage arg)
+        {
+            if (arg.Content.Length < 750) { return; }
+
+            string content = String.Format(Header, $"{arg.Author.Username}#{arg.Author.DiscriminatorValue}",
+                    arg.Channel.Name, DateTime.Now.ToString("dddd, MMMM d yyyy @ H:mm:ss"), arg.Id, FormatUtilities.FixIndentation(arg.Content));
+
+            string url = await new CodePasteService().UploadCode(content);
+
+            await arg.Channel.SendMessageAsync($"Sorry {arg.Author.Mention}, your message was a bit too long! Next time, paste long chunks of code elsewhere!\n{url}");
+            await arg.DeleteAsync();
+        }
+    }
+}

--- a/Modix/Services/AutoCodePaste/CodePasteService.cs
+++ b/Modix/Services/AutoCodePaste/CodePasteService.cs
@@ -1,0 +1,37 @@
+﻿using Modix.Utilities;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Modix.Services.AutoCodePaste
+{
+    public class CodePasteService
+    {
+        private string _ApiReferenceUrl = "https://hastebin.com/";
+
+        /// <summary>
+        /// Uploads a given piece of code to the service, and returns the URL to the post.
+        /// </summary>
+        /// <param name="code">The code to post</param>
+        /// <returns>The URL to the newly created post</returns>
+        public async Task<string> UploadCode(string code)
+        {
+            var client = new HttpClient();
+            var response = await client.PostAsync($"{_ApiReferenceUrl}documents", FormatUtilities.BuildContent(code));
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new WebException("Something failed while posting code to Hastebin.");
+            }
+
+            string urlResponse = await response.Content.ReadAsStringAsync();
+            string pasteKey = JObject.Parse(urlResponse)["key"].Value<string>();
+
+            return $"{_ApiReferenceUrl}{pasteKey}.cs";
+        }
+    }
+}

--- a/Modix/Utilities/FormatUtilities.cs
+++ b/Modix/Utilities/FormatUtilities.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Modix.Utilities
+{
+    public static class FormatUtilities
+    {
+        private static Regex _buildContentRegex = new Regex(@"```([^\s]+|)");
+
+        /// <summary>
+        /// Prepares a piece of input code for use in HTTP operations
+        /// </summary>
+        /// <param name="code">The code to prepare</param>
+        /// <returns>The resulting StringContent for HTTP operations</returns>
+        public static StringContent BuildContent(string code)
+        {
+            string cleanCode = _buildContentRegex.Replace(code.Trim(), string.Empty); //strip out the ` characters and code block markers
+            cleanCode = cleanCode.Replace("\t", "    "); //spaces > tabs
+            cleanCode = FixIndentation(cleanCode);
+
+            return new StringContent(cleanCode, Encoding.UTF8, "text/plain");
+        }
+
+        /// <summary>
+        /// Attempts to fix the indentation of a piece of code by aligning the left sidie.
+        /// </summary>
+        /// <param name="code">The code to align</param>
+        /// <returns>The newly aligned code</returns>
+        public static string FixIndentation(string code)
+        {
+            var lines = code.Split('\n');
+            string indentLine = lines.SkipWhile(d => d[0] != ' ').FirstOrDefault();
+            
+            if (indentLine != null)
+            {
+                int indent = indentLine.LastIndexOf(' ') + 1;
+
+                string pattern = $@"^[^\S\n]{{{indent}}}";
+
+                return Regex.Replace(code, pattern, "", RegexOptions.Multiline);
+            }
+
+            return code;
+        }
+    }
+}


### PR DESCRIPTION
This feature automatically uploads messages longer than a given length to a text pasting service, then deletes the original message.

Other than the addition of this service, I made a few small refactors - specifically extracting the code-block-stripping logic from the ReplModule into a separate class, and improving it slightly with a different regex. Further testing may be needed.