### PR TITLE
Also include full stack trace in exception logs

### DIFF
--- a/Modix.Services/Utilities/ExceptionContractResolver.cs
+++ b/Modix.Services/Utilities/ExceptionContractResolver.cs
@@ -11,7 +11,7 @@ namespace Modix.Services.Utilities
         private static readonly string[] _propertyFilter = new[]
         {
             "Message", "StackTraceString", "InnerException",
-            "Source", "ClassName"
+            "Source", "ClassName", "StackTrace"
         };
 
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)


### PR DESCRIPTION
I assumed "StackTraceString" would be enough but I guess not