### PR TITLE
Allow admins to moderate anyone, including themselves or other admins

### DIFF
--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -630,13 +630,14 @@ namespace Modix.Services.Moderation
 
         private async Task RequireSubjectRankLowerThanModeratorRankAsync(ulong guildId, ulong subjectId)
         {
-            var rankRoles = await GetRankRolesAsync();
-
-            var subject = await UserService.GetGuildUserAsync(guildId, subjectId);
             var moderator = await UserService.GetGuildUserAsync(guildId, AuthorizationService.CurrentUserId.Value);
 
             if (moderator.GuildPermissions.Administrator)
                 return;
+
+            var rankRoles = await GetRankRolesAsync();
+
+            var subject = await UserService.GetGuildUserAsync(guildId, subjectId);
 
             var subjectRankRoles = rankRoles.Where(r => subject.RoleIds.Contains(r.Id));
             var moderatorRankRoles = rankRoles.Where(r => moderator.RoleIds.Contains(r.Id));

--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -259,7 +259,7 @@ namespace Modix.Services.Moderation
             AuthorizationService.RequireAuthenticatedUser();
             AuthorizationService.RequireClaims(_createInfractionClaimsByType[type]);
 
-            await RequireSubjectRankLowerThanModeratorRank(AuthorizationService.CurrentGuildId.Value, subjectId);
+            await RequireSubjectRankLowerThanModeratorRankAsync(AuthorizationService.CurrentGuildId.Value, subjectId);
 
             var guild = await DiscordClient.GetGuildAsync(AuthorizationService.CurrentGuildId.Value);
 
@@ -374,7 +374,7 @@ namespace Modix.Services.Moderation
             if (infraction == null)
                 throw new InvalidOperationException($"Infraction {infractionId} does not exist");
 
-            await RequireSubjectRankLowerThanModeratorRank(infraction.GuildId, infraction.Subject.Id);
+            await RequireSubjectRankLowerThanModeratorRankAsync(infraction.GuildId, infraction.Subject.Id);
 
             await InfractionRepository.TryDeleteAsync(infraction.Id, AuthorizationService.CurrentUserId.Value);
 
@@ -578,7 +578,7 @@ namespace Modix.Services.Moderation
                 throw new InvalidOperationException("Infraction does not exist");
 
             if (!isAutoRescind)
-                await RequireSubjectRankLowerThanModeratorRank(infraction.GuildId, infraction.Subject.Id);
+                await RequireSubjectRankLowerThanModeratorRankAsync(infraction.GuildId, infraction.Subject.Id);
 
             await InfractionRepository.TryRescindAsync(infraction.Id, AuthorizationService.CurrentUserId.Value);
 
@@ -628,12 +628,15 @@ namespace Modix.Services.Moderation
                 }))
                 .Select(r => r.Role);
 
-        private async Task RequireSubjectRankLowerThanModeratorRank(ulong guildId, ulong subjectId)
+        private async Task RequireSubjectRankLowerThanModeratorRankAsync(ulong guildId, ulong subjectId)
         {
             var rankRoles = await GetRankRolesAsync();
 
             var subject = await UserService.GetGuildUserAsync(guildId, subjectId);
             var moderator = await UserService.GetGuildUserAsync(guildId, AuthorizationService.CurrentUserId.Value);
+
+            if (moderator.GuildPermissions.Administrator)
+                return;
 
             var subjectRankRoles = rankRoles.Where(r => subject.RoleIds.Contains(r.Id));
             var moderatorRankRoles = rankRoles.Where(r => moderator.RoleIds.Contains(r.Id));


### PR DESCRIPTION
I noticed that the bot was preventing admins from deleting infractions from themselves, which seemed odd. It would allow infractions to get into a "stuck" state where nobody could rescind or delete them. Besides that, the point of the admin permission is that you can do whatever you want short of deleting the server, so this PR rectifies that by ignoring admins in the rank validation.

Another potential option might be to create a claim for avoiding the rank check and giving that claim to the admin role.

I could go either way on this one.