### PR TITLE
Disable Assign button when not applicable

### DIFF
--- a/Modix/ClientApp/src/views/Configuration/ChannelDesignations.vue
+++ b/Modix/ClientApp/src/views/Configuration/ChannelDesignations.vue
@@ -73,7 +73,7 @@
                         <button class="button" @click="cancel()">Cancel</button>
                     </div>
                     <div class="level-right">
-                        <button class="button is-success" :class="{'is-loading': createLoading}" @click="createAssignment()" :disable="disableAssignButton()">Assign</button>
+                        <button class="button is-success" :class="{'is-loading': createLoading}" @click="createAssignment()" :disabled="disableAssignButton()">Assign</button>
                     </div>
                 </footer>
             </div>
@@ -207,7 +207,7 @@ export default class ChannelDesignations extends Vue
     {
         if (this.designationCreationData.channelId == '') { return true; }
 
-        return _.some(this.$store.state.modix.channelDesignations, channel =>
+        return _.some(this.$store.state.modix.channelDesignations, (channel: DesignatedChannelMapping) =>
             channel.channelId == this.designationCreationData.channelId &&
             this.designationCreationData.channelDesignations.indexOf(channel.channelDesignation) > -1);
     }

--- a/Modix/ClientApp/src/views/Configuration/ChannelDesignations.vue
+++ b/Modix/ClientApp/src/views/Configuration/ChannelDesignations.vue
@@ -73,7 +73,7 @@
                         <button class="button" @click="cancel()">Cancel</button>
                     </div>
                     <div class="level-right">
-                        <button class="button is-success" :class="{'is-loading': createLoading}" @click="createAssignment()">Assign</button>
+                        <button class="button is-success" :class="{'is-loading': createLoading}" @click="createAssignment()" :disable="disableAssignButton()">Assign</button>
                     </div>
                 </footer>
             </div>
@@ -201,6 +201,15 @@ export default class ChannelDesignations extends Vue
         return _.some(this.$store.state.modix.channelDesignations, channel => 
                 channel.channelId == this.designationCreationData.channelId &&
                 channel.channelDesignation == designation);
+    }
+
+    disableAssignButton(): boolean
+    {
+        if (this.designationCreationData.channelId == '') { return true; }
+
+        return _.some(this.$store.state.modix.channelDesignations, channel =>
+            channel.channelId == this.designationCreationData.channelId &&
+            this.designationCreationData.channelDesignations.indexOf(channel.channelDesignation) > -1);
     }
 
     async createAssignment()

--- a/Modix/ClientApp/src/views/Configuration/RoleDesignations.vue
+++ b/Modix/ClientApp/src/views/Configuration/RoleDesignations.vue
@@ -73,7 +73,7 @@
                         <button class="button" @click="cancel()">Cancel</button>
                     </div>
                     <div class="level-right">
-                        <button class="button is-success" :class="{'is-loading': createLoading}" @click="createAssignment()">Assign</button>
+                        <button class="button is-success" :class="{'is-loading': createLoading}" @click="createAssignment()" :disabled="disableAssignButton()">Assign</button>
                     </div>
                 </footer>
             </div>
@@ -203,6 +203,15 @@ export default class RoleDesignations extends Vue
         return _.some(this.$store.state.modix.roleMappings, (role: DesignatedRoleMapping) => 
                 role.roleId == this.designationCreationData.roleId &&
                 role.roleDesignation == designation);
+    }
+
+    disableAssignButton(): boolean
+    {
+        if (this.designationCreationData.roleId == '') { return true; }
+
+        return _.some(this.$store.state.modix.roleMappings, (role: DesignatedRoleMapping) =>
+            role.roleId == this.designationCreationData.roleId &&
+            this.designationCreationData.roleDesignations.indexOf(role.roleDesignation) > -1);
     }
 
     async createAssignment()


### PR DESCRIPTION
Disables the Assign button on the Configuration modals when the selected role/designations or channel/designations combination isn't valid. If it were left enabled instead, clicking Assign otherwise would cause the bot to hang.

**Before**:
![before](https://user-images.githubusercontent.com/2829282/48654958-60741800-e9df-11e8-9eb7-4b495c4a9852.gif)

**After**:
![after](https://user-images.githubusercontent.com/2829282/48654959-636f0880-e9df-11e8-8696-4f8dd00654d5.gif)
