### PR TITLE
Fixed permission error logging at warning level when executing !quote, now set to debug

### DIFF
--- a/Modix/Modules/QuoteModule.cs
+++ b/Modix/Modules/QuoteModule.cs
@@ -97,7 +97,7 @@ namespace Modix.Modules
                 }
                 catch (Exception e)
                 {
-                    Log.Warning(e, "Failed accessing channel {ChannelName} when searching for message {MessageId}",
+                    Log.Debug(e, "Failed accessing channel {ChannelName} when searching for message {MessageId}",
                         channel.Name, messageId);
                 }
             }


### PR DESCRIPTION
When executing !quote with just a Discord message ID, the bot will spam the log alerting that it cannot access channels it does not have permissions to. Has now been reduced to a debug message.