### PR TITLE
Fix error responses from Note and Infraction modules

### DIFF
--- a/Modix/Modules/InfractionModule.cs
+++ b/Modix/Modules/InfractionModule.cs
@@ -33,7 +33,7 @@ namespace Modix.Modules
             // TODO: We shouldn't need to do this once claims are working
             if (!IsStaff(user) && !IsOperator(user))
             {
-                await ReplyAsync($"I'm sorry, @{user.Nickname}, I'm afraid I can't do that.");
+                await ReplyAsync($"I'm sorry, {user.Mention}, I'm afraid I can't do that.");
                 return;
             }
 

--- a/Modix/Modules/NoteModule.cs
+++ b/Modix/Modules/NoteModule.cs
@@ -32,7 +32,7 @@ namespace Modix.Modules
             // TODO: We shouldn't need to do this once claims are working
             if (!IsStaff(guildUser) && !IsOperator(guildUser))
             {
-                await ReplyAsync($"I'm sorry, @{guildUser.Nickname}, I'm afraid I can't do that.");
+                await ReplyAsync($"I'm sorry, {guildUser.Mention}, I'm afraid I can't do that.");
                 return;
             }
 
@@ -63,7 +63,7 @@ namespace Modix.Modules
             // TODO: We shouldn't need to do this once claims are working
             if (!IsStaff(user) && !IsOperator(user))
             {
-                await ReplyAsync($"I'm sorry, @{user.Nickname}, I'm afraid I can't do that.");
+                await ReplyAsync($"I'm sorry, {user.Mention}, I'm afraid I can't do that.");
                 return;
             }
 
@@ -88,7 +88,7 @@ namespace Modix.Modules
             // TODO: We shouldn't need to do this once claims are working
             if (!IsStaff(user) && !IsOperator(user))
             {
-                await ReplyAsync($"I'm sorry, @{user.Nickname}, I'm afraid I can't do that.");
+                await ReplyAsync($"I'm sorry, {user.Mention}, I'm afraid I can't do that.");
                 return;
             }
 


### PR DESCRIPTION
Previously error messages would say, "I'm sorry, @, I'm afraid I can't do that.". Now they'll mention the user instead of just saying `@`.