### PR TITLE
Acknowledge commands with :white_check_mark:

### DIFF
--- a/Modix/Modules/ModerationModule.cs
+++ b/Modix/Modules/ModerationModule.cs
@@ -20,7 +20,7 @@ namespace Modix.Modules
 
         public async Task AddConfirmation()
         {
-            await Context.Message.AddReactionAsync(new Emoji("🆗"));
+            await Context.Message.AddReactionAsync(new Emoji("✅"));
         }
 
         [Command("note")]


### PR DESCRIPTION
Some controversy has come up regarding the use of 🆗 to acknowledge moderation commands since it is more commonly used with a hint of sarcasm. ✅ has been proposed as an alternative.