### PR TITLE
Basic automatic file upload moderation

### DIFF
--- a/Modix/ModixBotHooks.cs
+++ b/Modix/ModixBotHooks.cs
@@ -55,10 +55,14 @@ namespace Modix
             await _codePaste.ReactionRemoved(message, channel, reaction);
         }
 
-        public async Task HandleMessage(SocketMessage message)
+        public async Task HandleMessage(SocketMessage messageParam)
         {
-            if (message.Attachments.Any())
-                await _fileUploadHandler.Handle(message);
+            var user = ((messageParam as SocketUserMessage)?.Author as SocketGuildUser);
+
+            if (user == null) return;
+
+            if (messageParam.Attachments.Any())
+                await _fileUploadHandler.Handle(messageParam);
         }
     }
 }

--- a/Modix/ModixBotHooks.cs
+++ b/Modix/ModixBotHooks.cs
@@ -10,12 +10,14 @@ using Discord.WebSocket;
 using Modix.Data.Models;
 using Serilog;
 using Modix.Services.AutoCodePaste;
+using Modix.Services.FileUpload;
 
 namespace Modix
 {
     public class ModixBotHooks
     {
-        private CodePasteHandler codePaste = new CodePasteHandler();
+        private readonly CodePasteHandler _codePaste = new CodePasteHandler();
+        private readonly FileUploadHandler _fileUploadHandler = new FileUploadHandler();
 
         public Task HandleLog(LogMessage message)
         {
@@ -45,40 +47,18 @@ namespace Modix
 
         public async Task HandleAddReaction(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
         {
-            await codePaste.ReactionAdded(message, channel, reaction);
+            await _codePaste.ReactionAdded(message, channel, reaction);
         }
 
         public async Task HandleRemoveReaction(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel, SocketReaction reaction)
         {
-            await codePaste.ReactionRemoved(message, channel, reaction);
+            await _codePaste.ReactionRemoved(message, channel, reaction);
         }
 
-        public async Task HandleMessage(SocketMessage messageParam)
+        public async Task HandleMessage(SocketMessage message)
         {
-            var user = ((messageParam as SocketUserMessage)?.Author as SocketGuildUser);
-
-            if (user == null) return;
-
-            //var msg = new DiscordMessage()
-            //{
-                //AvatarId = user.AvatarId,
-                //AvatarUrl = user.AvatarUrl,
-                //Content = messageParam.Content,
-                //CreatedAt = messageParam.Timestamp.DateTime,
-                //Discriminator = user.Discriminator,
-                //DiscriminatorValue = user.DiscriminatorValue,
-                //Username = user.Username,
-                //IsBot = messageParam.Author.IsBot,
-                //MessageId = messageParam.Id,
-                //Mention = messageParam.Author.Mention,
-                //GuildId = user.Guild.Id,
-                //Game = user.Game.ToString(),
-                //Attachments = messageParam.Attachments.Select((attachment) => attachment.Url).ToArray(),
-            //};
-
-            //var res = new MessageRepository().InsertAsync(msg);
-            //await res;
-            //Logger.Info($"Logged message from {user.Username} in {user.Guild.Name}/{messageParam.Channel}");
+            if (message.Attachments.Any())
+                await _fileUploadHandler.Handle(message);
         }
     }
 }

--- a/Modix/Services/FileUpload/FileUploadHandler.cs
+++ b/Modix/Services/FileUpload/FileUploadHandler.cs
@@ -24,7 +24,8 @@ namespace Modix.Services.FileUpload
             ".com",
             ".scr",
             ".msi",
-            ".cmd"
+            ".cmd",
+            ".vbs"
         };
 
         public async Task Handle(IMessage message)

--- a/Modix/Services/FileUpload/FileUploadHandler.cs
+++ b/Modix/Services/FileUpload/FileUploadHandler.cs
@@ -25,13 +25,14 @@ namespace Modix.Services.FileUpload
             ".scr",
             ".msi",
             ".cmd",
-            ".vbs"
+            ".vbs",
+            ".js",
         };
 
         public async Task Handle(IMessage message)
         {
             // Check if the attachment's file name ends in anything suspicious first
-            if (!_blacklistedExtensions.Any(ext => message.Attachments.Any(m => m.Filename.EndsWith(ext))))
+            if (!_blacklistedExtensions.Any(ext => message.Attachments.Any(m => m.Filename.ToLower().EndsWith(ext))))
                 return;
 
             await TryPostToModerationChannel(message);

--- a/Modix/Services/FileUpload/FileUploadHandler.cs
+++ b/Modix/Services/FileUpload/FileUploadHandler.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+using Serilog;
+
+namespace Modix.Services.FileUpload
+{
+    public class FileUploadHandler
+    {
+        private const ulong ChannelIdToPostModerationLog = 360507591488438283;
+
+        private readonly List<string> _blacklistedExtensions = new List<string>
+        {
+            ".exe",
+            ".dll",
+            ".application",
+            ".msc",
+            ".bat",
+            ".pdb",
+            ".sh",
+            ".com",
+            ".src",
+            ".msi",
+        };
+
+        public async Task Handle(IMessage message)
+        {
+            // Check if the attachment's file name ends in anything suspicious first
+            if (!_blacklistedExtensions.Any(ext => message.Attachments.Any(m => m.Filename.EndsWith(ext))))
+                return;
+
+            await TryPostToModerationChannel(message);
+
+            await TryDeleteAndReplyToUser(message);
+        }
+
+        private static async Task TryPostToModerationChannel(IMessage message)
+        {
+            try
+            {
+                if (!(message.Channel is SocketTextChannel channel))
+                    return;
+
+                var moderationChannel = channel.Guild.Channels.SingleOrDefault(x => x.Id == ChannelIdToPostModerationLog) as SocketTextChannel;
+
+                if (moderationChannel == null)
+                {
+                    Log.Debug("Moderation channel with ID: {id} not found", ChannelIdToPostModerationLog);
+                    return;
+                }
+
+                var moderationEmbed = BuildModerationEmbed(message);
+                await moderationChannel.SendMessageAsync(string.Empty, false, moderationEmbed);
+            }
+            catch (Exception e)
+            {
+                Log.Debug(e, "Failed posting to moderation channel {channelId}", ChannelIdToPostModerationLog);
+            }
+        }
+
+        private static async Task TryDeleteAndReplyToUser(IMessage message)
+        {
+            try
+            {
+                await message.DeleteAsync();
+
+                var reply = GetReplyToUser(message);
+
+                await message.Channel.SendMessageAsync(reply);
+            }
+            catch (Exception e)
+            {
+                Log.Warning(e, "Failed to remove message {messageId} with suspicious file(s) attached in {channelName}", message.Id, message.Channel.Name);
+            }
+        }
+
+        private static EmbedBuilder BuildModerationEmbed(IMessage message)
+        {
+            var embed = new EmbedBuilder().WithTitle("Message with suspicious file(s) removed");
+
+            embed.AddField(a => a.WithName("Message ID").WithValue(message.Id));
+
+            if (!string.IsNullOrWhiteSpace(message.Content))
+                embed.AddField(a => a.WithName("Content").WithValue(message.Content));
+
+            var files = string.Join(", ", message.Attachments.Select(x => x.Filename));
+
+            embed.AddField(a => a.WithName("Files").WithValue($"{message.Attachments.Count} file(s) attached: {files}"));
+
+            embed.AddField(a => a.WithName("Time").WithValue($"{message.Timestamp:yyyy/MM/dd HH:mm}"));
+
+            embed.AddField(a => a.WithName("Channel").WithValue($"#{message.Channel.Name}"));
+
+            embed.AddField(a => a.WithName("Author").WithValue(message.Author.Mention));
+
+            embed.WithColor(new Color(255, 51, 51));
+
+            return embed;
+        }
+
+        private static string GetReplyToUser(IMessage message)
+            => $"Please don't upload any potentialy harmful files {message.Author.Mention}, your message has been removed";
+    }
+}

--- a/Modix/Services/FileUpload/FileUploadHandler.cs
+++ b/Modix/Services/FileUpload/FileUploadHandler.cs
@@ -22,8 +22,9 @@ namespace Modix.Services.FileUpload
             ".pdb",
             ".sh",
             ".com",
-            ".src",
+            ".scr",
             ".msi",
+            ".cmd"
         };
 
         public async Task Handle(IMessage message)

