### PR TITLE
Improvements to Promotions

### DIFF
--- a/Modix.Bot/Behaviors/PromotionLoggingHandler.cs
+++ b/Modix.Bot/Behaviors/PromotionLoggingHandler.cs
@@ -92,8 +92,6 @@ namespace Modix.Behaviors
                     }))
                     .First();
 
-                    var comments = (await PromotionsService.GetCampaignDetailsAsync(targetCampaign.Id)).Comments.AsEnumerable();
-
                     embed = embed
                         .WithTitle("The campaign is over!")
                         .AddField("Approval Rate", fullCampaign.GetApprovalPercentage().ToString("p"), true);
@@ -106,14 +104,10 @@ namespace Modix.Behaviors
                         case PromotionCampaignOutcome.Accepted:
                             embed = embed
                                 .WithDescription($"Staff accepted the campaign, and {boldName} was promoted to {boldRole}! 🎉");
-
-                            comments = comments.Where(d => d.Sentiment == PromotionSentiment.Approve);
                             break;
                         case PromotionCampaignOutcome.Rejected:
                             embed = embed
                                 .WithDescription($"Staff rejected the campaign to promote {boldName} to {boldRole}");
-
-                            comments = comments.Where(d => d.Sentiment == PromotionSentiment.Oppose);
                             break;
                         case PromotionCampaignOutcome.Failed:
                         default:
@@ -121,12 +115,6 @@ namespace Modix.Behaviors
                                 .WithDescription("There was an issue while accepting or denying the campaign. Ask staff for details.")
                                 .AddField("Target Role", MentionUtils.MentionRole(targetCampaign.TargetRole.Id), true);
                             break;
-                    }
-
-                    foreach (var comment in comments.Take(5))
-                    {
-                        var commentSymbol = targetCampaign.Outcome == PromotionCampaignOutcome.Accepted ? "👍" : "👎";
-                        embed = embed.AddField($"Comment posted {comment.CreateAction.Created.ToString("g")}", $"{commentSymbol} {comment.Content}", true);
                     }
 
                     break;

--- a/Modix.Bot/Behaviors/PromotionLoggingHandler.cs
+++ b/Modix.Bot/Behaviors/PromotionLoggingHandler.cs
@@ -71,6 +71,10 @@ namespace Modix.Behaviors
 
             var embed = new EmbedBuilder();
 
