### PR TITLE
Fixed not being able to see commands unless you're logged in

### DIFF
--- a/Modix.WebServer/Controllers/ApiController.cs
+++ b/Modix.WebServer/Controllers/ApiController.cs
@@ -10,18 +10,13 @@ namespace Modix.WebServer.Controllers
 {
     public class ApiController : ModixController
     {
-        private DiscordSocketClient _client;
         private GuildInfoService _guildInfoService;
-        private CommandHelpService _commandHelpService;
 
-        public ApiController(DiscordSocketClient client, GuildInfoService guildInfoService, CommandHelpService commandHelpService)
+        public ApiController(DiscordSocketClient client, GuildInfoService guildInfoService) : base(client)
         {
-            _client = client;
             _guildInfoService = guildInfoService;
-            _commandHelpService = commandHelpService;
         }
 
-        [Authorize]
         public async Task<IActionResult> Guilds()
         {
             var guildInfo = new Dictionary<string, List<GuildInfoResult>>();
@@ -34,15 +29,9 @@ namespace Modix.WebServer.Controllers
             return Ok(guildInfo);
         }
 
-        [Authorize]
         public IActionResult UserInfo()
         {
             return Ok(DiscordUser);
-        }
-
-        public IActionResult Commands()
-        {
-            return Ok(_commandHelpService.GetData());
         }
     }
 }

--- a/Modix.WebServer/Controllers/CommandsController.cs
+++ b/Modix.WebServer/Controllers/CommandsController.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Modix.Services.CommandHelp;
+
+namespace Modix.WebServer.Controllers
+{
+    [Route("~/api")]
+    public class CommandsController : Controller
+    {
+        private CommandHelpService _commandHelpService;
+
+        public CommandsController(CommandHelpService commandHelpService)
+        {
+            _commandHelpService = commandHelpService;
+        }
+
+        [HttpGet("commands")]
+        public IActionResult Commands()
+        {
+            return Ok(_commandHelpService.GetData());
+        }
+    }
+}


### PR DESCRIPTION
Removes the `[Authorize]` attribute from ApiController (since it should be inherited from ModixController), and moves the command endpoints to a separate controller without `[Authorize]`.