### PR TITLE
Fix stackexchange module

### DIFF
--- a/Modix.Services/StackExchange/StackExchangeService.cs
+++ b/Modix.Services/StackExchange/StackExchangeService.cs
@@ -1,10 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.IO;
-using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Modix.Services.StackExchange

--- a/Modix.Services/StackExchange/StackExchangeService.cs
+++ b/Modix.Services/StackExchange/StackExchangeService.cs
@@ -8,6 +8,11 @@ namespace Modix.Services.StackExchange
 {
     public class StackExchangeService
     {
+        private static HttpClient HttpClient => new HttpClient(new HttpClientHandler
+        {
+            AutomaticDecompression = DecompressionMethods.GZip
+        });
+
         private string _ApiReferenceUrl =
             $"http://api.stackexchange.com/2.2/search/advanced" +
             "?key={0}" +
@@ -23,20 +28,15 @@ namespace Modix.Services.StackExchange
             tags = Uri.EscapeDataString(tags);
             var query = _ApiReferenceUrl += $"&site={site}&tags={tags}&q={phrase}";
 
-            var client = new HttpClient(new HttpClientHandler
-            {
-                AutomaticDecompression = DecompressionMethods.GZip
-            });
-
-            var response = await client.GetAsync(query);
+            var response = await HttpClient.GetAsync(query);
 
             if (!response.IsSuccessStatusCode)
             {
                 throw new WebException("Something failed while querying the Stack Exchange API.");
             }
 
-            var json = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<StackExchangeResponse>(json);
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<StackExchangeResponse>(jsonResponse);
         }
     }
 }

--- a/Modix.Services/StackExchange/StackExchangeService.cs
+++ b/Modix.Services/StackExchange/StackExchangeService.cs
@@ -1,7 +1,10 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.IO;
+using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Modix.Services.StackExchange
@@ -23,15 +26,20 @@ namespace Modix.Services.StackExchange
             tags = Uri.EscapeDataString(tags);
             var query = _ApiReferenceUrl += $"&site={site}&tags={tags}&q={phrase}";
 
-            var client = new HttpClient();
+            var client = new HttpClient(new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip
+            });
+
             var response = await client.GetAsync(query);
 
             if (!response.IsSuccessStatusCode)
             {
                 throw new WebException("Something failed while querying the Stack Exchange API.");
             }
-            var jsonResponse = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<StackExchangeResponse>(jsonResponse);
+
+            var json = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<StackExchangeResponse>(json);
         }
     }
 }


### PR DESCRIPTION
StackExchange added compression to their api responses. Fixing our encoding accept headers to specify gzip decompression on the response.