### PR TITLE
Upgrade to Discord.Net 2.0.1

### DIFF
--- a/Modix.Bot/Extensions/GuildChannelExtensions.cs
+++ b/Modix.Bot/Extensions/GuildChannelExtensions.cs
@@ -10,7 +10,7 @@ namespace Modix.Bot.Extensions
             {
                 var permissions = channel.GetPermissionOverwrite(guild.EveryoneRole);
 
-                return !permissions.HasValue || permissions.Value.ReadMessages != PermValue.Deny;
+                return !permissions.HasValue || permissions.Value.ViewChannel != PermValue.Deny;
             }
 
             return false;

--- a/Modix.Bot/Modix.Bot.csproj
+++ b/Modix.Bot/Modix.Bot.csproj
@@ -7,7 +7,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-01023" />
+    <PackageReference Include="Discord.Net" Version="2.0.1" />
     <PackageReference Include="Humanizer.Core" Version="2.4.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/Modix.Data/Modix.Data.csproj
+++ b/Modix.Data/Modix.Data.csproj
@@ -7,7 +7,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-01023" />
+    <PackageReference Include="Discord.Net" Version="2.0.1" />
     <PackageReference Include="MediatR" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.4" />

--- a/Modix.Services/Modix.Services.csproj
+++ b/Modix.Services/Modix.Services.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncEvent" Version="0.2.0" />
-    <PackageReference Include="Discord.Net" Version="2.0.0-beta2-01023" />
+    <PackageReference Include="Discord.Net" Version="2.0.1" />
     <PackageReference Include="Humanizer.Core" Version="2.4.2" />
     <PackageReference Include="Kitsu" Version="1.4.1" />
     <PackageReference Include="MediatR" Version="5.1.0" />

--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OAuth.Discord" Version="2.0.0" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="2.0.0-beta2-01023" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.1.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />


### PR DESCRIPTION
Nearly all of the required changes were taken care of when jmaz upgraded to the 2.0.0 preview release.

Closes #271.