### PR TITLE
Added forceban and forceunban, user info improvements, and small fixes

### DIFF
--- a/Modix.Data/Models/EphemeralUser.cs
+++ b/Modix.Data/Models/EphemeralUser.cs
@@ -1,0 +1,111 @@
+﻿using Discord;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Modix.Data.Models
+{
+    public class EphemeralUser : IGuildUser
+    {
+        public EphemeralUser(ulong userId, string name, IGuild guild)
+        {
+            Id = userId;
+            Username = name;
+            Guild = guild;
+        }
+
+        public DateTimeOffset? JoinedAt { get; private set; } = null;
+
+        public string Nickname { get; private set; } = null;
+
+        public GuildPermissions GuildPermissions { get; private set; } = new GuildPermissions();
+
+        public IGuild Guild { get; private set; }
+
+        public ulong GuildId => Guild.Id;
+
+        public IReadOnlyCollection<ulong> RoleIds { get; private set; } = new List<ulong>();
+
+        public string AvatarId { get; private set; } = null;
+
+        public string Discriminator { get; private set; } = null;
+
+        public ushort DiscriminatorValue { get; private set; } = 0;
+
+        public bool IsBot { get; private set; } = false;
+
+        public bool IsWebhook { get; private set; } = false;
+
+        public string Username { get; private set; }
+
+        public DateTimeOffset CreatedAt { get; private set; } = DateTimeOffset.UtcNow;
+
+        public ulong Id { get; private set; }
+
+        public string Mention => MentionUtils.MentionUser(Id);
+
+        public Game? Game { get; private set; } = null;
+
+        public UserStatus Status { get; private set; } = UserStatus.Offline;
+
+        public bool IsDeafened { get; private set; } = false;
+
+        public bool IsMuted { get; private set; } = false;
+
+        public bool IsSelfDeafened { get; private set; } = false;
+
+        public bool IsSelfMuted { get; private set; } = false;
+
+        public bool IsSuppressed { get; private set; } = false;
+
+        public IVoiceChannel VoiceChannel { get; private set; } = null;
+
+        public string VoiceSessionId { get; private set; } = null;
+
+        public Task AddRoleAsync(IRole role, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task AddRolesAsync(IEnumerable<IRole> roles, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IDMChannel> GetOrCreateDMChannelAsync(RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ChannelPermissions GetPermissions(IGuildChannel channel)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task KickAsync(string reason = null, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task ModifyAsync(Action<GuildUserProperties> func, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RemoveRoleAsync(IRole role, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RemoveRolesAsync(IEnumerable<IRole> roles, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Modix.Services/AutoCodePaste/CodePasteService.cs
+++ b/Modix.Services/AutoCodePaste/CodePasteService.cs
@@ -70,7 +70,7 @@ namespace Modix.Services.AutoCodePaste
         {
             var formatted = string.Format(Header,
                 $"{msg.Author.Username}#{msg.Author.DiscriminatorValue}", msg.Channel.Name,
-                DateTime.Now.ToString("dddd, MMMM d yyyy @ H:mm:ss"), msg.Id, 
+                DateTimeOffset.UtcNow.ToString("dddd, MMMM d yyyy @ H:mm:ss"), msg.Id, 
                 FormatUtilities.FixIndentation(code ?? msg.Content));
 
             return await UploadCode(formatted);

--- a/Modix.Services/Core/MessageLogBehavior.cs
+++ b/Modix.Services/Core/MessageLogBehavior.cs
@@ -89,14 +89,12 @@ namespace Modix.Services.Core
 
             string messageLink = ModixEmbedBuilderExtensions.MessageLink(guild.Id, channel.Id, original.Id);
 
-            string descriptionText = $"**Original**\n```{FormatMessage(original.Content)}```";
+            string descriptionText = $"**[Original]({messageLink})**\n```{FormatMessage(original.Content)}```";
 
             if (descriptionText.Length <= 2048)
             {
                 descriptionText += $"\n**Updated**\n```{FormatMessage(updated.Content)}```"; ;
             }
-
-            descriptionText += $"\n{messageLink}";
 
             var embed = new EmbedBuilder()
                 .WithVerboseAuthor(original.Author)

--- a/Modix.Services/Core/UserService.cs
+++ b/Modix.Services/Core/UserService.cs
@@ -24,6 +24,14 @@ namespace Modix.Services.Core
         Task<IUser> GetUserAsync(ulong userId);
 
         /// <summary>
+        /// Checks if a user exists that is associated with the given Discord ID value that also belongs to a specified guild.
+        /// </summary>
+        /// <param name="guildId">The <see cref="IEntity{T}.Id" /> of the guild to be checked for the user.</param>
+        /// <param name="userId">The <see cref="IEntity{T}.Id" /> of the user to look for.</param>
+        /// <returns>True if the user exists, false if either the guild or user don't exist</returns>
+        Task<bool> GuildUserExistsAsync(ulong guildId, ulong userId);
+
+        /// <summary>
         /// Retrieves the user, if any, associated with the given Discord ID value that also belongs to a specified guild.
         /// </summary>
         /// <param name="guildId">The <see cref="IEntity{T}.Id" /> of the guild whose user is to be retrieved.</param>
@@ -78,6 +86,20 @@ namespace Modix.Services.Core
                 await TrackUserAsync(guildUser);
 
             return user;
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> GuildUserExistsAsync(ulong guildId, ulong userId)
+        {
+            var guild = await DiscordClient.GetGuildAsync(guildId);
+            if (guild == null) { return false; }
+
+            var user = await guild.GetUserAsync(userId);
+            if (user == null) { return false; }
+
+            await TrackUserAsync(user);
+
+            return true;
         }
 
         /// <inheritdoc />

--- a/Modix.Services/Moderation/EphemeralUser.cs
+++ b/Modix.Services/Moderation/EphemeralUser.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Modix.Data.Models
+namespace Modix.Services.Moderation
 {
     public class EphemeralUser : IGuildUser
     {

--- a/Modix.Services/Utilities/FormatUtilities.cs
+++ b/Modix.Services/Utilities/FormatUtilities.cs
@@ -1,5 +1,8 @@
 ﻿using Discord;
+using Humanizer;
+using Modix.Data.Models.Moderation;
 using Modix.Services.AutoCodePaste;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -86,6 +89,26 @@ namespace Modix.Services.Utilities
                 {
                     embed.AddField(a => a.WithName("More...").WithValue(we.Message));
                 }
+            }
+        }
+
+        public static string FormatInfractionCounts(IDictionary<InfractionType, int> counts)
+        {
+            if (counts.Values.Sum() == 0)
+            {
+                return "This user is clean - no active infractions!";
+            }
+            else
+            {
+                var formatted = 
+                    counts.Select(d =>
+                    {
+                        var formattedKey = d.Key.Humanize().ToLower();
+                        return $"{d.Value} {(d.Value == 1 ? formattedKey : formattedKey.Pluralize())}";
+                    })
+                    .Humanize();
+
+                return $"This user has {formatted}";
             }
         }
     }

--- a/Modix.WebServer/Auth/ModixAuthenticationExtensions.cs
+++ b/Modix.WebServer/Auth/ModixAuthenticationExtensions.cs
@@ -39,7 +39,7 @@ namespace Modix.WebServer.Auth
                         errorMessage = "There was a problem authenticating via OAuth. Try again later.";
                     }
 
-                    context.Response.Cookies.Append("Error", errorMessage, new CookieOptions { Expires = DateTimeOffset.Now.AddHours(1) });
+                    context.Response.Cookies.Append("Error", errorMessage, new CookieOptions { Expires = DateTimeOffset.UtcNow.AddHours(1) });
                     context.HandleResponse();
 
                     return Task.CompletedTask;

--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Sentry" Version="2.1.6" />
-    <PackageReference Include="Tababular" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Modix.Services\Modix.Services.csproj" />

--- a/Modix/Modules/InfractionModule.cs
+++ b/Modix/Modules/InfractionModule.cs
@@ -26,15 +26,16 @@ namespace Modix.Modules
 
         [Command("search")]
         [Summary("Display all infractions for a user, that haven't been deleted.")]
+        [Priority(10)]
         public async Task Search(
-            [Summary("The user whose infractions are to be displayed.")]
-                IGuildUser subject)
+            [Summary("The id of the user whose infractions are to be displayed.")]
+                ulong subjectId)
         {
             var infractions = await ModerationService.SearchInfractionsAsync(
                 new InfractionSearchCriteria
                 {
-                    GuildId = subject.GuildId,
-                    SubjectId = subject.Id,
+                    GuildId = Context.Guild.Id,
+                    SubjectId = subjectId,
                     IsDeleted = false
                 },
                 new[]
@@ -42,7 +43,7 @@ namespace Modix.Modules
                     new SortingCriteria { PropertyName = "CreateAction.Created", Direction = SortDirection.Descending }
                 });
 
-            if(infractions.Count == 0)
+            if (infractions.Count == 0)
             {
                 await ReplyAsync(Format.Code("No infractions"));
                 return;
@@ -67,7 +68,7 @@ namespace Modix.Modules
             var replyBuilder = new StringBuilder();
             foreach (var line in tableText.Split("\r\n"))
             {
-                if((replyBuilder.Length + line.Length) > 1998)
+                if ((replyBuilder.Length + line.Length) > 1998)
                 {
                     await ReplyAsync(Format.Code(replyBuilder.ToString()));
                     replyBuilder.Clear();
@@ -75,8 +76,17 @@ namespace Modix.Modules
                 replyBuilder.AppendLine(line);
             }
 
-            if(replyBuilder.Length > 0)
+            if (replyBuilder.Length > 0)
                 await ReplyAsync(Format.Code(replyBuilder.ToString()));
+        }
+
+        [Command("search")]
+        [Summary("Display all infractions for a user, that haven't been deleted.")]
+        public async Task Search(
+            [Summary("The user whose infractions are to be displayed.")]
+                IGuildUser subject)
+        {
+            await Search(subject.Id);
         }
         
         [Command("search embed")]

--- a/Modix/Modules/ModerationModule.cs
+++ b/Modix/Modules/ModerationModule.cs
@@ -18,44 +18,48 @@ namespace Modix.Modules
             ModerationService = moderationService;
         }
 
-        protected override void AfterExecute(CommandInfo command)
-        {
-            Context.Message.AddReactionAsync(new Emoji("🆗"));
-        }
-
         [Command("note")]
         [Summary("Applies a note to a user's infraction history.")]
-        public Task Note(
+        public async Task Note(
             [Summary("The user to which the note is being applied.")]
                 IGuildUser subject,
             [Summary("The reason for the note.")]
             [Remainder]
                 string reason)
-            => ModerationService.CreateInfractionAsync(InfractionType.Notice, subject.Id, reason, null);
+        {
+            await ModerationService.CreateInfractionAsync(InfractionType.Notice, subject.Id, reason, null);
+            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+        }
 
         [Command("warn")]
         [Summary("Issue a warning to a user.")]
-        public Task Warn(
+        public async Task Warn(
             [Summary("The user to which the warning is being issued.")]
                 IGuildUser subject,
             [Summary("The reason for the warning.")]
             [Remainder]
                 string reason)
-            => ModerationService.CreateInfractionAsync(InfractionType.Warning, subject.Id, reason, null);
+        {
+            await ModerationService.CreateInfractionAsync(InfractionType.Warning, subject.Id, reason, null);
+            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+        }
 
         [Command("mute")]
         [Summary("Mute a user.")]
-        public Task Mute(
+        public async Task Mute(
             [Summary("The user to be muted.")]
                 IGuildUser subject,
             [Summary("The reason for the mute.")]
             [Remainder]
                 string reason)
-            => ModerationService.CreateInfractionAsync(InfractionType.Mute, subject.Id, reason, null);
+        {
+            await ModerationService.CreateInfractionAsync(InfractionType.Mute, subject.Id, reason, null);
+            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+        }
 
         [Command("tempmute")]
         [Summary("Mute a user, for a temporary amount of time.")]
-        public Task TempMute(
+        public async Task TempMute(
             [Summary("The user to be muted.")]
                 IGuildUser subject,
             [Summary("The duration of the mute.")]
@@ -68,53 +72,68 @@ namespace Modix.Modules
             var duration = TimeSpanTypeReader.Read(durationString);
             if (!duration.HasValue) { throw new ArgumentException("Invalid Timespan Format"); }
 
-            return ModerationService.CreateInfractionAsync(InfractionType.Mute, subject.Id, reason, duration.Value);
+            await ModerationService.CreateInfractionAsync(InfractionType.Mute, subject.Id, reason, duration.Value);
+            await Context.Message.AddReactionAsync(new Emoji("🆗"));
         }
 
         [Command("unmute")]
         [Summary("Remove a mute that has been applied to a user.")]
-        public Task UnMute(
+        public async Task UnMute(
             [Summary("The user to be un-muted.")]
                 IGuildUser subject)
-            => ModerationService.RescindInfractionAsync(InfractionType.Mute, subject.Id);
+        {
+            await ModerationService.RescindInfractionAsync(InfractionType.Mute, subject.Id);
+        }
 
         [Command("ban")]
         [Summary("Ban a user from the current guild.")]
-        public Task Ban(
+        public async Task Ban(
             [Summary("The user to be banned.")]
                 IGuildUser subject,
             [Summary("The reason for the ban.")]
             [Remainder]
                 string reason)
-            => ModerationService.CreateInfractionAsync(InfractionType.Ban, subject.Id, reason, null);
+        {
+            await ModerationService.CreateInfractionAsync(InfractionType.Ban, subject.Id, reason, null);
+            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+        }
 
         [Command("forceban")]
         [Alias("ban")]
         [Summary("Ban a user from the guild, even if they are not a member.")]
         [Priority(10)]
-        public Task Forceban(
+        public async Task Forceban(
             [Summary("The id of the user to be banned.")]
                 ulong subject,
             [Summary("The reason for the ban.")]
             [Remainder]
                 string reason)
-            => ModerationService.CreateInfractionAsync(InfractionType.Ban, subject, reason, null);
+        {
+            await ModerationService.CreateInfractionAsync(InfractionType.Ban, subject, reason, null);
+            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+        }
 
         [Command("unban")]
         [Summary("Remove a ban that has been applied to a user.")]
-        public Task UnBan(
+        public async Task UnBan(
             [Summary("The user to be un-banned.")]
                 IGuildUser subject)
-            => ModerationService.RescindInfractionAsync(InfractionType.Ban, subject.Id);
+        {
+            await ModerationService.RescindInfractionAsync(InfractionType.Ban, subject.Id);
+            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+        }
 
         [Command("forceunban")]
         [Alias("unban")]
         [Summary("Remove a ban that has been applied to a user.")]
         [Priority(10)]
-        public Task ForceUnban(
+        public async Task ForceUnban(
             [Summary("The id of the user to be un-banned.")]
                 ulong subject)
-            => ModerationService.RescindInfractionAsync(InfractionType.Ban, subject);
+        {
+            await ModerationService.RescindInfractionAsync(InfractionType.Ban, subject);
+            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+        }
 
         internal protected IModerationService ModerationService { get; }
     }

--- a/Modix/Modules/ModerationModule.cs
+++ b/Modix/Modules/ModerationModule.cs
@@ -18,6 +18,11 @@ namespace Modix.Modules
             ModerationService = moderationService;
         }
 
+        public async Task AddConfirmationEmoji()
+        {
+            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+        }
+
         [Command("note")]
         [Summary("Applies a note to a user's infraction history.")]
         public async Task Note(
@@ -28,7 +33,7 @@ namespace Modix.Modules
                 string reason)
         {
             await ModerationService.CreateInfractionAsync(InfractionType.Notice, subject.Id, reason, null);
-            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+            await AddConfirmationEmoji();
         }
 
         [Command("warn")]
@@ -41,7 +46,7 @@ namespace Modix.Modules
                 string reason)
         {
             await ModerationService.CreateInfractionAsync(InfractionType.Warning, subject.Id, reason, null);
-            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+            await AddConfirmationEmoji();
         }
 
         [Command("mute")]
@@ -54,7 +59,7 @@ namespace Modix.Modules
                 string reason)
         {
             await ModerationService.CreateInfractionAsync(InfractionType.Mute, subject.Id, reason, null);
-            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+            await AddConfirmationEmoji();
         }
 
         [Command("tempmute")]
@@ -73,7 +78,7 @@ namespace Modix.Modules
             if (!duration.HasValue) { throw new ArgumentException("Invalid Timespan Format"); }
 
             await ModerationService.CreateInfractionAsync(InfractionType.Mute, subject.Id, reason, duration.Value);
-            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+            await AddConfirmationEmoji();
         }
 
         [Command("unmute")]
@@ -95,7 +100,7 @@ namespace Modix.Modules
                 string reason)
         {
             await ModerationService.CreateInfractionAsync(InfractionType.Ban, subject.Id, reason, null);
-            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+            await AddConfirmationEmoji();
         }
 
         [Command("forceban")]
@@ -110,7 +115,7 @@ namespace Modix.Modules
                 string reason)
         {
             await ModerationService.CreateInfractionAsync(InfractionType.Ban, subject, reason, null);
-            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+            await AddConfirmationEmoji();
         }
 
         [Command("unban")]
@@ -120,7 +125,7 @@ namespace Modix.Modules
                 IGuildUser subject)
         {
             await ModerationService.RescindInfractionAsync(InfractionType.Ban, subject.Id);
-            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+            await AddConfirmationEmoji();
         }
 
         [Command("forceunban")]
@@ -132,7 +137,7 @@ namespace Modix.Modules
                 ulong subject)
         {
             await ModerationService.RescindInfractionAsync(InfractionType.Ban, subject);
-            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+            await AddConfirmationEmoji();
         }
 
         internal protected IModerationService ModerationService { get; }

--- a/Modix/Modules/ModerationModule.cs
+++ b/Modix/Modules/ModerationModule.cs
@@ -18,6 +18,11 @@ namespace Modix.Modules
             ModerationService = moderationService;
         }
 
+        protected override void AfterExecute(CommandInfo command)
+        {
+            Context.Message.AddReactionAsync(new Emoji("🆗"));
+        }
+
         [Command("note")]
         [Summary("Applies a note to a user's infraction history.")]
         public Task Note(
@@ -83,12 +88,33 @@ namespace Modix.Modules
                 string reason)
             => ModerationService.CreateInfractionAsync(InfractionType.Ban, subject.Id, reason, null);
 
+        [Command("forceban")]
+        [Alias("ban")]
+        [Summary("Ban a user from the guild, even if they are not a member.")]
+        [Priority(10)]
+        public Task Forceban(
+            [Summary("The id of the user to be banned.")]
+                ulong subject,
+            [Summary("The reason for the ban.")]
+            [Remainder]
+                string reason)
+            => ModerationService.CreateInfractionAsync(InfractionType.Ban, subject, reason, null);
+
         [Command("unban")]
         [Summary("Remove a ban that has been applied to a user.")]
         public Task UnBan(
             [Summary("The user to be un-banned.")]
                 IGuildUser subject)
             => ModerationService.RescindInfractionAsync(InfractionType.Ban, subject.Id);
+
+        [Command("forceunban")]
+        [Alias("unban")]
+        [Summary("Remove a ban that has been applied to a user.")]
+        [Priority(10)]
+        public Task ForceUnban(
+            [Summary("The id of the user to be un-banned.")]
+                ulong subject)
+            => ModerationService.RescindInfractionAsync(InfractionType.Ban, subject);
 
         internal protected IModerationService ModerationService { get; }
     }

--- a/Modix/Modules/ModerationModule.cs
+++ b/Modix/Modules/ModerationModule.cs
@@ -18,7 +18,7 @@ namespace Modix.Modules
             ModerationService = moderationService;
         }
 
-        public async Task AddConfirmationEmoji()
+        public async Task AddConfirmation()
         {
             await Context.Message.AddReactionAsync(new Emoji("🆗"));
         }
@@ -33,7 +33,7 @@ namespace Modix.Modules
                 string reason)
         {
             await ModerationService.CreateInfractionAsync(InfractionType.Notice, subject.Id, reason, null);
-            await AddConfirmationEmoji();
+            await AddConfirmation();
         }
 
         [Command("warn")]
@@ -46,7 +46,7 @@ namespace Modix.Modules
                 string reason)
         {
             await ModerationService.CreateInfractionAsync(InfractionType.Warning, subject.Id, reason, null);
-            await AddConfirmationEmoji();
+            await AddConfirmation();
         }
 
         [Command("mute")]
@@ -59,7 +59,7 @@ namespace Modix.Modules
                 string reason)
         {
             await ModerationService.CreateInfractionAsync(InfractionType.Mute, subject.Id, reason, null);
-            await AddConfirmationEmoji();
+            await AddConfirmation();
         }
 
         [Command("tempmute")]
@@ -78,7 +78,7 @@ namespace Modix.Modules
             if (!duration.HasValue) { throw new ArgumentException("Invalid Timespan Format"); }
 
             await ModerationService.CreateInfractionAsync(InfractionType.Mute, subject.Id, reason, duration.Value);
-            await AddConfirmationEmoji();
+            await AddConfirmation();
         }
 
         [Command("unmute")]
