### PR TITLE
Improvements to restricted mentions

### DIFF
--- a/Modix.Bot/Modules/MentionModule.cs
+++ b/Modix.Bot/Modules/MentionModule.cs
@@ -22,20 +22,7 @@ namespace Modix.Bot.Modules
         public async Task MentionAsync(
             [Summary("The role that the user is attempting to mention.")]
                 IRole role)
-        {
-            MentionService.AuthorizeMention(role);
-
-            var mentionContinuation = await MentionService.EnsureMentionableAsync(role);
-
-            try
-            {
-                await Context.Channel.SendMessageAsync(MentionUtils.MentionRole(role.Id));
-            }
-            finally
-            {
-                await mentionContinuation();
-            }
-        }
+            => await MentionService.MentionRoleAsync(role, Context.Channel);
 
         [Command("mention")]
         [Alias("@")]

--- a/Modix.Data/Models/Core/DesignatedRoleType.cs
+++ b/Modix.Data/Models/Core/DesignatedRoleType.cs
@@ -16,6 +16,6 @@
         /// <summary>
         /// Defines a role whose mentionability is restricted in MODiX.
         /// </summary>
-        ResctrictedMentionability,
+        RestrictedMentionability,
     }
 }

--- a/Modix.Services/Core/DesignatedRoleService.cs
+++ b/Modix.Services/Core/DesignatedRoleService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Modix.Data.Models.Core;
 using Modix.Data.Repositories;
@@ -55,6 +56,14 @@ namespace Modix.Services.Core
         /// containing the requested role designations.
         /// </returns>
         Task<IReadOnlyCollection<DesignatedRoleMappingBrief>> SearchDesignatedRolesAsync(DesignatedRoleMappingSearchCriteria searchCriteria);
+
+        /// <summary>
+        /// Checks if the given role has the given designation
+        /// </summary>
+        /// <param name="guild">The Id of the guild where the role is located</param>
+        /// <param name="channel">The Id of the role to check the designation for</param>
+        /// <param name="designation">The <see cref="DesignatedRoleType"/> to check for</param>
+        Task<bool> RoleHasDesignationAsync(ulong guildId, ulong roleId, DesignatedRoleType designation);
     }
 
     public class DesignatedRoleService : IDesignatedRoleService
@@ -153,6 +162,17 @@ namespace Modix.Services.Core
         /// <inheritdoc />
         public Task<IReadOnlyCollection<DesignatedRoleMappingBrief>> SearchDesignatedRolesAsync(DesignatedRoleMappingSearchCriteria searchCriteria)
             => DesignatedRoleMappingRepository.SearchBriefsAsync(searchCriteria);
+
+        public async Task<bool> RoleHasDesignationAsync(ulong guildId, ulong roleId, DesignatedRoleType designation)
+        {
+            return (await SearchDesignatedRolesAsync(new DesignatedRoleMappingSearchCriteria
+            {
+                GuildId = guildId,
+                RoleId = roleId,
+                IsDeleted = false,
+                Type = designation
+            })).Any();
+        }
 
         /// <summary>
         /// A <see cref="IAuthorizationService"/> to be used to perform authorization.

--- a/Modix.Services/Mentions/MentionService.cs
+++ b/Modix.Services/Mentions/MentionService.cs
@@ -11,21 +11,11 @@ namespace Modix.Services.Mentions
     public interface IMentionService
     {
         /// <summary>
-        /// Determines whether the user can mention the supplied role.
+        /// Mentions the given role in the given channel
         /// </summary>
-        /// <param name="role">The role that the user is trying to mention.</param>
-        /// <exception cref="ArgumentNullException">Throws for <paramref name="role"/>.</exception>
-        void AuthorizeMention(IRole role);
-
-        /// <summary>
-        /// Ensures that the role can be mentioned.
-        /// </summary>
-        /// <param name="role">The role to be mentioned.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that will complete when the operation completes,
-        /// with a delegate that can be invoked to restore the role to its previous configuration.
-        /// </returns>
-        Task<Func<Task>> EnsureMentionableAsync(IRole role);
+        /// <param name="role">The role to mention</param>
+        /// <param name="channel">The channel to mention in</param>
+        Task MentionRoleAsync(IRole role, IMessageChannel channel);
     }
 
     /// <inheritdoc />
@@ -33,31 +23,56 @@ namespace Modix.Services.Mentions
     {
         public MentionService(
             IDiscordClient discordClient,
-            IAuthorizationService authorizationService)
+            IAuthorizationService authorizationService,
+            IDesignatedRoleService designatedRoleService)
         {
             DiscordClient = discordClient;
             AuthorizationService = authorizationService;
+            DesignatedRoleService = designatedRoleService;
+        }
+
+        private void AuthorizeMention(IRole role)
+        {
+            if (role is null)
+                throw new ArgumentNullException(nameof(role));
+
+            if (role.IsMentionable)
+                return;
+
+            AuthorizationService.RequireClaims(AuthorizationClaim.MentionRestrictedRole);
         }
 
         /// <inheritdoc />
