### PR TITLE
Fix AutoRescind exceptions

### DIFF
--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -69,6 +69,10 @@ namespace Modix.Services.Moderation
         /// Marks an existing infraction as rescinded, based on its ID.
         /// </summary>
         /// <param name="infractionId">The <see cref="InfractionEntity.Id"/> value of the infraction to be rescinded.</param>
+        /// <param name="isAutoRescind">
+        /// Indicates whether the rescind request is an AutoRescind from MODiX.
+        /// This determines whether checks such as rank validation will occur.
+        /// </param>
         /// <returns>A <see cref="Task"/> which will complete when the operation has completed.</returns>
         Task RescindInfractionAsync(long infractionId, bool isAutoRescind = false);
 


### PR DESCRIPTION
Fix for issues found during dev testing.

Fixes a `NullReferenceException` that was occurring because the `CurrentGuildId` was not set during autorescinds.

Fixes an `InvalidOperationException` that was occurring when MODiX didn't have a rank higher than the infraction subject.