### PR TITLE
Aliases for !jumbo

### DIFF
--- a/Modix/Modules/FunModule.cs
+++ b/Modix/Modules/FunModule.cs
@@ -15,7 +15,7 @@ namespace Modix.Modules
     [Name("Fun"), Summary("A bunch of miscellaneous, fun commands")]
     public class FunModule : ModuleBase
     {
-        [Command("jumbo"), Summary("Jumbofy an emoji")]
+        [Command("jumbo"), Summary("Jumbofy an emoji"), Alias("enlarge"), Alias("big"), Alias("large"), Alias("biggen"), Alias("sizeify"), Alias("makegobig")]
         public async Task Jumbo(string emoji)
         {
             string emojiUrl = null;


### PR DESCRIPTION
It's annoying when i try !enlarge just to realize the actual command is !jumbo, so I added a few aliases that would be suitable.
Alias("enlarge"),
Alias("big"),
Alias("large"),
Alias("biggen"),
Alias("sizeify"),
Alias("makegobig")