+            //Because we have comment creation as a separate operation from starting the campaign,
+            //we don't have access to the "initial" comment when a campaign is created. So, we have to
+            //note that a campaign was created, and actually send the log message when the first comment
+            //is created (containing the comment body)
             switch (promotionAction.Type)
             {
                 case PromotionActionType.CampaignCreated:

--- a/Modix.Bot/Behaviors/PromotionLoggingHandler.cs
+++ b/Modix.Bot/Behaviors/PromotionLoggingHandler.cs
@@ -104,10 +104,7 @@ namespace Modix.Behaviors
                                 .AddField("Their new role is", MentionUtils.MentionRole(targetCampaign.TargetRole.Id));
                             break;
                         case PromotionCampaignOutcome.Rejected:
-                            embed = embed
-                                .WithDescription("The campaign was rejected by staff.")
-                                .AddField("Their new role would have been", MentionUtils.MentionRole(targetCampaign.TargetRole.Id));
-                            break;
+                            return null; //Don't send notifications for rejections
                         case PromotionCampaignOutcome.Failed:
                         default:
                             embed = embed

--- a/Modix.Bot/Behaviors/PromotionLoggingHandler.cs
+++ b/Modix.Bot/Behaviors/PromotionLoggingHandler.cs
@@ -1,15 +1,19 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Discord;
+using Discord.WebSocket;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Modix.Data.Messages;
 using Modix.Data.Models.Core;
 using Modix.Data.Models.Promotions;
 using Modix.Data.Repositories;
+using Modix.Data.Utilities;
 using Modix.Services.Core;
 using Modix.Services.Promotions;
 
@@ -37,37 +41,121 @@ namespace Modix.Behaviors
 
         public async Task OnPromotionActionCreatedAsync(long promotionActionId, PromotionActionCreationData data)
         {
-            if (!await DesignatedChannelService.AnyDesignatedChannelAsync(data.GuildId, DesignatedChannelType.PromotionLog))
-                return;
-
-            try
+            if (await DesignatedChannelService.AnyDesignatedChannelAsync(data.GuildId, DesignatedChannelType.PromotionLog))
             {
-                var promotionAction = await PromotionsService.GetPromotionActionSummaryAsync(promotionActionId);
+                var message = await FormatPromotionLogEntry(promotionActionId, data);
 
-                if (!_renderTemplates.TryGetValue((promotionAction.Type, promotionAction.NewComment?.Sentiment, promotionAction.Campaign?.Outcome), out var renderTemplate))
+                if (message == null)
                     return;
-
-                var message = string.Format(renderTemplate,
-                    promotionAction.Created.UtcDateTime.ToString("HH:mm:ss"),
-                    promotionAction.Campaign?.Id,
-                    promotionAction.Campaign?.Subject.DisplayName,
-                    promotionAction.Campaign?.Subject.Id,
-                    promotionAction.Campaign?.TargetRole.Name,
-                    promotionAction.Campaign?.TargetRole.Id,
-                    promotionAction.NewComment?.Campaign.Id,
-                    promotionAction.NewComment?.Campaign.Subject.DisplayName,
-                    promotionAction.NewComment?.Campaign.Subject.Id,
-                    promotionAction.NewComment?.Campaign.TargetRole.Name,
-                    promotionAction.NewComment?.Campaign.TargetRole.Id,
-                    promotionAction.NewComment?.Content);
 
                 await DesignatedChannelService.SendToDesignatedChannelsAsync(
                     await DiscordClient.GetGuildAsync(data.GuildId), DesignatedChannelType.PromotionLog, message);
             }
-            catch (Exception ex)
+
+            if (await DesignatedChannelService.AnyDesignatedChannelAsync(data.GuildId, DesignatedChannelType.PromotionNotifications))
             {
-                var text = Newtonsoft.Json.JsonConvert.SerializeObject(ex);
+                var embed = await FormatPromotionNotification(promotionActionId, data);
+
+                if (embed == null)
+                    return;
+
+                await DesignatedChannelService.SendToDesignatedChannelsAsync(
+                    await DiscordClient.GetGuildAsync(data.GuildId), DesignatedChannelType.PromotionNotifications, "", embed);
             }
+        }
+
+        private async Task<Embed> FormatPromotionNotification(long promotionActionId, PromotionActionCreationData data)
+        {
+            var promotionAction = await PromotionsService.GetPromotionActionSummaryAsync(promotionActionId);
+            var targetCampaign = promotionAction.Campaign ?? promotionAction.NewComment.Campaign;
+
+            var embed = new EmbedBuilder();
+
+            switch (promotionAction.Type)
+            {
+                case PromotionActionType.CampaignCreated:
+
+                    _initialCommentQueue.TryAdd(targetCampaign.Id, embed
+                        .WithTitle("A new campaign has been started!")
+                        .AddField("If accepted, their new role will be", MentionUtils.MentionRole(targetCampaign.TargetRole.Id)));
+
+                    return null;
+                case PromotionActionType.CampaignClosed:
+
+                    var fullCampaign = (await PromotionsService.SearchCampaignsAsync(new PromotionCampaignSearchCriteria
+                    {
+                        Id = targetCampaign.Id
+                    }))
+                    .First();
+
+                    embed = embed
+                        .WithTitle("The campaign is over!")
+                        .AddField("Approval Rate", fullCampaign.GetApprovalPercentage().ToString("p"));
+
+                    switch (targetCampaign.Outcome)
+                    {
+                        case PromotionCampaignOutcome.Accepted:
+                            embed = embed
+                                .WithDescription($"Staff accepted the campaign, and **{targetCampaign.Subject.Username}#{targetCampaign.Subject.Discriminator}** was promoted! 🎉")
+                                .AddField("Their new role is", MentionUtils.MentionRole(targetCampaign.TargetRole.Id));
+                            break;
+                        case PromotionCampaignOutcome.Rejected:
+                            embed = embed
+                                .WithDescription("The campaign was rejected by staff.")
+                                .AddField("Their new role would have been", MentionUtils.MentionRole(targetCampaign.TargetRole.Id));
+                            break;
+                        case PromotionCampaignOutcome.Failed:
+                        default:
+                            embed = embed
+                                .WithDescription("There was an issue while accepting or denying the campaign. Ask staff for details.")
+                                .AddField("Target Role", MentionUtils.MentionRole(targetCampaign.TargetRole.Id));
+                            break;
+                    }
+
+                    break;
+                case PromotionActionType.CommentCreated:
+
+                    if (_initialCommentQueue.TryRemove(targetCampaign.Id, out embed))
+                    {
+                        embed.Description = $"👍 {promotionAction.NewComment.Content}";
+                    }
+                    else
+                    {
+                        return null;
+                    }
+
+                    break;
+                case PromotionActionType.CommentModified:
+                default:
+                    return null;
+            }
+
+            return embed
+                .WithAuthor(await DiscordClient.GetUserAsync(targetCampaign.Subject.Id))
+                .WithFooter("See more at https://mod.gg/promotions")
+                .Build();
+        }
+
+        private async Task<string> FormatPromotionLogEntry(long promotionActionId, PromotionActionCreationData data)
+        {
+            var promotionAction = await PromotionsService.GetPromotionActionSummaryAsync(promotionActionId);
+
+            if (!_logRenderTemplates.TryGetValue((promotionAction.Type, promotionAction.NewComment?.Sentiment, promotionAction.Campaign?.Outcome), out var renderTemplate))
+                return null;
+
+            return string.Format(renderTemplate,
+                   promotionAction.Created.UtcDateTime.ToString("HH:mm:ss"),
+                   promotionAction.Campaign?.Id,
+                   promotionAction.Campaign?.Subject.DisplayName,
+                   promotionAction.Campaign?.Subject.Id,
+                   promotionAction.Campaign?.TargetRole.Name,
+                   promotionAction.Campaign?.TargetRole.Id,
+                   promotionAction.NewComment?.Campaign.Id,
+                   promotionAction.NewComment?.Campaign.Subject.DisplayName,
+                   promotionAction.NewComment?.Campaign.Subject.Id,
+                   promotionAction.NewComment?.Campaign.TargetRole.Name,
+                   promotionAction.NewComment?.Campaign.TargetRole.Id,
+                   promotionAction.NewComment?.Content);
         }
 
         /// <summary>
@@ -87,16 +175,18 @@ namespace Modix.Behaviors
             => _lazyPromotionsService.Value;
         private readonly Lazy<IPromotionsService> _lazyPromotionsService;
 
-        private static readonly Dictionary<(PromotionActionType, PromotionSentiment?, PromotionCampaignOutcome?), string> _renderTemplates
+        private static ConcurrentDictionary<long, EmbedBuilder> _initialCommentQueue = new ConcurrentDictionary<long, EmbedBuilder>();
+
+        private static readonly Dictionary<(PromotionActionType, PromotionSentiment?, PromotionCampaignOutcome?), string> _logRenderTemplates
             = new Dictionary<(PromotionActionType, PromotionSentiment?, PromotionCampaignOutcome?), string>()
             {
                 { (PromotionActionType.CampaignCreated,  null,                       null),                              "`[{0}]` A campaign (`{1}`) was created to promote **{2}** (`{3}`) to **{4}** (`{5}`)." },
                 { (PromotionActionType.CommentCreated,   PromotionSentiment.Abstain, null),                              "`[{0}]` A comment was added to the campaign (`{6}`) to promote **{7}** (`{8}`) to **{9}** (`{10}`), abstaining from the campaign. ```{11}```" },
                 { (PromotionActionType.CommentCreated,   PromotionSentiment.Approve, null),                              "`[{0}]` A comment was added to the campaign (`{6}`) to promote **{7}** (`{8}`) to **{9}** (`{10}`), approving of the promotion. ```{11}```" },
                 { (PromotionActionType.CommentCreated,   PromotionSentiment.Oppose,  null),                              "`[{0}]` A comment was added to the campaign (`{6}`) to promote **{7}** (`{8}`) to **{9}** (`{10}`), opposing the promotion. ```{11}```" },
-                { (PromotionActionType.CommentModified,   PromotionSentiment.Abstain, null),                              "`[{0}]` A comment was modified in the campaign (`{6}`) to promote **{7}** (`{8}`) to **{9}** (`{10}`), abstaining from the campaign. ```{11}```" },
-                { (PromotionActionType.CommentModified,   PromotionSentiment.Approve, null),                              "`[{0}]` A comment was modified in the campaign (`{6}`) to promote **{7}** (`{8}`) to **{9}** (`{10}`), approving of the promotion. ```{11}```" },
-                { (PromotionActionType.CommentModified,   PromotionSentiment.Oppose,  null),                              "`[{0}]` A comment was modified in the campaign (`{6}`) to promote **{7}** (`{8}`) to **{9}** (`{10}`), opposing the promotion. ```{11}```" },
+                { (PromotionActionType.CommentModified,  PromotionSentiment.Abstain, null),                              "`[{0}]` A comment was modified in the campaign (`{6}`) to promote **{7}** (`{8}`) to **{9}** (`{10}`), abstaining from the campaign. ```{11}```" },
+                { (PromotionActionType.CommentModified,  PromotionSentiment.Approve, null),                              "`[{0}]` A comment was modified in the campaign (`{6}`) to promote **{7}** (`{8}`) to **{9}** (`{10}`), approving of the promotion. ```{11}```" },
+                { (PromotionActionType.CommentModified,  PromotionSentiment.Oppose,  null),                              "`[{0}]` A comment was modified in the campaign (`{6}`) to promote **{7}** (`{8}`) to **{9}** (`{10}`), opposing the promotion. ```{11}```" },
                 { (PromotionActionType.CampaignClosed,   null,                       PromotionCampaignOutcome.Accepted), "`[{0}]` The campaign (`{1}`) to promote **{2}** (`{3}`) to **{4}** (`{5}`) was accepted." },
                 { (PromotionActionType.CampaignClosed,   null,                       PromotionCampaignOutcome.Rejected), "`[{0}]` The campaign (`{1}`) to promote **{2}** (`{3}`) to **{4}** (`{5}`) was rejected." },
                 { (PromotionActionType.CampaignClosed,   null,                       PromotionCampaignOutcome.Failed),   "`[{0}]` The campaign (`{1}`) to promote **{2}** (`{3}`) to **{4}** (`{5}`) failed to process." },

--- a/Modix.Bot/Modules/DesignatedChannelModule.cs
+++ b/Modix.Bot/Modules/DesignatedChannelModule.cs
@@ -93,10 +93,11 @@ namespace Modix.Modules
         private static readonly Dictionary<DesignatedChannelType, string> _designatedChannelTypeRenderings
             = new Dictionary<DesignatedChannelType, string>()
             {
-                { DesignatedChannelType.MessageLog,    "Message Log" },
-                { DesignatedChannelType.ModerationLog, "Moderation Log" },
-                { DesignatedChannelType.PromotionLog,  "Promotion Log" },
-                { DesignatedChannelType.Unmoderated,   "Unmoderated" },
+                { DesignatedChannelType.MessageLog,             "Message Log" },
+                { DesignatedChannelType.ModerationLog,          "Moderation Log" },
+                { DesignatedChannelType.PromotionLog,           "Promotion Log" },
+                { DesignatedChannelType.PromotionNotifications, "Promotion Notifications" },
+                { DesignatedChannelType.Unmoderated,            "Unmoderated" },
             };
     }
 }

