### PR TITLE
Restrict promotions page with a claim

### DIFF
--- a/Modix.Data/Models/Core/AuthorizationClaim.cs
+++ b/Modix.Data/Models/Core/AuthorizationClaim.cs
@@ -109,6 +109,11 @@ namespace Modix.Data.Models.Core
         [ClaimInfo(PromotionActions, "Authorizes a request to comment on a promotion campaign for a user.")]
         PromotionsComment,
         /// <summary>
+        /// Authorizes a request to read promotion campaign data.
+        /// </summary>
+        [ClaimInfo(PromotionActions, "Authorizes a request to read promotion campaign data.")]
+        PromotionsRead,
+        /// <summary>
         /// Authorizes a request to perform a count for a popularity contest
         /// </summary>
         [ClaimInfo(Misc, "Authorizes a request to perform a count for a popularity contest")]

--- a/Modix.Services/Promotions/PromotionsService.cs
+++ b/Modix.Services/Promotions/PromotionsService.cs
@@ -308,16 +308,28 @@ namespace Modix.Services.Promotions
         }
 
         /// <inheritdoc />
-        public Task<IReadOnlyCollection<PromotionCampaignSummary>> SearchCampaignsAsync(PromotionCampaignSearchCriteria searchCriteria)
-            => PromotionCampaignRepository.SearchSummariesAsync(searchCriteria);
+        public async Task<IReadOnlyCollection<PromotionCampaignSummary>> SearchCampaignsAsync(PromotionCampaignSearchCriteria searchCriteria)
+        {
+            AuthorizationService.RequireClaims(AuthorizationClaim.PromotionsRead);
+
+            return await PromotionCampaignRepository.SearchSummariesAsync(searchCriteria);
+        }
 
         /// <inheritdoc />
         public async Task<PromotionCampaignDetails> GetCampaignDetailsAsync(long campaignId)
-            => await PromotionCampaignRepository.ReadDetailsAsync(campaignId);
+        {
+            AuthorizationService.RequireClaims(AuthorizationClaim.PromotionsRead);
+
+            return await PromotionCampaignRepository.ReadDetailsAsync(campaignId);
+        }
 
         /// <inheritdoc />
-        public Task<PromotionActionSummary> GetPromotionActionSummaryAsync(long promotionActionId)
-            => PromotionActionRepository.ReadSummaryAsync(promotionActionId);
+        public async Task<PromotionActionSummary> GetPromotionActionSummaryAsync(long promotionActionId)
+        {
+            AuthorizationService.RequireClaims(AuthorizationClaim.PromotionsRead);
+
+            return await PromotionActionRepository.ReadSummaryAsync(promotionActionId);
+        }
 
         /// <summary>
         /// An <see cref="IDiscordClient"/> for interacting with the Discord API.

--- a/Modix/ClientApp/src/router.ts
+++ b/Modix/ClientApp/src/router.ts
@@ -45,7 +45,7 @@ let routes: ModixRouteData[] =
         name: 'promotions',
         component: Promotions,
         showInNavbar: true,
-        requiresAuth: true
+        requiredClaims: ["PromotionsRead"]
     },
     {
         path: '/promotions/create',


### PR DESCRIPTION
Adds a new `PromotionsRead` claim to restrict who can view the Promotions page and use the `!promotions` command.

Making this PR because it's pointless for us to restrict the #promotion-log channel in the guild if everyone can still see the campaigns in the website anyway.