### PR TITLE
Services should be resolved from separate scopes

### DIFF
--- a/Modix/ModixBot.cs
+++ b/Modix/ModixBot.cs
@@ -116,7 +116,7 @@ namespace Modix
 
             using (var scope = _provider.CreateScope())
             {
-                var result = await _commands.ExecuteAsync(context, argPos, _provider);
+                var result = await _commands.ExecuteAsync(context, argPos, scope.ServiceProvider);
 
                 if (!result.IsSuccess)
                 {
@@ -133,7 +133,7 @@ namespace Modix
 
                     if (result.Error != CommandError.Exception)
                     {
-                        var handler = _provider.GetRequiredService<CommandErrorHandler>();
+                        var handler = scope.ServiceProvider.GetRequiredService<CommandErrorHandler>();
                         await handler.AssociateError(message, error);
                     }
                     else


### PR DESCRIPTION
ModixBot's `HandleCommand` method and the methods in `ModixBotHooks` currently resolve services from the application scope. This could result in services that are registered as instance-per-scope to be unintentionally shared across events.

This PR updates both of those locations to create a new child scope per event. Additionally, ModixBot will now use it's own app-level service provider instead of using the provider created by the MVC app.