### PR TITLE
Remove role selection from Promotions creation

### DIFF
--- a/Modix/ClientApp/src/models/promotions/PromotionCreationData.ts
+++ b/Modix/ClientApp/src/models/promotions/PromotionCreationData.ts
@@ -1,6 +1,5 @@
 export default interface PromotionCreationData
 {
     userId: string;
-    roleId: string;
     comment: string;
 }

--- a/Modix/ClientApp/src/services/PromotionService.ts
+++ b/Modix/ClientApp/src/services/PromotionService.ts
@@ -5,6 +5,7 @@ import client from './ApiClient';
 import _ from 'lodash';
 import PromotionComment from '@/models/promotions/PromotionComment';
 import Deserializer from '@/app/Deserializer';
+import Role from '@/models/Role';
 
 export default class PromotionService
 {
@@ -36,6 +37,11 @@ export default class PromotionService
         });
 
         return response;
+    }
+
+    static async getNextRankRoleForUser(subjectId: string): Promise<Role>
+    {
+        return (await client.get(`campaigns/nextRank/${subjectId}`)).data as Role;
     }
 
     static async createCampaign(data: PromotionCreationData): Promise<void>

--- a/Modix/Controllers/PromotionController.cs
+++ b/Modix/Controllers/PromotionController.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Discord;
 using Discord.WebSocket;
 using Microsoft.AspNetCore.Mvc;
 using Modix.Data.Models.Promotions;
@@ -31,6 +33,17 @@ namespace Modix.Controllers
         {
             var result = await _promotionsService.GetCampaignDetailsAsync(campaignId);
             return Ok(result.Comments);
+        }
+
+        [HttpGet("nextRank/{subjectId}")]
+        public async Task<IActionResult> GetNextRankRoleForUser(ulong subjectId)
+        {
+            var result = await _promotionsService.GetNextRankRoleForUserAsync(subjectId);
+            var color = result is null
+                ? Color.DarkGrey
+                : UserGuild.Roles.FirstOrDefault(r => r.Id == result.Id).Color;
+
+            return Ok(new { result?.Id, result?.Name, fgColor = color.ToString() });
         }
 
         [HttpPut("{campaignId}/comments")]
@@ -90,8 +103,7 @@ namespace Modix.Controllers
         {
             try
             {
-                // TODO: get promotion rank from creation data
-                await _promotionsService.CreateCampaignAsync(creationData.UserId, creationData.RoleId, creationData.Comment);
+                await _promotionsService.CreateCampaignAsync(creationData.UserId, creationData.Comment);
             }
             catch (InvalidOperationException ex)
             {

--- a/Modix/Models/PromotionCreationData.cs
+++ b/Modix/Models/PromotionCreationData.cs
@@ -3,7 +3,6 @@
     public class PromotionCreationData
     {
         public ulong UserId { get; set; }
-        public ulong RoleId { get; set; }
         public string Comment { get; set; }
     }
 }


### PR DESCRIPTION
Removes the role dropdown from the Promotions creation page and replaces it with a field indicating the rank that the user will be promoted to.

![image](https://user-images.githubusercontent.com/2829282/48668144-7dc6e600-eab4-11e8-9125-573b612f32fc.png)