@@ -100,7 +100,7 @@ namespace Modix.Modules
                 string reason)
         {
             await ModerationService.CreateInfractionAsync(InfractionType.Ban, subject.Id, reason, null);
-            await AddConfirmationEmoji();
+            await AddConfirmation();
         }
 
         [Command("forceban")]
@@ -109,13 +109,13 @@ namespace Modix.Modules
         [Priority(10)]
         public async Task Forceban(
             [Summary("The id of the user to be banned.")]
-                ulong subject,
+                ulong subjectId,
             [Summary("The reason for the ban.")]
             [Remainder]
                 string reason)
         {
-            await ModerationService.CreateInfractionAsync(InfractionType.Ban, subject, reason, null);
-            await AddConfirmationEmoji();
+            await ModerationService.CreateInfractionAsync(InfractionType.Ban, subjectId, reason, null);
+            await AddConfirmation();
         }
 
         [Command("unban")]
@@ -125,7 +125,7 @@ namespace Modix.Modules
                 IGuildUser subject)
         {
             await ModerationService.RescindInfractionAsync(InfractionType.Ban, subject.Id);
-            await AddConfirmationEmoji();
+            await AddConfirmation();
         }
 
         [Command("forceunban")]
@@ -134,10 +134,10 @@ namespace Modix.Modules
         [Priority(10)]
         public async Task ForceUnban(
             [Summary("The id of the user to be un-banned.")]
-                ulong subject)
+                ulong subjectId)
         {
-            await ModerationService.RescindInfractionAsync(InfractionType.Ban, subject);
-            await AddConfirmationEmoji();
+            await ModerationService.RescindInfractionAsync(InfractionType.Ban, subjectId);
+            await AddConfirmation();
         }
 
         internal protected IModerationService ModerationService { get; }


