### PR TITLE
Skip auto quoting a message link if the content is empty

### DIFF
--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -67,7 +67,7 @@ namespace Modix.Services.Quote
                         {
                             var msg = await messageChannel.GetMessageAsync(messageId);
 
-                            if (msg != null)
+                            if (msg != null && !string.IsNullOrWhiteSpace(msg.Content))
                             {
                                 await SelfExecuteRequest<IQuoteService>(
                                     quoteService =>

--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Discord;
@@ -44,13 +45,10 @@ namespace Modix.Services.Quote
         {
             if (!(message is SocketUserMessage userMessage) ||
                 !(userMessage.Author is SocketGuildUser guildUser) ||
-                guildUser.IsBot || guildUser.IsWebhook ||
-                string.IsNullOrWhiteSpace(userMessage.Content))
+                guildUser.IsBot || guildUser.IsWebhook || IsQuote(message))
             {
                 return;
             }
-
-            var embeds = new List<EmbedBuilder>();
 
             foreach (Match match in Pattern.Matches(message.Content))
             {
@@ -60,24 +58,7 @@ namespace Modix.Services.Quote
                 {
                     try
                     {
-                        var channel = DiscordClient.GetChannel(channelId);
-
-                        if (channel is IGuildChannel &&
-                            channel is ISocketMessageChannel messageChannel)
-                        {
-                            var msg = await messageChannel.GetMessageAsync(messageId);
-
-                            if (msg != null && !string.IsNullOrWhiteSpace(msg.Content))
-                            {
-                                await SelfExecuteRequest<IQuoteService>(
-                                    quoteService =>
-                                    {
-                                        var embed = quoteService.BuildQuoteEmbed(msg, guildUser);
-                                        embeds.Add(embed);
-                                        return Task.CompletedTask;
-                                    });
-                            }
-                        }
+                        await SendQuoteEmbedAsync(channelId, messageId, guildUser, userMessage.Channel);
                     }
                     catch (Exception ex)
                     {
@@ -85,11 +66,35 @@ namespace Modix.Services.Quote
                     }
                 }
             }
+        }
 
-            foreach (var embed in embeds)
+        private async Task SendQuoteEmbedAsync(ulong originalChannelId, ulong messageId, SocketGuildUser quoter, ISocketMessageChannel targetChannel)
+        {
+            var channel = DiscordClient.GetChannel(originalChannelId);
+
+            if (channel is IGuildChannel &&
+                channel is ISocketMessageChannel messageChannel)
             {
-                await userMessage.Channel.SendMessageAsync(string.Empty, embed: embed.Build());
+                var msg = await messageChannel.GetMessageAsync(messageId);
+                if (msg == null) { return; }
+
+                await SelfExecuteRequest<IQuoteService>(async quoteService =>
+                {
+                    var embed = quoteService.BuildQuoteEmbed(msg, quoter)?.Build();
+                    if (embed == null) { return; }
+
+                    await targetChannel.SendMessageAsync(string.Empty, embed: embed);
+                });
             }
+        }
+
+        private bool IsQuote(IMessage message)
+        {
+            return
+                message
+                .Embeds?.FirstOrDefault()
+                ?.Fields.FirstOrDefault()
+                .Name == "Quoted by";
         }
     }
 }

--- a/Modix.Services/Quote/QuoteService.cs
+++ b/Modix.Services/Quote/QuoteService.cs
@@ -1,41 +1,124 @@
 ﻿using System;
+using System.Linq;
 using Discord;