--- a/Modix.Data/Models/Core/DesignatedChannelType.cs
+++ b/Modix.Data/Models/Core/DesignatedChannelType.cs
@@ -18,6 +18,10 @@
         /// </summary>
         PromotionLog,
         /// <summary>
+        /// Defines a channel to send promotion campaign creation/closing notifications.
+        /// </summary>
+        PromotionNotifications,
+        /// <summary>
         /// Defines a channel that is not subject to auto-moderation behaviors of the moderation feature.
         /// </summary>
         Unmoderated

--- a/Modix.Data/Models/Promotions/PromotionCampaignSearchCriteria.cs
+++ b/Modix.Data/Models/Promotions/PromotionCampaignSearchCriteria.cs
@@ -12,6 +12,11 @@ namespace Modix.Data.Models.Promotions
     public class PromotionCampaignSearchCriteria
     {
         /// <summary>
+        /// A <see cref="PromotionCampaignEntity.Id"/> value, defining the <see cref="PromotionCampaignEntity"/> entities to be returned.
+        /// </summary>
+        public long? Id { get; set; }
+
+        /// <summary>
         /// A <see cref="PromotionCampaignEntity.GuildId"/> value, defining the <see cref="PromotionCampaignEntity"/> entities to be returned.
         /// </summary>
         public ulong? GuildId { get; set; }
@@ -73,6 +78,9 @@ namespace Modix.Data.Models.Promotions
                 return query;
 
             return query
+                .FilterBy(
+                    x => x.Id == criteria.Id,
+                    !(criteria.Id is null))
                 .FilterBy(
                     x => x.GuildId == criteria.GuildId,
                     !(criteria.GuildId is null))

--- a/Modix.Data/Utilities/EntityExtensions.cs
+++ b/Modix.Data/Utilities/EntityExtensions.cs
@@ -22,9 +22,9 @@ namespace Modix.Data.Utilities
                 .Select(x => x.Value)
                 .Sum();
 
-            var totalVotes = GetTotalVotes(campaign);
+            double totalVotes = GetTotalVotes(campaign);
 
-            return (float)totalApprovals / totalVotes;
+            return totalApprovals / totalVotes;
         }
     }
 }