-        public void AuthorizeMention(IRole role)
+        public async Task MentionRoleAsync(IRole role, IMessageChannel channel)
         {
-            AuthorizationService.RequireClaims(AuthorizationClaim.MentionRestrictedRole);
+            AuthorizeMention(role);
 
-            if (role is null)
-                throw new ArgumentNullException(nameof(role));
-        }
-
-        public async Task<Func<Task>> EnsureMentionableAsync(IRole role)
-        {
-            if (!role.IsMentionable)
+            if (role.IsMentionable)
             {
-                await role.ModifyAsync(x => x.Mentionable = true);
-
-                return async () => await role.ModifyAsync(x => x.Mentionable = false);
+                await channel.SendMessageAsync($"You can do that yourself - but fine: {role.Mention}");
+                return;
             }
 
-            return () => Task.CompletedTask;
+            if (await DesignatedRoleService.RoleHasDesignationAsync(role.Guild.Id, role.Id, DesignatedRoleType.RestrictedMentionability) == false)
+            {
+                await channel.SendMessageAsync($"Sorry, **{role.Name}** hasn't been designated as mentionable.");
+                return;
+            }
+
+            //Set the role to mentionable, immediately mention it, then set it
+            //to unmentionable again
+
+            await role.ModifyAsync(x => x.Mentionable = true);
+
+            //Make sure we set the role to unmentionable again no matter what
+            try
+            {
+                await channel.SendMessageAsync(role.Mention);
+            }
+            finally
+            {
+                await role.ModifyAsync(x => x.Mentionable = false);
+            }
         }
 
         /// <summary>
@@ -69,5 +84,10 @@ namespace Modix.Services.Mentions
         /// An <see cref="IAuthorizationService"/> to be used to interact with frontend authentication system, and perform authorization.
         /// </summary>
         internal protected IAuthorizationService AuthorizationService { get; }
+
+        /// <summary>
+        /// An <see cref="IDesignatedRoleService"/> to be used to check if a role is mentionable
+        /// </summary>
+        public IDesignatedRoleService DesignatedRoleService { get; }
     }
 }

--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -202,6 +202,48 @@ namespace Modix.Services.Moderation
             AuthorizationService.RequireAuthenticatedUser();
             AuthorizationService.RequireClaims(AuthorizationClaim.DesignatedRoleMappingCreate);
 
+            await SetUpMuteRole(guild);
+            await SetUpMentionableRoles(guild);
+        }
+
+        private async Task SetUpMentionableRoles(IGuild guild)
+        {
+            var mentionableRoleMappings = await DesignatedRoleMappingRepository.SearchBriefsAsync(new DesignatedRoleMappingSearchCriteria
+            {
+                GuildId = guild.Id,
+                Type = DesignatedRoleType.RestrictedMentionability,
+                IsDeleted = false
+            });
+
+            Log.Information("Roles with RestrictedMentionability are: {Roles}", mentionableRoleMappings.Select(d => d.Role.Name));
+
+            //Get the actual roles that correspond to our mappings
+            var mentionableRoles = mentionableRoleMappings
+                .Join(guild.Roles, d => d.Role.Id, d => d.Id, (map, role) => role)
+                .Where(d => d.IsMentionable);
+
+            try
+            {
+                //Ensure all roles with restricted mentionability are not mentionable
+                foreach (var role in mentionableRoles)
+                {
+                    Log.Information("Role @{Role} has RestrictedMentionability but was marked as Mentionable.", role.Name);
+                    await role.ModifyAsync(d => d.Mentionable = false);
+                    Log.Information("Role @{Role} was set to unmentionable.", role.Name);
+                }
+            }
+            catch (HttpException ex)
+            {
+                var errorTemplate = "An exception was thrown when attempting to set up mention-restricted roles for {Guild}. " +
+                    "This is likely due to Modix not having the \"Manage Roles\" permission, or Modix's role being below one of " +
+                    "the mention-restricted roles in your server's Role list - please check your server settings.";
+
+                Log.Error(ex, errorTemplate, guild.Name);
+            }
+        }
+
+        private async Task SetUpMuteRole(IGuild guild)
+        {
             var muteRole = await GetOrCreateDesignatedMuteRoleAsync(guild, AuthorizationService.CurrentUserId.Value);
 
             var nonCategoryChannels =


### PR DESCRIPTION
- Moved logic from MentionModule to MentionService
- Fixed typo of role type
- Added RoleHasDesignationAsync to DesignatedRoleService
- Refactored MentionService and IMentionService to include the message sending aspect & reduce API surface
- Added logic to ModerationService.cs for setup of mentionable roles - ensures designated roles are set to "Unmentionable" on startup