+using Humanizer.Bytes;
 using static System.FormattableString;
 
 namespace Modix.Services.Quote
 {
     public interface IQuoteService
     {
+        /// <summary>
+        /// Build an embed quote for the given message. Returns null if the message could not be quoted.
+        /// </summary>
+        /// <param name="message">The message to quote</param>
+        /// <param name="executingUser">The user that is doing the quoting</param>
         EmbedBuilder BuildQuoteEmbed(IMessage message, IUser executingUser);
     }
 
     public class QuoteService : IQuoteService
     {
+        /// <inheritdoc />
         public EmbedBuilder BuildQuoteEmbed(IMessage message, IUser executingUser)
         {
+            var embed = new EmbedBuilder();
+
+            if (TryAddRichEmbed(message, executingUser, ref embed))
+            {
+                return embed;
+            }
+
+            if (TryAddImageAttachment(message, executingUser, ref embed) == false)
+            {
+                TryAddOtherAttachment(message, executingUser, ref embed);
+            }
+
+            AddContent(message, executingUser, ref embed);
+            AddOtherEmbed(message, executingUser, ref embed);
+            AddActivity(message, executingUser, ref embed);
+            AddMeta(message, executingUser, ref embed);
+
+            return embed;
+        }
+
+        private bool TryAddImageAttachment(IMessage message, IUser executingUser, ref EmbedBuilder embed)
+        {
+            var firstAttachment = message.Attachments.FirstOrDefault();
+            if (firstAttachment == null || firstAttachment.Height == null) { return false; }
+
+            embed = embed
+                .WithImageUrl(firstAttachment.Url);
+
+            return true;
+        }
+
+        private bool TryAddOtherAttachment(IMessage message, IUser executingUser, ref EmbedBuilder embed)
+        {
+            var firstAttachment = message.Attachments.FirstOrDefault();
+            if (firstAttachment == null) { return false; }
+
+            embed = embed
+                .AddField($"Attachment (Size: {new ByteSize(firstAttachment.Size)})", firstAttachment.Url);
+
+            return true;
+        }
+
+        private bool TryAddRichEmbed(IMessage message, IUser executingUser, ref EmbedBuilder embed)
+        {
+            var firstEmbed = message.Embeds.FirstOrDefault();
+            if (firstEmbed?.Type != EmbedType.Rich) { return false; }
+
+            embed = message.Embeds
+                    .First()
+                    .ToEmbedBuilder()
+                    .AddField("Quoted by", executingUser.Mention, true);
+
+            if (firstEmbed.Color == null)
+            {
+                embed.Color = Color.DarkGrey;
+            }
+
+            return true;
+        }
+
+        private void AddActivity(IMessage message, IUser executingUser, ref EmbedBuilder embed)
+        {
+            if (message.Activity == null) { return; }
+
+            embed = embed
+                .AddField("Invite Type", message.Activity.Type)
+                .AddField("Party Id", message.Activity.PartyId);
+        }
+
+        private void AddOtherEmbed(IMessage message, IUser executingUser, ref EmbedBuilder embed)
+        {
+            if (!message.Embeds.Any()) { return; }
+
+            embed = embed
+                .AddField("Embed Type", message.Embeds.First().Type);
+        }
+
+        private void AddContent(IMessage message, IUser executingUser, ref EmbedBuilder embed)
+        {
+            if (string.IsNullOrWhiteSpace(message.Content)) { return; }
+
             string messageUrl = null;
             if (message.Channel is IGuildChannel guildChannel && guildChannel.Guild is IGuild guild)
             {
                 messageUrl = Invariant($"https://discordapp.com/channels/{guild.Id}/{guildChannel.Id}/{message.Id}");
             }
 
-            var embed = new EmbedBuilder()
-                .WithAuthor(x =>
-                {
-                    x = x.WithIconUrl(message.Author.GetAvatarUrl()).WithName(message.Author.Username);
-
-                    if (messageUrl != null)
-                    {
-                        x.WithUrl(messageUrl);
-                    }
-                })
+            embed = embed
                 .WithDescription(message.Content);
+        }
 
-            embed.AddField("Quoted by", executingUser.Mention, true);
-
-            embed.WithFooter(GetPostedMeta(message)).WithColor(new Color(95, 186, 125));
-
-            return embed;
+        private void AddMeta(IMessage message, IUser executingUser, ref EmbedBuilder embed)
+        {
+            embed = embed
+                .WithAuthor(message.Author)
+                .WithFooter(GetPostedMeta(message))
+                .WithColor(new Color(95, 186, 125))
+                .AddField("Quoted by", executingUser.Mention, true);
         }
 
         private static string GetPostedMeta(IMessage message)


### PR DESCRIPTION
Currently if someone quotes a message that consists of just an embed (ex. a Modix code eval), the quote embed we reply with is pretty redundant. When/if we render embeds within our quote, we can remove this check - but for now, this should reduce unnecessary replies.

![image](https://user-images.githubusercontent.com/1239222/50250436-c2dd8100-03ae-11e9-9a56-cfe8d9f92753.png)