--- a/Modix.Data/Utilities/EntityExtensions.cs
+++ b/Modix.Data/Utilities/EntityExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Modix.Data.Models.Promotions;
+
+namespace Modix.Data.Utilities
+{
+    public static class EntityExtensions
+    {
+        public static int GetTotalVotes(this PromotionCampaignSummary campaign)
+        {
+            return campaign.CommentCounts
+                .Select(x => x.Value)
+                .Sum();
+        }
+
+        public static double GetApprovalPercentage(this PromotionCampaignSummary campaign)
+        {
+            var totalApprovals = campaign.CommentCounts
+                .Where(x => x.Key == PromotionSentiment.Approve)
+                .Select(x => x.Value)
+                .Sum();
+
+            var totalVotes = GetTotalVotes(campaign);
+
+            return (float)totalApprovals / totalVotes;
+        }
+    }
+}

--- a/Modix/ClientApp/src/components/Configuration/IndividualDesignation.vue
+++ b/Modix/ClientApp/src/components/Configuration/IndividualDesignation.vue
@@ -1,7 +1,7 @@
 <template>
 
     <div class="tags has-addons">
-        <span class="tag is-info">
+        <span class="tag is-link">
             <template v-if="isChannel">#</template><template v-else>@</template>{{designation.name}}
         </span>
 

--- a/Modix/ClientApp/src/components/MiniProfile.vue
+++ b/Modix/ClientApp/src/components/MiniProfile.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="profile">
         <template v-if="user && user.userId">
-            <img class="avatar-icon" :src="user.avatarUrl">
+            <img class="avatar-icon" v-if="user.avatarHash" :src="user.avatarUrl">
 
             <v-popover>
                 <p class="title is-4">

--- a/Modix/ClientApp/src/components/MiniProfile.vue
+++ b/Modix/ClientApp/src/components/MiniProfile.vue
@@ -5,7 +5,12 @@
 
             <v-popover>
                 <p class="title is-4">
-                    <span class="username">{{user.name}} <small>&#9660;</small></span>
+                    <span class="username">
+                        {{user.name}}
+                        <div class="expander">
+                            &#9660;
+                        </div>
+                    </span>
                 </p>
 
                 <template slot="popover">
@@ -36,7 +41,7 @@
                     <img class="dropdown-icon" :src="currentGuild.iconUrl">
 
                     <div class="expander">
-                        <template>&#9660;</template>
+                        &#9660;
                     </div>
 
                 </div>

--- a/Modix/ClientApp/src/components/Promotions/PromotionCommentEditModal.vue
+++ b/Modix/ClientApp/src/components/Promotions/PromotionCommentEditModal.vue
@@ -35,7 +35,7 @@
                 </div>
                 <div class="level-right">
                     <button class="button is-success" v-bind:class="{'is-loading': loadingCommentUpdate}"
-                            v-on:click="updateComment()" v-bind:disabled="newComment.body.length <= 3 || newComment.body == comment.content">Update</button>
+                            v-on:click="updateComment()" v-bind:disabled="!allowUpdate">Update</button>
                 </div>
             </footer>
         </div>
