### PR TITLE
Disconnects should not be logged as errors

### DIFF
--- a/Modix.Bot/ModixBot.cs
+++ b/Modix.Bot/ModixBot.cs
@@ -140,7 +140,7 @@ namespace Modix
 
         private Task OnDisconnect(Exception ex)
         {
-            Log.LogError(ex, "The bot has disconnected because of an error. Stopping the application.");
+            Log.LogInformation(ex, "The bot has disconnected unexpectedly. Stopping the application.");
             _applicationLifetime.StopApplication();
             return Task.CompletedTask;
         }


### PR DESCRIPTION
These disconnects happen a lot more often than I expected. Since the bot recovers automatically, lets stop logging them as errors.