### PR TITLE
OnGuildMemberUpdatedAsync should not log an error when username is null

### DIFF
--- a/Modix.Services/Core/UserTrackingBehavior.cs
+++ b/Modix.Services/Core/UserTrackingBehavior.cs
@@ -73,8 +73,11 @@ namespace Modix.Services.Core
         private Task OnGuildMemberUpdatedAsync(IGuildUser oldUser, IGuildUser newUser)
             => SelfExecuteOnScopedServiceAsync<IUserService>(x =>
             {
-                if(newUser.Username == null)
-                    Log.Error($"OnGuildMemberUpdatedAsync:\r\n ~ newUser.Id: {newUser.Id}\r\n ~ newUser.Discriminator: {newUser.Discriminator ?? "null"}\r\n ~ newUser.Nickname: {newUser.Nickname ?? "null"}\r\n ~ newUser.IsBot: {newUser.IsBot}\r\n ~ newUser.IsWebhook: {newUser.IsWebhook}");
+                if (newUser.Username == null)
+                {
+                    //Log.Error($"OnGuildMemberUpdatedAsync:\r\n ~ newUser.Id: {newUser.Id}\r\n ~ newUser.Discriminator: {newUser.Discriminator ?? "null"}\r\n ~ newUser.Nickname: {newUser.Nickname ?? "null"}\r\n ~ newUser.IsBot: {newUser.IsBot}\r\n ~ newUser.IsWebhook: {newUser.IsWebhook}");
+                    return Task.CompletedTask;
+                }
 
                 return x.TrackUserAsync(newUser);
             });


### PR DESCRIPTION
This reverts some of the error logging that was introduced in 99bd9223a6b981dd8a73ce5415121ed092a5d9fe. Currently the error that this removes gets logged several times per minute.