### PR TITLE
Quote embed should link to the original message

### DIFF
--- a/Modix.Services/Quote/QuoteService.cs
+++ b/Modix.Services/Quote/QuoteService.cs
@@ -1,4 +1,6 @@
-﻿using Discord;
+﻿using System;
+using Discord;
+using static System.FormattableString;
 
 namespace Modix.Services.Quote
 {
@@ -11,8 +13,21 @@ namespace Modix.Services.Quote
     {
         public EmbedBuilder BuildQuoteEmbed(IMessage message, IUser executingUser)
         {
+            string messageUrl = null;
+            if (message.Channel is IGuildChannel guildChannel && guildChannel.Guild is IGuild guild)
+            {
+                messageUrl = Invariant($"https://discordapp.com/channels/{guild.Id}/{guildChannel.Id}/{message.Id}");
+            }
+
             var embed = new EmbedBuilder()
-                .WithAuthor(x => x.WithIconUrl(message.Author.GetAvatarUrl()).WithName(message.Author.Username))
+                .WithAuthor(x => {
+                    x = x.WithIconUrl(message.Author.GetAvatarUrl()).WithName(message.Author.Username);
+
+                    if (messageUrl != null)
+                    {
+                        x.WithUrl(messageUrl);
+                    }
+                })
                 .WithDescription(message.Content);
 
             embed.AddField("Quoted by", executingUser.Mention, true);

--- a/Modix.Services/Quote/QuoteService.cs
+++ b/Modix.Services/Quote/QuoteService.cs
@@ -20,7 +20,8 @@ namespace Modix.Services.Quote
             }
 
             var embed = new EmbedBuilder()
-                .WithAuthor(x => {
+                .WithAuthor(x =>
+                {
                     x = x.WithIconUrl(message.Author.GetAvatarUrl()).WithName(message.Author.Username);
 
                     if (messageUrl != null)


### PR DESCRIPTION
If the message being quoted was sent in a guild channel, this will make the author's name in the embed a link to the original message. However, it won't appear to be a link until the user hovers their mouse over the name. The author's name currently never links to anything so this shouldn't change existing behavior. 

The only other place I could think of to put this was in the footer, but that doesn't support markdown and the footer doesn't have a URL property.