--- a/Modix/Services/FileUpload/FileUploadHandler.cs
+++ b/Modix/Services/FileUpload/FileUploadHandler.cs
@@ -102,6 +102,6 @@ namespace Modix.Services.FileUpload
         }
 
         private static string GetReplyToUser(IMessage message)
-            => $"Please don't upload any potentialy harmful files {message.Author.Mention}, your message has been removed";
+            => $"Please don't upload any potentially harmful files {message.Author.Mention}, your message has been removed";
     }
 }


### PR DESCRIPTION
This adds extremely basic detection/prevention for uploading suspicious looking files with a number of "blacklisted" extensions - these are hardcoded and would require redeployment if any extensions would be modified.

There have been suggestions to partially download the file and check the signature of the file.

## Additions

- Message received hook has been changed to now forward any messages with any attachments to `FileUploadHandler`
- If any attachment's filename ends with a blacklisted extension, the message will be removed from the channel and a message will be posted to the user in that same channel
- If a message with attachments has been removed, MODiX will post into `#moderation`. This could be changed to a environment variable, rather than a constant in code

I also took the liberty of removing some commented out code in `ModixBotHooks`, if you want this reverted, please say so.

## Preview

Message to user:

![image](https://user-images.githubusercontent.com/1341180/35481813-49b78b6c-0423-11e8-932c-5e06ee1e67b6.png)

Message posted to `#moderation`

![image](https://user-images.githubusercontent.com/1341180/35481816-5214b8c0-0423-11e8-84a2-6a858faf3625.png)
