### PR TITLE
Frontend improvements & adjustments

### DIFF
--- a/Modix.Frontend/src/app/Store.ts
+++ b/Modix.Frontend/src/app/Store.ts
@@ -18,6 +18,7 @@ import Role from '@/models/Role';
 import Claim from '@/models/Claim';
 import Guild from '@/models/Guild';
 import DesignatedRoleMapping from '@/models/moderation/DesignatedRoleMapping';
+import Channel from '@/models/Channel';
 
 Vue.use(Vuex);
 
@@ -33,9 +34,10 @@ const modixState: ModixState =
     commands: [],
     campaigns: [],
     infractions: [],
-    channels: [],
+    channelDesignations: [],
     claims: {},
     roles: [],
+    channels: [],
     guilds: [],
     roleMappings: []
 };
@@ -52,8 +54,9 @@ namespace modix
     const setInfractions = (state: ModixState, infractions: InfractionSummary[]) => state.infractions = infractions;
     const setRoles = (state: ModixState, roles: Role[]) => state.roles = roles;
     const setGuilds = (state: ModixState, guilds: Guild[]) => state.guilds = guilds;
+    const setChannels = (state: ModixState, channels: Channel[]) => state.channels = channels;
     
-    const setChannelDesignations = (state: ModixState, mappings: DesignatedChannelMapping[]) => state.channels = mappings;
+    const setChannelDesignations = (state: ModixState, mappings: DesignatedChannelMapping[]) => state.channelDesignations = mappings;
     const setRoleDesignations = (state: ModixState, mappings: DesignatedRoleMapping[]) => state.roleMappings = mappings;
     const setClaims = (state: ModixState, claims: {[claim: string]: Claim[]}) => state.claims = claims;
     
@@ -78,6 +81,7 @@ namespace modix
     const updateCampaigns = async (context: ModixContext) => mutatingServiceCall(PromotionService.getCampaigns, setCampaigns);
     const updateInfractions = async (context: ModixContext) => mutatingServiceCall(GeneralService.getInfractions, setInfractions);
     const updateRoles = async (context: ModixContext) => mutatingServiceCall(GeneralService.getGuildRoles, setRoles);
+    const updateChannels = async (context: ModixContext) => mutatingServiceCall(GeneralService.getChannels, setChannels);
 
     const updateChannelDesignations = async (context: ModixContext) => mutatingServiceCall(ConfigurationService.getChannelDesignations, setChannelDesignations);
     const updateRoleDesignations = async (context: ModixContext) => mutatingServiceCall(ConfigurationService.getRoleDesignations, setRoleDesignations);
@@ -92,6 +96,7 @@ namespace modix
     export const retrieveRoleDesignations = moduleBuilder.dispatch(updateRoleDesignations);
     export const retrieveClaims = moduleBuilder.dispatch(updateClaims);
     export const retrieveRoles = moduleBuilder.dispatch(updateRoles);
+    export const retrieveChannels = moduleBuilder.dispatch(updateChannels);
     export const retrieveGuilds = moduleBuilder.dispatch(updateGuilds);
 
     export const pushErrorMessage = moduleBuilder.commit(pushError);
@@ -110,7 +115,6 @@ namespace modix
 
         return diff.length === 0;
     };
-
 }
 
 export default modix;

--- a/Modix.Frontend/src/components/Configuration/IndividualDesignation.vue
+++ b/Modix.Frontend/src/components/Configuration/IndividualDesignation.vue
@@ -1,7 +1,9 @@
 <template>
 
     <div class="tags has-addons">
-        <span class="tag is-info">#{{designation.name}}</span>
+        <span class="tag is-info">
+            <template v-if="isChannel">#</template><template v-else>@</template>{{designation.name}}
+        </span>
 
         <template v-if="showConfirm">
             <span class="tag is-dark">Remove Designation?</span>
@@ -48,6 +50,11 @@ export default class IndividualDesignation extends Vue
         this.$emit("confirm", this.designation);
         
         this.loading = false;
+    }
+
+    get isChannel(): boolean
+    {
+        return (this.designation as any).channelId != undefined;
     }
 }
 </script>

