### PR TITLE
Run Vue CLI before BeforeBuild

### DIFF
--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -35,6 +35,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <UpToDateCheckInput Include="$(SpaRoot)package-lock.json"/>
+    <UpToDateCheckInput Include="@(ClientSrc)"/>
+
+    <UpToDateCheckBuilt Include="$(SpaRoot)node_modules\.npm_timestamp"/>
+    <UpToDateCheckBuilt Include="$(MSBuildThisFileDirectory)obj\$(Configuration)\.vue_timestamp"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Don't publish the SPA source files, but do show them in the project files list -->
     <Content Remove="$(SpaRoot)**" />
     <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />

--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -65,11 +65,14 @@
     </Touch>
   </Target>
 
-  <Target Name="RunVueCli" BeforeTargets="Build" DependsOnTargets="NpmInstall" Inputs="@(ClientSrc)" Outputs="$(MSBuildThisFileDirectory)obj\$(Configuration)\.vue_timestamp" 
+  <Target Name="RunVueCli" AfterTargets="BeforeBuild" DependsOnTargets="NpmInstall" Inputs="@(ClientSrc)" Outputs="$(MSBuildThisFileDirectory)obj\$(Configuration)\.vue_timestamp"
           Condition=" '$(Configuration)' == 'Debug'">
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run $(NpmBuild)" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run $(NpmBuild)">
+      <Output TaskParameter="ExitCode" PropertyName="VueErrorCode" />
+    </Exec>
 
-    <Touch Files="$(MSBuildThisFileDirectory)obj\$(Configuration)\.vue_timestamp" AlwaysCreate="true">
+    <Touch Files="$(MSBuildThisFileDirectory)obj\$(Configuration)\.vue_timestamp" AlwaysCreate="true"
+           Condition=" '$(VueErrorCode)' == '0' ">
       <Output TaskParameter="TouchedFiles" ItemName="FileWrites" />
     </Touch>
   </Target>


### PR DESCRIPTION
When VS builds incrementally it's possible that the Build target itself won't actually run if none of the files for the compilation have been changed since the last build. This may result in the Vue CLI step not running despite changes to front-end files. Let's try running this target earlier in the build so that it doesn't get skipped.