### PR TITLE
Remove unnecessary dependency in Mod Invite Purging

### DIFF
--- a/Modix.Services/Moderation/ModerationInvitePurgingBehavior.cs
+++ b/Modix.Services/Moderation/ModerationInvitePurgingBehavior.cs
@@ -23,11 +23,10 @@ namespace Modix.Services.Moderation
         /// </summary>
         /// <param name="discordClient">The value to use for <see cref="DiscordClient"/>.</param>
         /// <param name="serviceProvider">See <see cref="BehaviorBase"/>.</param>
-        public ModerationInvitePurgingBehavior(DiscordSocketClient discordClient, IServiceProvider serviceProvider, IDesignatedChannelService designatedChannelService)
+        public ModerationInvitePurgingBehavior(DiscordSocketClient discordClient, IServiceProvider serviceProvider)
             : base(serviceProvider)
         {
             DiscordClient = discordClient;
-            DesignatedChannelService = designatedChannelService;
         }
 
         /// <inheritdoc />
@@ -53,7 +52,6 @@ namespace Modix.Services.Moderation
         /// A <see cref="DiscordSocketClient"/> for interacting with, and receiving events from, the Discord API.
         /// </summary>
         internal protected DiscordSocketClient DiscordClient { get; }
-        internal protected IDesignatedChannelService DesignatedChannelService { get; }
 
         private Task OnDiscordClientMessageReceived(IMessage message)
             => TryPurgeInviteLink(message);


### PR DESCRIPTION
This dependency was refactored to be unused and shouldn't work as expected because Mod Invite Purging Behavior is behavior lifetime while the used service is request scope lifetime. It seems on some machines GetServices is returning something unexpected and injecting that. It looks like this is a bug in the DI library.