--- a/Modix.Frontend/src/components/MiniProfile.vue
+++ b/Modix.Frontend/src/components/MiniProfile.vue
@@ -115,10 +115,7 @@
 
 .v-popover
 {
-    @include tiny()
-    {
-        display: none;
-    }
+    
 }
 
 .avatar-icon, .dropdown-icon
@@ -128,15 +125,17 @@
     border-radius: 4px;
     box-shadow: -1px 1px 0px white;
 
-    @include tiny()
-    {
-        display: none;
-    }
+    
 }
 
 .username
 {
     margin-right: 0.2em;
+
+    @include tiny()
+    {
+        display: none;
+    }
 }
 </style>
 

--- a/Modix.Frontend/src/models/ModixState.ts
+++ b/Modix.Frontend/src/models/ModixState.ts
@@ -9,6 +9,7 @@ import Role from '@/models/Role';
 import Claim from '@/models/Claim';
 import Guild from '@/models/Guild';
 import DesignatedRoleMapping from '@/models/moderation/DesignatedRoleMapping';
+import Channel from '@/models/Channel';
 
 export default interface ModixState
 {
@@ -21,11 +22,12 @@ export default interface ModixState
     campaigns: PromotionCampaign[];
     infractions: InfractionSummary[];
     
-    channels: DesignatedChannelMapping[];
+    channelDesignations: DesignatedChannelMapping[];
     roleMappings: DesignatedRoleMapping[];
     
     claims: {[claim: string]: Claim[]};
 
     roles: Role[];
     guilds: Guild[];
+    channels: Channel[];
 }

--- a/Modix.Frontend/src/models/PersistentConfig.ts
+++ b/Modix.Frontend/src/models/PersistentConfig.ts
@@ -3,13 +3,15 @@ import PersistentKeyValueService from "@/services/PersistentKeyValueService";
 export interface PersistentConfig
 {
     showInactiveCampaigns: boolean;
-    showInactiveInfractions: boolean;
+    showInfractionState: boolean;
+    showDeletedInfractions: boolean;
 }
 
 const defaultConfig: PersistentConfig =
 {
     showInactiveCampaigns: false,
-    showInactiveInfractions: false
+    showInfractionState: false,
+    showDeletedInfractions: false
 };
 
 export const config = (): PersistentConfig => PersistentKeyValueService.get("persistentConfig") || defaultConfig;

--- a/Modix.Frontend/src/services/GeneralService.ts
+++ b/Modix.Frontend/src/services/GeneralService.ts
@@ -40,6 +40,12 @@ export default class GeneralService
         return response;
     }
 
