### PR TITLE
Fix CommandErrorHandler

### DIFF
--- a/Modix.Services/CommandHelp/CommandHelpSetup.cs
+++ b/Modix.Services/CommandHelp/CommandHelpSetup.cs
@@ -17,7 +17,8 @@ namespace Modix.Services.CommandHelp
         public static IServiceCollection AddCommandHelp(this IServiceCollection services)
             => services
                 .AddSingleton<CommandHelpService>()
-                .AddScoped<INotificationHandler<ReactionAdded>, CommandErrorHandler>()
-                .AddScoped<INotificationHandler<ReactionRemoved>, CommandErrorHandler>();
+                .AddSingleton<CommandErrorHandler>()
+                .AddSingleton<INotificationHandler<ReactionAdded>>(x => x.GetService<CommandErrorHandler>())
+                .AddSingleton<INotificationHandler<ReactionRemoved>>(x => x.GetService<CommandErrorHandler>());
     }
 }

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -77,7 +77,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ICodePasteRepository, MemoryCodePasteRepository>();
             services.AddScoped<IPopularityContestService, PopularityContestService>();
 
-            services.AddSingleton<CommandErrorHandler>();
             services.AddScoped<IBehaviourConfigurationRepository, BehaviourConfigurationRepository>();
             services.AddScoped<IBehaviourConfigurationService, BehaviourConfigurationService>();
             services.AddSingleton<IBehaviourConfiguration, BehaviourConfiguration>();


### PR DESCRIPTION
The bot wasn't replying with the reason why a command failed, because separate instances of `CommandErrorHandler` were being created. This PR makes the `CommandErrorHandler` a singleton regardless of the registered interface.

![image](https://user-images.githubusercontent.com/2829282/49678162-96417500-fa50-11e8-87a4-6abcccc65f3b.png)