### PR DESCRIPTION
**Added EphemeralUser**
- Mocked user that implements IGuildUser, can set id, guild, and username
- Needed to facilitate forceban/forceunban and other features that require a user to be tracked who isn't a guild member

**MessageLogBehavior**
- Message hyperlink is now embedded via markdown, as the Discord client has been updated to support this

**ModerationModule**
- Added "forceban" and "forceunban" commands
- Added aliases to "ban" and "unban" respectively, with higher priority so they don't try to resolve users
- Added "OK" emoji reaction on successful command (as per a suggestion in the server)

**InfractionModule**
- Added Search command override to search by raw ID

**ModerationService**
- CreateInfractionAsync - we now try to retrieve the user from the guild, and if it doesn't exist, we create and track an EphemeralUser instance with mocked data
- DoRescindInfractionAsync - we now try to retrieve the user, and if we couldn't, only throw an error if we then try to unmute the user as that requires a proper instance. RemoveBanAsync is now passed the user id from the infraction

**UserInfoModule**
- Massive refactor (inline diff is useless)
  - Reduced code duplication
  - Modularized the sections a bit
  - Removed list formatting code as we already have Humanizer
- Made it work for users that aren't in the guild, but are tracked
  - Member info is not shown for such users
- Added infraction information (only shown if the user that runs the command has the ModerationRead claim, properly resolves #154 )