@@ -74,14 +74,24 @@ export default class PromotionCommentEditModal extends Vue
     @Watch('showUpdateModal')
     modalShownOrUnshown()
     {
-        if (this.showUpdateModal) {
-            this.newComment.body = this.comment.content;
-            this.newComment.sentiment = this.comment.sentiment;
+        if (this.showUpdateModal)
+        {
+            this.newComment = {
+                body: this.comment.content,
+                sentiment: this.comment.sentiment
+            };
+
+            this.error = "";
         }
         else
         {
             this.$emit('comment-edit-modal-closed')
         }
+    }
+
+    get allowUpdate(): boolean
+    {
+        return this.newComment.body.length > 3;
     }
 
     async updateComment()

--- a/Modix/ClientApp/src/components/Promotions/PromotionCommentView.vue
+++ b/Modix/ClientApp/src/components/Promotions/PromotionCommentView.vue
@@ -5,7 +5,7 @@
         <span class="commentBody">
             {{comment.content}} <span class="date">{{formatDate(comment.createAction.created)}}</span>
         </span>
-        <span class="button is-primary" :style="{'margin-left': '0.33em'}" v-if="comment.isFromCurrentUser && !isCampaignClosed" v-on:click="$emit('comment-edit-modal-opened', comment)">Edit</span>
+        <span class="button is-link edit" :style="{'margin-left': '0.33em'}" v-if="comment.isFromCurrentUser && !hidden" v-on:click="$emit('comment-edit-modal-opened', comment)">Edit</span>
 
     </div>
 
@@ -28,7 +28,7 @@ export default class PromotionCommentView extends Vue
     newComment: PromotionCommentData = { body: "", sentiment: PromotionSentiment.Abstain };
 
     @Prop() private comment!: PromotionComment;
-    @Prop() private isCampaignClosed!: boolean;
+    @Prop() private hidden!: boolean;
 
     sentimentIcon(sentiment: PromotionSentiment)
     {

--- a/Modix/ClientApp/src/components/Promotions/PromotionListItem.vue
+++ b/Modix/ClientApp/src/components/Promotions/PromotionListItem.vue
@@ -61,11 +61,11 @@
             <small class="date">Campaign started <span class="has-text-weight-bold">{{formatDate(campaign.startDate)}}</span></small>
 
             <div class="commentList">
-                <PromotionCommentView v-for="(comment, index) in comments" :key="comment.promotionCampaignId" :comment="comment" :isCampaignClosed="campaign.closeAction"
+                <PromotionCommentView v-for="(comment, index) in comments" :key="comment.promotionCampaignId" :comment="comment" :hidden="!shouldShowEdit(campaign, comment)"
                                       :style="{'transition-delay': (index * 33) + 'ms'}" v-on:comment-edit-modal-opened="onCommentEditModalOpened"/>
             </div>
 
-            <div class="field has-addons" v-if="!campaign.closeAction">
+            <div class="field has-addons" v-if="!campaign.closeAction && !userAlreadyCommented(campaign)">
                 <p class="control">
                     <span class="select">
                         <select v-model="newComment.sentiment">
@@ -230,6 +230,16 @@ export default class PromotionListItem extends Vue
     onCommentEditModalOpened(comment: PromotionComment)
     {
         this.$emit('comment-edit-modal-opened', comment);
+    }
+
+    userAlreadyCommented()
+    {
+        return _.some(this.comments, comment => comment.isFromCurrentUser);
+    }
+
+    shouldShowEdit(campaign: PromotionCampaign, comment: PromotionComment): boolean
+    {
+        return campaign.closeAction == null;
     }
 }
 </script>

--- a/Modix/ClientApp/src/components/Promotions/PromotionListItem.vue
+++ b/Modix/ClientApp/src/components/Promotions/PromotionListItem.vue
@@ -28,7 +28,7 @@
 
             </div>
 
-            <div class="column is-narrow-tablet adminButtons" v-if="canClose">
+            <div class="column is-narrow-tablet adminButtons">
                 <a class="button is-primary is-small is-fullwidth" :class="{'is-loading': dialogLoading}"
                    :disabled="campaign.outcome == 'Accepted'" @click.stop="showPanel()">More…</a>
             </div>
@@ -61,11 +61,14 @@
             <small class="date">Campaign started <span class="has-text-weight-bold">{{formatDate(campaign.startDate)}}</span></small>
 
             <div class="commentList">
+                <div v-if="forCurrentUser" class="commentNotification">
+                    Sorry, you aren't allowed to see comments on your own campaign.
+                </div>
                 <PromotionCommentView v-for="(comment, index) in comments" :key="comment.promotionCampaignId" :comment="comment" :hidden="!shouldShowEdit(campaign, comment)"
                                       :style="{'transition-delay': (index * 33) + 'ms'}" v-on:comment-edit-modal-opened="onCommentEditModalOpened"/>
             </div>
 
-            <div class="field has-addons" v-if="!campaign.closeAction && !userAlreadyCommented(campaign)">
+            <div class="field has-addons" v-if="!campaign.closeAction && !userAlreadyCommented(campaign) && !forCurrentUser">
                 <p class="control">
                     <span class="select">
                         <select v-model="newComment.sentiment">
@@ -105,12 +108,13 @@ import Role from '@/models/Role';
 import store from '@/app/Store';
 import PromotionCommentData from '@/models/promotions/PromotionCommentData';
 import PromotionService from '@/services/PromotionService';
+import ModixComponent from '@/components/ModixComponent.vue';
 
 
 @Component({
     components: {PromotionCommentView}
 })
-export default class PromotionListItem extends Vue
+export default class PromotionListItem extends ModixComponent
 {
     @Prop() private campaign!: PromotionCampaign;
     @Prop({default: false}) private dialogLoading!: boolean;
@@ -131,6 +135,11 @@ export default class PromotionListItem extends Vue
         return store.userHasClaims(["PromotionsCloseCampaign"]);
     }
 
+    get forCurrentUser()
+    {
+        return this.campaign.subject && this.state.user && this.campaign.subject.id.toString() == this.state.user.userId;
+    }
+
     @Watch('newComment.body')
     commentChanged()
     {
@@ -147,7 +156,11 @@ export default class PromotionListItem extends Vue
 
     async created()
     {
-        this.comments = await PromotionService.getComments(this.campaign.id);
+        if (!this.forCurrentUser)
+        {
+            this.comments = await PromotionService.getComments(this.campaign.id);
+        }
+
         this.resetNewComment();
     }
 

--- a/Modix/ClientApp/src/models/moderation/ChannelDesignation.ts
+++ b/Modix/ClientApp/src/models/moderation/ChannelDesignation.ts
@@ -3,5 +3,6 @@ export enum ChannelDesignation
     ModerationLog = "ModerationLog",
     MessageLog = "MessageLog",
     PromotionLog = "PromotionLog",
+    PromotionNotifications = "PromotionNotifications",
     Unmoderated = "Unmoderated"
 }

--- a/Modix/ClientApp/src/services/PromotionService.ts
+++ b/Modix/ClientApp/src/services/PromotionService.ts
@@ -12,8 +12,8 @@ export default class PromotionService
     static async getCampaigns(): Promise<PromotionCampaign[]>
     {
         let response = (await client.get("campaigns")).data as PromotionCampaign[];
-        
-        _.forEach(response, campaign => 
+
+        _.forEach(response, campaign =>
         {
             if (campaign.createAction)
             {
@@ -28,7 +28,7 @@ export default class PromotionService
     {
         let response = (await client.get(`campaigns/${campaignId}`)).data as PromotionComment[];
 
-        _.forEach(response, comment => 
+        _.forEach(response, comment =>
         {
             if (comment.createAction)
             {
@@ -62,6 +62,11 @@ export default class PromotionService
     static async approveCampaign(campaign: PromotionCampaign): Promise<void>
     {
         await client.post(`campaigns/${campaign.id}/accept`);
+    }
+
+    static async forceApproveCampaign(campaign: PromotionCampaign): Promise<void>
+    {
+        await client.post(`campaigns/${campaign.id}/forceAccept`);
     }
 
     static async denyCampaign(campaign: PromotionCampaign): Promise<void>

--- a/Modix/ClientApp/src/styles/components/configuration.scss
+++ b/Modix/ClientApp/src/styles/components/configuration.scss
@@ -1,0 +1,20 @@
+.configuration
+{
+    .tabs
+    {
+        a
+        {
+            margin-bottom: 0;
+        }
+
+        ul
+        {
+            border-bottom: 0;
+        }
+
+        li
+        {
+            margin-top: 0;
+        }
+    }
+}

--- a/Modix/ClientApp/src/styles/components/miniProfile.scss
+++ b/Modix/ClientApp/src/styles/components/miniProfile.scss
@@ -4,32 +4,16 @@
 
     border-left: 1px solid transparentize($white, 0.75);
 
-    margin: 2px 0.25em 0 0.33em;
+    margin: 5px 5px 0 5px;
     padding-left: 0.66em;
 
     display: inline-block;
-
-    & > .avatar-icon
-    {
-        position: relative;
-        top: 2px;
-    }
 }
 
 .icon
 {
     vertical-align: middle;
     margin-right: 0.5em;
-}
-
-
-.expander
-{
-    display: inline-block;
-    font-size: 0.8em;
-
-    position: relative;
-    top: -7px;
 }
 
 .profile
@@ -54,7 +38,7 @@
 
     &:hover
     {
-        background: $info;
+        background: $link;
         color: white;
 
         cursor: pointer;
@@ -69,7 +53,7 @@
     {
         padding-top: 0;
         padding-bottom: 0;
-        border-bottom: 1px solid $link;
+        border-bottom: 1px solid lightgray;
     }
 }
 
@@ -84,7 +68,6 @@ img.avatar-icon, img.dropdown-icon
     margin-right: 0.5em;
 
     border-radius: 4px;
-    box-shadow: -1px 1px 0px white;
 
     height: 32px;
     max-height: 32px;

--- a/Modix/ClientApp/src/styles/components/promotionCommentView.scss
+++ b/Modix/ClientApp/src/styles/components/promotionCommentView.scss
@@ -19,6 +19,8 @@
     align-items: center;
     align-content: stretch;
 
+    overflow: hidden;
+
     &:first-child
     {
         border-radius: 0 1em 0 0;
@@ -75,4 +77,12 @@
 .own
 {
     background: lighten($primary, 50%);
+}
+
+.edit
+{
+    position: absolute;
+    right: 0px;
+
+    padding: 2em;
 }

--- a/Modix/ClientApp/src/styles/components/promotionListItem.scss
+++ b/Modix/ClientApp/src/styles/components/promotionListItem.scss
@@ -54,12 +54,12 @@
     max-height: 70px;
     overflow: hidden;
 
+    transition: box-shadow 0.33s cubic-bezier(0.23, 1, 0.32, 1);
+
     & > .columns
     {
         cursor: pointer;
     }
-
-    transition: box-shadow 0.33s cubic-bezier(0.23, 1, 0.32, 1);
 
     &.expanded
     {
@@ -78,6 +78,14 @@
     &.inactive
     {
         background-color: $light;
+    }
+
+    .commentNotification
+    {
+        text-align: center;
+        font-weight: bold;
+
+        margin: 1em 0 0.5em 0;
     }
 
     .date, .role

--- a/Modix/ClientApp/src/styles/components/promotionListItem.scss
+++ b/Modix/ClientApp/src/styles/components/promotionListItem.scss
@@ -25,28 +25,6 @@
     }
 }
 
-.toRole
-{
-    font-size: 14px;
-    font-weight: 400 !important;
-    padding: 4px 8px;
-
-    border: 2px solid black;
-    border-radius: 3px;
-
-    position: relative;
-    top: -2px;
-    left: 20px;
-
-    @include mobile()
-    {
-        display: table;
-
-        margin-left: 2em;
-        margin-top: -0.6em;
-    }
-}
-
 .ratings
 {
     padding: 0.85rem 0.75rem 0em 0.75em;
@@ -110,6 +88,28 @@
         color: grey;
 
         margin-bottom: -10px;
+    }
+
+    .toRole
+    {
+        font-size: 14px;
+        font-weight: 400 !important;
+        padding: 4px 8px;
+
+        border: 2px solid black;
+        border-radius: 3px;
+
+        position: relative;
+        top: -2px;
+        left: 20px;
+
+        @include mobile()
+        {
+            display: table;
+
+            margin-left: 2em;
+            margin-top: -0.6em;
+        }
     }
 
     @include mobile()

--- a/Modix/ClientApp/src/styles/mixins/modal-dark-bg.scss
+++ b/Modix/ClientApp/src/styles/mixins/modal-dark-bg.scss
@@ -1,0 +1,10 @@
+.modal-card-foot
+{
+    color: white;
+
+    label:hover
+    {
+        color: white;
+        font-weight: bold;
+    }
+}

--- a/Modix/ClientApp/src/styles/required.scss
+++ b/Modix/ClientApp/src/styles/required.scss
@@ -23,3 +23,4 @@
 @import "@/styles/components/promotionCommentView.scss";
 @import "@/styles/components/commandView.scss";
 @import "@/styles/components/promotionListItem.scss";
+@import "@/styles/components/configuration.scss";

--- a/Modix/ClientApp/src/styles/themes/holiday.scss
+++ b/Modix/ClientApp/src/styles/themes/holiday.scss
@@ -1,3 +1,5 @@
+@import '../mixins/modal-dark-bg.scss';
+
 $holiday-green: #235941;
 $holiday-red: #9c2b40;
 

--- a/Modix/ClientApp/src/styles/themes/spoopy.scss
+++ b/Modix/ClientApp/src/styles/themes/spoopy.scss
@@ -1,3 +1,5 @@
+@import '../mixins/modal-dark-bg.scss';
+
 //Generic Bulma overrides
 
 $primary: rgb(200, 120, 50);

--- a/Modix/ClientApp/src/styles/variables.scss
+++ b/Modix/ClientApp/src/styles/variables.scss
@@ -90,6 +90,16 @@ a.is-disabled
     margin: 0;
 }
 
+.expander
+{
+    display: inline-block;
+    font-size: 12px;
+
+    vertical-align: top;
+    position: relative;
+    top: 10px;
+}
+
 @keyframes fadeIn
 {
     0%

--- a/Modix/ClientApp/src/views/CreatePromotion.vue
+++ b/Modix/ClientApp/src/views/CreatePromotion.vue
@@ -123,7 +123,11 @@ export default class CreatePromotion extends Vue
     async userChanged()
     {
         this.creationData.userId = this.selectedUser.userId;
-        this.selectedRole = await PromotionService.getNextRankRoleForUser(this.selectedUser.userId);
+
+        if (this.selectedUser && this.selectedUser.userId)
+        {
+            this.selectedRole = await PromotionService.getNextRankRoleForUser(this.selectedUser.userId);
+        }
     }
 
     @Watch('selectedRole')

--- a/Modix/ClientApp/src/views/Infractions.vue
+++ b/Modix/ClientApp/src/views/Infractions.vue
@@ -38,10 +38,10 @@
                         </span>
                         <span v-else-if="props.column.field == 'actions'">
                             <span class="level">
-                                <button class="button is-primary is-small level-left" v-show="props.row.canDelete" v-on:click="onInfractionDelete(props.row.id)">
+                                <button class="button is-link is-small level-left" v-show="props.row.canDelete" v-on:click="onInfractionDelete(props.row.id)">
                                     Delete
                                 </button>
-                                <button class="button is-primary is-small level-right" v-if="props.row.canRescind" v-on:click="onInfractionRescind(props.row.id)">
+                                <button class="button is-link is-small level-right" v-if="props.row.canRescind" v-on:click="onInfractionRescind(props.row.id)">
                                     Rescind
                                 </button>
                             </span>

--- a/Modix/ClientApp/src/views/Promotions.vue
+++ b/Modix/ClientApp/src/views/Promotions.vue
@@ -71,18 +71,21 @@
                     <section class="modal-card-body">
                         <h4 class="title is-size-4">Infractions</h4>
 
-                        <ol v-if="modalCampaignInfractions.length > 0">
-                            <li v-for="infraction in modalCampaignInfractions" :key="infraction.id" :value="infraction.id">
-                                <strong>{{infraction.createAction.createdBy.displayName}}</strong> gave a
-                                <strong>{{infraction.type}}</strong> on <strong>{{formatDate(infraction.createAction.created)}}</strong> for
-                                &quot;<strong>{{infraction.reason}}</strong>&quot;
-                            </li>
-                        </ol>
+                        <template v-if="canSeeInfractions">
+                            <ol v-if="modalCampaignInfractions.length > 0">
+                                <li v-for="infraction in modalCampaignInfractions" :key="infraction.id" :value="infraction.id">
+                                    <strong>{{infraction.createAction.createdBy.displayName}}</strong> gave a
+                                    <strong>{{infraction.type}}</strong> on <strong>{{formatDate(infraction.createAction.created)}}</strong> for
+                                    &quot;<strong>{{infraction.reason}}</strong>&quot;
+                                </li>
+                            </ol>
+                            <h6 v-else class="title is-size-6">No active infractions for this user</h6>
+                        </template>
+                        <h6 v-else>You can't see infractions because you're missing the ModerationRead claim.</h6>
 
-                        <h6 v-else class="title is-size-6">No active infractions for this user</h6>
 
                     </section>
-                    <footer class="modal-card-foot level">
+                    <footer class="modal-card-foot level" v-if="canCloseCampaign">
                         <div class="level-left">
                             <button class="button is-success" :class="{'is-loading': modifyLoading}" :disabled="modalCampaign.closeAction" @click="promote()">Accept</button>
                             <label class="checkbox">
@@ -191,6 +194,7 @@ import PromotionComment from '@/models/promotions/PromotionComment';
 import PromotionCommentEditModal from '@/components/Promotions/PromotionCommentEditModal.vue';
 
 import {formatDate} from '@/app/Util';
+import ModixComponent from '@/components/ModixComponent.vue';
 
 var Clipboard = require('clipboard');
 
@@ -203,7 +207,7 @@ var Clipboard = require('clipboard');
         PromotionCommentEditModal
     },
 })
-export default class Promotions extends Vue
+export default class Promotions extends ModixComponent
 {
     showInactive: boolean = false;
     showModal: boolean = false;
@@ -230,6 +234,16 @@ export default class Promotions extends Vue
         ], ['desc', 'desc']);
 
         return _.filter(ordered, campaign => (this.showInactive ? true : campaign.isActive));
+    }
+
+    get canSeeInfractions()
+    {
+        return store.userHasClaims(["ModerationRead"]);
+    }
+
+    get canCloseCampaign()
+    {
+        return store.userHasClaims(["PromotionsCloseCampaign"]);
     }
 
     @Watch('showInactive')
@@ -261,7 +275,12 @@ export default class Promotions extends Vue
         this.currentlyLoadingInfractions = campaign.id;
 
         this.modalCampaign = campaign;
-        this.modalCampaignInfractions = await GeneralService.getInfractionsForUser(this.modalCampaign.subject!.id);
+
+        if (this.state.user && store.userHasClaims(["ModerationRead"]))
+        {
+            this.modalCampaignInfractions = await GeneralService.getInfractionsForUser(this.modalCampaign.subject!.id);
+        }
+
         this.modalForceAccept = false;
 
         this.toggleModal();

--- a/Modix/ClientApp/src/views/Promotions.vue
+++ b/Modix/ClientApp/src/views/Promotions.vue
@@ -85,6 +85,10 @@
                     <footer class="modal-card-foot level">
                         <div class="level-left">
                             <button class="button is-success" :class="{'is-loading': modifyLoading}" :disabled="modalCampaign.closeAction" @click="promote()">Accept</button>
+                            <label class="checkbox">
+                                <input type="checkbox" v-model="modalForceAccept">
+                                Force?
+                            </label>
                         </div>
                         <div class="level-right">
                             <button class="button is-danger" :class="{'is-loading': modifyLoading}" :disabled="modalCampaign.closeAction" @click="deny()">Reject</button>
@@ -206,6 +210,7 @@ export default class Promotions extends Vue
 
     modalCampaign: PromotionCampaign | null = null;
     modalCampaignInfractions: InfractionSummary[] = [];
+    modalForceAccept: boolean = false;
 
     currentlyLoadingInfractions: number | null = null;
     loading: boolean = false;
@@ -257,6 +262,7 @@ export default class Promotions extends Vue
 
         this.modalCampaign = campaign;
         this.modalCampaignInfractions = await GeneralService.getInfractionsForUser(this.modalCampaign.subject!.id);
+        this.modalForceAccept = false;
 
         this.toggleModal();
 
@@ -276,7 +282,14 @@ export default class Promotions extends Vue
 
         try
         {
-            await PromotionService.approveCampaign(this.modalCampaign);
+            if (this.modalForceAccept)
+            {
+                await PromotionService.forceApproveCampaign(this.modalCampaign);
+            }
+            else
+            {
+                await PromotionService.approveCampaign(this.modalCampaign);
+            }
         }
         catch (err)
         {

--- a/Modix/Controllers/ModixController.cs
+++ b/Modix/Controllers/ModixController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Discord;
 using Discord.WebSocket;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -28,6 +29,7 @@ namespace Modix.Controllers
 
         public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
+            if (!DiscordSocketClient.Guilds.Any()) { await next(); return; }
             if (HttpContext.User == null) { await next(); return; }
 
             //Parse the ID to look up socket user

--- a/Modix/Controllers/PromotionController.cs
+++ b/Modix/Controllers/PromotionController.cs
@@ -61,9 +61,12 @@ namespace Modix.Controllers
         [HttpPut("{campaignId}/comments")]
         public async Task<IActionResult> AddComment(int campaignId, [FromBody] PromotionCommentData commentData)
         {
-            var campaign = await _promotionsService.GetCampaignDetailsAsync(campaignId);
+            var campaigns = await _promotionsService.SearchCampaignsAsync(new PromotionCampaignSearchCriteria
+            {
+                Id = campaignId
+            });
 
-            if (campaign == null)
+            if (!campaigns.Any())
             {
                 return BadRequest($"Invalid campaign ID specified ({campaignId})");
             }

--- a/Modix/Controllers/PromotionController.cs
+++ b/Modix/Controllers/PromotionController.cs
@@ -33,6 +33,8 @@ namespace Modix.Controllers
         {
             var result = await _promotionsService.GetCampaignDetailsAsync(campaignId);
 
+            if (result == null) { return NotFound(); }
+
             //TODO: Map this properly
             return Ok(result.Comments.Select(c => new
             {
@@ -98,7 +100,22 @@ namespace Modix.Controllers
         {
             try
             {
-                await _promotionsService.AcceptCampaignAsync(campaignId);
+                await _promotionsService.AcceptCampaignAsync(campaignId, false);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+
+            return Ok();
+        }
+
+        [HttpPost("{campaignId}/forceAccept")]
+        public async Task<IActionResult> ForceAcceptCampaign(int campaignId)
+        {
+            try
+            {
+                await _promotionsService.AcceptCampaignAsync(campaignId, true);
             }
             catch (InvalidOperationException ex)
             {


### PR DESCRIPTION
This PR primarily adds a new designated channel type for promotions, called "PromotionNotifications". The messages sent here are more user friendly (use embeds), and it only triggers on starting or closing a campaign. It also adds a "force" option when accepting campaigns, to bypass the time limit, and removes the input field from a campaign the frontend if the user has already commented on it (kind of treading all over #251, but this impl is simpler; sorry @Scott-Caldwell!).

**Changelog:**
- Add "PromotionNotifications" designated channel type, for public campaign creation/closing notifications
- Add handling for these notifications + light refactoring to `PromotionLoggingHandler`
- Add Id filter to `PromotionCampaignSearchCriteria`
- Add "force" argument to `AcceptCampaignAsync` of `PromotionsService`, to bypass time restrictions + checkbox on web frontend + extra arg to Discord command
- Many small style changes and improvements to frontend & promotions page
- Hide "new comment" input if the user has already commented on a campaign
- Potential fix for race condition when trying Auth before guilds have loaded