### PR TITLE
Create user info command

### DIFF
--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="1.0.2" />
+    <PackageReference Include="Humanizer.Core" Version="2.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />

--- a/Modix/Modules/HelpModule.cs
+++ b/Modix/Modules/HelpModule.cs
@@ -10,11 +10,11 @@ using Modix.Services.CommandHelp;
 namespace Modix.Modules
 {
     [Name("Info"), Summary("General helper module")]
-    public sealed class InfoModule : ModuleBase
+    public sealed class HelpModule : ModuleBase
     {
         private readonly CommandHelpService _commandService;
 
-        public InfoModule(CommandHelpService cs)
+        public HelpModule(CommandHelpService cs)
         {
             _commandService = cs;
         }

--- a/Modix/Modules/PingModule.cs
+++ b/Modix/Modules/PingModule.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading.Tasks;
+using Discord.Commands;
+
+namespace Modix.Modules
+{
+    public class PingModule : ModuleBase
+    {
+        [Command("ping")]
+        public Task Ping() =>
+            ReplyAsync("Pong!");
+    }
+}

--- a/Modix/Modules/UserInfoModule.cs
+++ b/Modix/Modules/UserInfoModule.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using Humanizer;
+using Humanizer.Localisation;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Modix.Modules
+{
+    public class UserInfoModule : ModuleBase
+    {
+        public UserInfoModule(ILogger<UserInfoModule> logger)
+        {
+            Log = logger ?? new NullLogger<UserInfoModule>();
+        }
+
+        private ILogger<UserInfoModule> Log { get; }
+
+        [Command("info")]
+        public async Task GetUserInfo([Remainder] IUser user = null)
+        {
+            user = user ?? Context.User;
+
+            var utcNow = DateTime.UtcNow;
+            var builder = new StringBuilder();
+            builder.AppendLine("**\u276F User Information**");
+            builder.AppendLine("ID: " + user.Id);
+            builder.AppendLine("Profile: " + user.Mention);
+
+            // TODO: Add content about the user's presence, if any
+
+            builder.AppendFormat(
+                CultureInfo.InvariantCulture,
+                "Created: {0} ago ({1:yyyy-MM-ddTHH:mm:ssK})\n",
+                (utcNow - user.CreatedAt).Humanize(maxUnit: TimeUnit.Year, culture: CultureInfo.InvariantCulture),
+                user.CreatedAt.UtcDateTime);
+
+            if (user is IGuildUser member)
+            {
+                builder.AppendLine();
+                builder.AppendLine("**\u276F Member Information**");
+
+                if (!string.IsNullOrEmpty(member.Nickname))
+                {
+                    builder.AppendLine("Nickname: " + member.Nickname);
+                }
+
+                if (member.JoinedAt is DateTimeOffset joinedAt)
+                {
+                    builder.AppendFormat(
+                        CultureInfo.InvariantCulture,
+                        "Joined: {0} ago ({1:yyyy-MM-ddTHH:mm:ssK})\n",
+                        (utcNow - joinedAt).Humanize(maxUnit: TimeUnit.Year, culture: CultureInfo.InvariantCulture),
+                        joinedAt.UtcDateTime);
+                }
+
+                if (member.RoleIds.Count > 0)
+                {
+                    var roles = member.RoleIds.Select(x => member.Guild.Roles.Single(y => y.Id == x))
+                        .Where(x => !string.Equals("@everyone", x.Name, StringComparison.Ordinal))
+                        .OrderBy(x => x.Name, StringComparer.InvariantCultureIgnoreCase)
+                        .ToArray();
+
+                    if (roles.Length > 0)
+                    {
+                        Array.Sort(roles, StringComparer.OrdinalIgnoreCase);
+                        builder.AppendLine("Roles: " + string.Join(',', (object[])roles));
+                    }
+                }
+            }
+
+            // TODO: Add infraction summary
+
+            // TODO: Add voice session data
+
+            var embedBuilder = new EmbedBuilder
+            {
+                Author = new EmbedAuthorBuilder
+                {
+                    Name = user.Username + "#" + user.Discriminator,
+                    IconUrl = user.GetAvatarUrl()
+                },
+                Color = GetDominateColor(user),
+                Description = builder.ToString(),
+                ThumbnailUrl = user.GetAvatarUrl()
+            };
+
+            await ReplyAsync(string.Empty, embed: embedBuilder.Build());
+        }
+
+        [Command("info")]
+        public async Task GetUserInfo([Remainder] ulong userId)
+        {
+            if (userId == Context.User.Id)
+            {
+                await GetUserInfo(Context.User);
+                return;
+            }
+
+            var user = await Context.Guild.GetUserAsync(userId) ?? await Context.Client.GetUserAsync(userId);
+            if (!(user is null))
+            {
+                await GetUserInfo(user);
+                return;
+            }
+
+            // TODO: Check the database to see if we have anything about the user in our database.
+            await ReplyAsync("User not found.");
+        }
+
+        private static Color GetDominateColor(IUser user)
+        {
+            // TODO: Get the dominate image in the user's avatar.
+            return new Color(253, 95, 0);
+        }
+    }
+}

--- a/Modix/Modules/UserInfoModule.cs
+++ b/Modix/Modules/UserInfoModule.cs
@@ -94,7 +94,7 @@ namespace Modix.Modules
         }
 
         [Command("info")]
-        public async Task GetUserInfo([Remainder] ulong userId)
+        public async Task GetUserInfo(ulong userId, [Remainder] string _)
         {
             if (userId == Context.User.Id)
             {


### PR DESCRIPTION
This provides a base implementation of Rowboat's `%info` command. There is still some work to be done to get feature parity (see the `TODO` comments for details) but it at least provides basic information from Discord's API. 

#30