### PR TITLE
Added aliases and other command tweaks to Promotions module

### DIFF
--- a/Modix/Modules/PromotionsModule.cs
+++ b/Modix/Modules/PromotionsModule.cs
@@ -119,7 +119,7 @@ namespace Modix.Modules
             => PromotionsService.AddCommentAsync(campaignId, PromotionSentiment.Oppose, content);
 
         [Command("abstain")]
-        [Summary("Alias to oppose on an ongoing campaign to promote a user.")]
+        [Summary("Alias to abstain on an ongoing campaign to promote a user.")]
         public Task Abstain(
             [Summary("The ID value of the campaign to be commented upon")]
                 long campaignId,

--- a/Modix/Modules/PromotionsModule.cs
+++ b/Modix/Modules/PromotionsModule.cs
@@ -15,12 +15,14 @@ namespace Modix.Modules
     [Group("promotions")]
     public class PromotionsModule : ModuleBase
     {
+        private const string DefaultApprovalMessage = "I approve of this nomination.";
+
         public PromotionsModule(IPromotionsService promotionsService)
         {
             PromotionsService = promotionsService;
         }
 
-        [Command("campaigns")]
+        [Command("campaigns"), Alias("")]
         [Summary("List all active promotion campaigns")]
         public async Task Campaigns()
         {
@@ -88,6 +90,43 @@ namespace Modix.Modules
             [Summary("The content of the comment")]
                 string content)
             => PromotionsService.AddCommentAsync(campaignId, sentiment, content);
+
+        [Command("approve")]
+        [Summary("Alias to approve on an ongoing campaign to promote a user.")]
+        public Task Approve(
+            [Summary("The ID value of the campaign to be commented upon")]
+                long campaignId,
+            [Remainder]
+            [Summary("The content of the comment")]
+                string content)
+            => PromotionsService.AddCommentAsync(campaignId, PromotionSentiment.Approve, content);
+
+        [Command("approve")]
+        [Summary("Alias to approve on an ongoing campaign to promote a user.")]
+        public Task Approve(
+            [Summary("The ID value of the campaign to be commented upon")]
+                long campaignId)
+            => PromotionsService.AddCommentAsync(campaignId, PromotionSentiment.Approve, DefaultApprovalMessage);
+
+        [Command("oppose")]
+        [Summary("Alias to oppose on an ongoing campaign to promote a user.")]
+        public Task Oppose(
+            [Summary("The ID value of the campaign to be commented upon")]
+                long campaignId,
+            [Remainder]
+            [Summary("The content of the comment")]
+                string content)
+            => PromotionsService.AddCommentAsync(campaignId, PromotionSentiment.Oppose, content);
+
+        [Command("abstain")]
+        [Summary("Alias to oppose on an ongoing campaign to promote a user.")]
+        public Task Abstain(
+            [Summary("The ID value of the campaign to be commented upon")]
+                long campaignId,
+            [Remainder]
+            [Summary("The content of the comment")]
+                string content)
+            => PromotionsService.AddCommentAsync(campaignId, PromotionSentiment.Abstain, content);
 
         [Command("accept")]
         [Summary("Accept an ongoing campaign to promote a user, and perform the promotion.")]

--- a/Modix/Modules/PromotionsModule.cs
+++ b/Modix/Modules/PromotionsModule.cs
@@ -119,7 +119,7 @@ namespace Modix.Modules
             => PromotionsService.AddCommentAsync(campaignId, PromotionSentiment.Oppose, content);
 
         [Command("abstain")]
-        [Summary("Alias to abstain on an ongoing campaign to promote a user.")]
+        [Summary("Alias to abstain from an ongoing campaign to promote a user.")]
         public Task Abstain(
             [Summary("The ID value of the campaign to be commented upon")]
                 long campaignId,


### PR DESCRIPTION
Added ability to:

- Invoke `!promotions` to get a list of all active campaigns, an alias to `!promotions campaigns`
- Invoke `!promotions approve {id} {comment}` as opposed to !promotions comment {id} Approve {comment}` and variations for oppose/abstain
- Added default message for approvals, removing the need for recurring comments.

