### PR TITLE
Added !quote command

### DIFF
--- a/Modix/ModixBot.cs
+++ b/Modix/ModixBot.cs
@@ -8,6 +8,7 @@ using Discord.WebSocket;
 using Modix.Data.Models;
 using Serilog;
 using Microsoft.Extensions.DependencyInjection;
+using Modix.Services.Quote;
 using Modix.Utilities;
 using Serilog.Events;
 
@@ -97,6 +98,7 @@ namespace Modix
         {
             _map.AddSingleton(_client);
             _map.AddSingleton(_config);
+            _map.AddScoped<IQuoteService, QuoteService>();
 
             _client.MessageReceived += HandleCommand;
             _client.MessageReceived += _hooks.HandleMessage;

--- a/Modix/Modules/QuoteModule.cs
+++ b/Modix/Modules/QuoteModule.cs
@@ -8,6 +8,13 @@ namespace Modix.Modules
     [Name("Quote Message"), Summary("Quote a message from the Guild with its ID")]
     public class QuoteModule : ModuleBase
     {
+        private readonly IQuoteService _quoteService;
+
+        public QuoteModule(IQuoteService quoteService)
+        {
+            _quoteService = quoteService;
+        }
+
         [Command("quote"), Summary("Quote a message using its Discord ID, returns a pretty embed of the message along with the author")]
         public async Task Run([Remainder] string id)
         {
@@ -18,7 +25,7 @@ namespace Modix.Modules
 
             if (message != null)
             {
-                var quoteEmbed = QuoteService.BuildQuoteEmbed(message);
+                var quoteEmbed = _quoteService.BuildQuoteEmbed(message);
 
                 await ReplyAsync(string.Empty, false, quoteEmbed);
             }

--- a/Modix/Modules/QuoteModule.cs
+++ b/Modix/Modules/QuoteModule.cs
@@ -1,0 +1,65 @@
+﻿using Discord.Commands;
+using System.Threading.Tasks;
+using Discord;
+using Modix.Services.Quote;
+
+namespace Modix.Modules
+{
+    [Name("Quote Message"), Summary("Quote a message from the Guild with its ID")]
+    public class QuoteModule : ModuleBase
+    {
+        [Command("quote"), Summary("Quote a message using its Discord ID, returns a pretty embed of the message along with the author")]
+        public async Task Run([Remainder] string id)
+        {
+            IMessage message = null;
+
+            if (ulong.TryParse(id, out var messageId))
+                message = await GetMessage(messageId);
+
+            if (message != null)
+            {
+                var quoteEmbed = QuoteService.BuildQuoteEmbed(message);
+
+                await ReplyAsync(string.Empty, false, quoteEmbed);
+            }
+            else
+            {
+                await ReplyFailure();
+            }
+
+            // Delete the message originally sent, we're done (even if we've failed fetching)
+            await Context.Message.DeleteAsync();
+        }
+
+        private async Task<IMessage> GetMessage(ulong messageId)
+        {
+            // Attempt to get the message from the channel the user
+            // is executing the command from
+            var message = await GetMessageInChannel(messageId);
+
+            if (message == null)
+            {
+                // We haven't found a message, now fetch all text
+                // channels and attempt to find the message
+
+                var channels = await Context.Guild.GetTextChannelsAsync();
+
+                foreach (var channel in channels)
+                {
+                    message = await GetMessageInChannel(messageId, channel);
+
+                    if (message != null)
+                        break;
+                }
+            }
+
+            return message;
+        }
+
+        private Task<IMessage> GetMessageInChannel(ulong messageId) => Context.Channel.GetMessageAsync(messageId);
+
+        private Task<IMessage> GetMessageInChannel(ulong messageId, ITextChannel channel) => channel.GetMessageAsync(messageId);
+
+        private Task ReplyFailure() => ReplyAsync($"I couldn't find the message you're referring to {Context.User.Mention}");
+    }
+}

--- a/Modix/Services/Quote/QuoteService.cs
+++ b/Modix/Services/Quote/QuoteService.cs
@@ -2,9 +2,14 @@
 
 namespace Modix.Services.Quote
 {
-    public static class QuoteService
+    public interface IQuoteService
     {
-        public static EmbedBuilder BuildQuoteEmbed(IMessage message)
+        EmbedBuilder BuildQuoteEmbed(IMessage message);
+    }
+
+    public class QuoteService : IQuoteService
+    {
+        public EmbedBuilder BuildQuoteEmbed(IMessage message)
         {
             return new EmbedBuilder()
                 .WithAuthor(message.Author)
@@ -14,7 +19,7 @@ namespace Modix.Services.Quote
         }
 
         private static string GetPostedMeta(IMessage message)
-            => string.Format("{0:dddd, dd}{1} {0:MMMM yyyy} at {0:HH:mm}, in {2}", message.Timestamp, GetDaySuffix(message.Timestamp.Day), $"#{message.Channel.Name}");
+            => string.Format("{0:dddd, dd}{1} {0:MMMM yyyy} at {0:HH:mm}, in #{2}", message.Timestamp, GetDaySuffix(message.Timestamp.Day), message.Channel.Name);
 
         private static string GetDaySuffix(int day)
         {

--- a/Modix/Services/Quote/QuoteService.cs
+++ b/Modix/Services/Quote/QuoteService.cs
@@ -1,0 +1,38 @@
+﻿using Discord;
+
+namespace Modix.Services.Quote
+{
+    public static class QuoteService
+    {
+        public static EmbedBuilder BuildQuoteEmbed(IMessage message)
+        {
+            return new EmbedBuilder()
+                .WithAuthor(message.Author)
+                .WithDescription(message.Content)
+                .WithFooter(GetPostedMeta(message))
+                .WithColor(new Color(95, 186, 125));
+        }
+
+        private static string GetPostedMeta(IMessage message)
+            => string.Format("{0:dddd, dd}{1} {0:MMMM yyyy} at {0:HH:mm}, in {2}", message.Timestamp, GetDaySuffix(message.Timestamp.Day), $"#{message.Channel.Name}");
+
+        private static string GetDaySuffix(int day)
+        {
+            switch (day)
+            {
+                case 1:
+                case 21:
+                case 31:
+                    return "st";
+                case 2:
+                case 22:
+                    return "nd";
+                case 3:
+                case 23:
+                    return "rd";
+                default:
+                    return "th";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added ability to invoke !quote and fetch the relevant Discord message with its ID

Syntax: `!quote {DiscordMessageId}`

There might be concern about the whole "if I can't find the message in the current channel, fetch all text channels in the entire guild and search until I find the message" feature. This can be removed as even I think the payload could be pretty large - I'm not entirely sure about how expensive this call is, however.

In action (ignore the bot name, it was one left over from two years ago I had available):

![image](https://user-images.githubusercontent.com/1341180/34231033-541bc182-e5d2-11e7-9233-2a0943709d47.png)

<img width="276" alt="discord_2017-12-20_22-07-34" src="https://user-images.githubusercontent.com/1341180/34231057-6f3ee5fc-e5d2-11e7-8b09-4c25af145dd0.png">