+    static async getChannels(): Promise<Channel[]>
+    {
+        let response = (await client.get("channels")).data;
+        return response;
+    }
+
     static async getGuilds(): Promise<Guild[]>
     {
         let response = (await client.get("guildOptions")).data;

--- a/Modix.Frontend/src/styles/variables.scss
+++ b/Modix.Frontend/src/styles/variables.scss
@@ -57,7 +57,7 @@ $default-transition: 1s cubic-bezier(0.165, 0.84, 0.44, 1);
 
 @mixin tiny()
 {
-    @media screen and (max-width: 400px)
+    @media screen and (max-width: 450px)
     {
         @content
     }

--- a/Modix.Frontend/src/views/Configuration/ChannelDesignations.vue
+++ b/Modix.Frontend/src/views/Configuration/ChannelDesignations.vue
@@ -144,7 +144,7 @@ export default class ChannelDesignations extends Vue
 
     get selectedChannels()
     {
-        let allDesignations: DesignatedChannelMapping[] = this.$store.state.modix.channels;
+        let allDesignations: DesignatedChannelMapping[] = this.$store.state.modix.channelDesignations;
         return _.filter(allDesignations, d => d.channelDesignation == this.viewedDesignation);
     }
 
@@ -198,7 +198,7 @@ export default class ChannelDesignations extends Vue
     {
         if (this.designationCreationData.channelId == '') { return true; }
 
-        return _.some(this.$store.state.modix.channels, channel => 
+        return _.some(this.$store.state.modix.channelDesignations, channel => 
                 channel.channelId == this.designationCreationData.channelId &&
                 channel.channelDesignation == designation);
     }

--- a/Modix.Frontend/src/views/Configuration/RoleDesignations.vue
+++ b/Modix.Frontend/src/views/Configuration/RoleDesignations.vue
@@ -43,11 +43,11 @@
 
                         <div class="column">
                             <label class="label">Role Name</label>
-                            <Autocomplete :serviceCall="serviceCall" placeholder="#general"
+                            <Autocomplete :serviceCall="serviceCall" placeholder="@Administrator"
                                 @select="selectedAutocomplete = $event" minimumChars="-1" >
                                 
                                 <template slot-scope="{entry}">
-                                    #{{entry.name}}
+                                    @{{entry.name}}
                                 </template>
 
                             </Autocomplete>
@@ -198,9 +198,11 @@ export default class RoleDesignations extends Vue
     {
         if (this.designationCreationData.roleId == '') { return true; }
 
-        return _.some(this.$store.state.modix.channels, channel => 
-                channel.channelId == this.designationCreationData.roleId &&
-                channel.channelDesignation == designation);
+        console.log(this.$store.state.modix.roleMappings);
+
+        return _.some(this.$store.state.modix.roleMappings, (role: DesignatedRoleMapping) => 
+                role.roleId == this.designationCreationData.roleId &&
+                role.roleDesignation == designation);
     }
 
     async createAssignment()

--- a/Modix.Frontend/src/views/CreatePromotion.vue
+++ b/Modix.Frontend/src/views/CreatePromotion.vue
@@ -1,12 +1,12 @@
 <template>
     <div>
-        <section class="section">
+        <section class="section container">
 
             <h1 class="title">
                 Start a Campaign
             </h1>
             
-            <div class="container columns">
+            <div class="columns">
 
                 <div class="column is-one-third">
                     <div class="">

--- a/Modix.WebServer/Controllers/ApiController.cs
+++ b/Modix.WebServer/Controllers/ApiController.cs
@@ -36,6 +36,11 @@ namespace Modix.WebServer.Controllers
             return Ok(UserGuild.Roles.Select(d => new { d.Id, d.Name, Color = d.Color.ToString() }));
         }
 
+        public IActionResult Channels()
+        {
+            return Ok(UserGuild.Channels.Select(d => new { d.Id, d.Name }));
+        }
+
         public IActionResult Claims()
         {
             return Ok(ClaimInfoData.GetClaims());

--- a/Modix.WebServer/Controllers/AutocompleteController.cs
+++ b/Modix.WebServer/Controllers/AutocompleteController.cs
@@ -29,7 +29,7 @@ namespace Modix.WebServer.Controllers
         {
             if (query.StartsWith('#'))
             {
-              query = query.Substring(1);
+                query = query.Substring(1);
             }
 
             var result = UserGuild.Channels
@@ -57,6 +57,11 @@ namespace Modix.WebServer.Controllers
         [HttpGet("roles")]
         public async Task<IActionResult> AutocompleteRoles(string query, [FromQuery] bool rankOnly)
         {
+            if (query.StartsWith('@'))
+            {
+                query = query.Substring(1);
+            }
+
             if (rankOnly)
             {
                 var criteria = new DesignatedRoleMappingSearchCriteria


### PR DESCRIPTION
There are only two small backend changes in this PR, the rest are frontend adjustments.

Backend
- Made role search take leading @ into account, if present
- Added endpoint to get the channels of the current server

General
- Changed layout of navbar on tiny mobile screens

Infractions
- Added ability to sort subject, id, and creator columns with query strings
- Improved filters for infraction creator/subject to be indexof instead of startswith
- Added channel ID resolving for reason messages
- Added channel API endpoint to facilitate the above
- Made infractions with newlines in the reason appear properly

Role Designations
- Fixed more formatting issues
- Fixed possible designations being disabled incorrectly
- Fixes roles being prefixed with # on role designation page
- Added separate checkboxes for showing the "state" column and showing deleted infractions on Infractions page
- Fixed page being too wide on Create Promotion page