### PR TITLE
Fix NullReferenceException when starting a new promotion campaign

### DIFF
--- a/Modix/ClientApp/src/services/PromotionService.ts
+++ b/Modix/ClientApp/src/services/PromotionService.ts
@@ -41,7 +41,7 @@ export default class PromotionService
 
     static async getNextRankRoleForUser(subjectId: string): Promise<Role>
     {
-        return (await client.get(`campaigns/nextRank/${subjectId}`)).data as Role;
+        return (await client.get(`campaigns/${subjectId}/nextRank`)).data as Role;
     }
 
     static async createCampaign(data: PromotionCreationData): Promise<void>

--- a/Modix/Controllers/PromotionController.cs
+++ b/Modix/Controllers/PromotionController.cs
@@ -35,7 +35,7 @@ namespace Modix.Controllers
             return Ok(result.Comments);
         }
 
-        [HttpGet("nextRank/{subjectId}")]
+        [HttpGet("{subjectId}/nextRank")]
         public async Task<IActionResult> GetNextRankRoleForUser(ulong subjectId)
         {
             var result = await _promotionsService.GetNextRankRoleForUserAsync(subjectId);


### PR DESCRIPTION
Changes the `nexkRank` route to be in the correct format.