### PR TITLE
Add infraction modify command

### DIFF
--- a/Modix.Bot/Modules/InfractionModule.cs
+++ b/Modix.Bot/Modules/InfractionModule.cs
@@ -10,6 +10,7 @@ using Modix.Data.Models.Moderation;
 using Modix.Services.Moderation;
 using Modix.Services.Core;
 using Modix.Services.Utilities;
+using Modix.Utilities;
 
 namespace Modix.Modules
 {
@@ -102,6 +103,95 @@ namespace Modix.Modules
             [Summary("The ID value of the infraction to be deleted.")]
                 long infractionId)
             => ModerationService.DeleteInfractionAsync(infractionId);
+
+        [Group("modify")]
+        [Name("Infraction Modification")]
+        [Summary("Provides commands for modifying infractions.")]
+        public class ModifyModule : ModuleBase
+        {
+            public ModifyModule(IModerationService moderationService)
+            {
+                ModerationService = moderationService;
+            }
+
+            [Command("note")]
+            [Summary("Updates an infraction to be a note.")]
+            public async Task ModifyNote(
+                [Summary("The ID value of the infraction to be modified.")]
+                    long infractionId,
+                [Summary("The reason for the note.")]
+                [Remainder]
+                    string reason = null)
+            {
+                await ModerationService.ModifyInfractionAsync(infractionId, InfractionType.Notice, reason: reason);
+
+                await this.AddConfirmation();
+            }
+
+            [Command("warn")]
+            [Summary("Updates an infraction to be a warning.")]
+            public async Task ModifyWarn(
+                [Summary("The ID value of the infraction to be modified.")]
+                    long infractionId,
+                [Summary("The reason for the warning.")]
+                [Remainder]
+                    string reason = null)
+            {
+                await ModerationService.ModifyInfractionAsync(infractionId, InfractionType.Warning, reason: reason);
+
+                await this.AddConfirmation();
+            }
+
+            [Command("mute")]
+            [Summary("Updates an infraction to be a mute.")]
+            public async Task ModifyMute(
+                [Summary("The ID value of the infraction to be modified.")]
+                    long infractionId,
+                [Summary("The reason for the mute.")]
+                [Remainder]
+                    string reason = null)
+            {
+                await ModerationService.ModifyInfractionAsync(infractionId, InfractionType.Mute, reason: reason);
+
+                await this.AddConfirmation();
+            }
+
+            [Command("tempmute")]
+            [Summary("Updates an infraction to be a temporary mute.")]
+            public async Task ModifyTempMute(
+                [Summary("The ID value of the infraction to be modified.")]
+                    long infractionId,
+                [Summary("The duration of the mute.")]
+                    string durationString,
+                [Summary("The reason for the mute.")]
+                [Remainder]
+                    string reason = null)
+            {
+                var duration = TimeSpanTypeReader.Read(durationString)
+                    ?? throw new ArgumentException("Invalid timespan format.");
+
+                await ModerationService.ModifyInfractionAsync(infractionId, InfractionType.Mute, duration, reason: reason);
+
+                await this.AddConfirmation();
+            }
+
+            [Command("ban")]
+            [Alias("forceban")]
+            [Summary("Updates an infraction to be a ban.")]
+            public async Task ModifyBan(
+                [Summary("The ID value of the infraction to be modified.")]
+                    long infractionId,
+                [Summary("The reason for the ban.")]
+                [Remainder]
+                    string reason = null)
+            {
+                await ModerationService.ModifyInfractionAsync(infractionId, InfractionType.Ban, reason: reason);
+
+                await this.AddConfirmation();
+            }
+
+            internal protected IModerationService ModerationService { get; }
+        }
 
         internal protected IModerationService ModerationService { get; }
         public IUserService UserService { get; }

--- a/Modix.Bot/Utilities/ModuleBaseExtensions.cs
+++ b/Modix.Bot/Utilities/ModuleBaseExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading.Tasks;
+
+using Discord;
+using Discord.Commands;
+
+namespace Modix.Utilities
+{
+    public static class ModuleBaseExtensions
+    {
+        public static async Task AddConfirmation(this ModuleBase moduleBase)
+            => await moduleBase.Context.Message.AddReactionAsync(new Emoji("✅"));
+    }
+}


### PR DESCRIPTION
Fixes #155.

This PR adds a number of new commands under the `!infraction` group:
- `!infraction modify note`
- `!infraction modify warn`
- `!infraction modify mute`
- `!infraction modify tempmute`
- `!infraction modify ban`
- `!infraction modify forceban`

Each of the above commands takes an infraction ID. The `tempmute` variant requires a duration, similar to the existing `!tempmute` command. The reason is an optional parameter for all variants. If it is supplied, then the modified infraction is saved with the supplied reason. If it is not supplied, then the modified infraction retains the comment from the existing infraction.

![image](https://user-images.githubusercontent.com/2829282/48318957-70ea5400-e5d5-11e8-8007-1624de03db1b.png)