### PR TITLE
Add improved type reader for users

### DIFF
--- a/Modix.Bot/Modules/InfractionModule.cs
+++ b/Modix.Bot/Modules/InfractionModule.cs
@@ -25,28 +25,19 @@ namespace Modix.Modules
 
         [Command("search")]
         [Summary("Display all infractions for a user, that haven't been deleted.")]
-        public async Task Search(
-            [Summary("The user whose infractions are to be displayed.")]
-                IGuildUser subject)
-        {
-            await Search(subject.Id);
-        }
-
-        [Command("search")]
-        [Summary("Display all infractions for a user, that haven't been deleted.")]
         [Priority(10)]
         public async Task Search(
             [Summary("The user whose infractions are to be displayed.")]
-            ulong subjectId)
+            IEntity<ulong> subjectEntity)
         {
             var requestor = Context.User.Mention;
-            var subject = await UserService.GetGuildUserSummaryAsync(Context.Guild.Id, subjectId);
+            var subject = await UserService.GetGuildUserSummaryAsync(Context.Guild.Id, subjectEntity.Id);
 
             var infractions = await ModerationService.SearchInfractionsAsync(
                 new InfractionSearchCriteria
                 {
                     GuildId = Context.Guild.Id,
-                    SubjectId = subjectId,
+                    SubjectId = subjectEntity.Id,
                     IsDeleted = false
                 },
                 new[]
@@ -71,7 +62,7 @@ namespace Modix.Modules
                 Rescinded = infraction.RescindAction != null
             }).OrderBy(s => s.Type);
 
-            var counts = await ModerationService.GetInfractionCountsForUserAsync(subjectId);
+            var counts = await ModerationService.GetInfractionCountsForUserAsync(subjectEntity.Id);
 
             var builder = new EmbedBuilder()
                 .WithTitle($"Infractions for user: {subject.Username}#{subject.Discriminator}")

--- a/Modix.Bot/Modules/ModerationModule.cs
+++ b/Modix.Bot/Modules/ModerationModule.cs
@@ -22,7 +22,7 @@ namespace Modix.Modules
         [Summary("Applies a note to a user's infraction history.")]
         public async Task Note(
             [Summary("The user to which the note is being applied.")]
-                IGuildUser subject,
+                IEntity<ulong> subject,
             [Summary("The reason for the note.")]
             [Remainder]
                 string reason)
@@ -35,7 +35,7 @@ namespace Modix.Modules
         [Summary("Issue a warning to a user.")]
         public async Task Warn(
             [Summary("The user to which the warning is being issued.")]
-                IGuildUser subject,
+                IEntity<ulong> subject,
             [Summary("The reason for the warning.")]
             [Remainder]
                 string reason)
@@ -48,7 +48,7 @@ namespace Modix.Modules
         [Summary("Mute a user.")]
         public async Task Mute(
             [Summary("The user to be muted.")]
-                IGuildUser subject,
+                IEntity<ulong> subject,
             [Summary("The reason for the mute.")]
             [Remainder]
                 string reason)
@@ -61,7 +61,7 @@ namespace Modix.Modules
         [Summary("Mute a user, for a temporary amount of time.")]
         public async Task TempMute(
             [Summary("The user to be muted.")]
-                IGuildUser subject,
+                IEntity<ulong> subject,
             [Summary("The duration of the mute.")]
                 TimeSpan duration,
             [Summary("The reason for the mute.")]
@@ -76,16 +76,18 @@ namespace Modix.Modules
         [Summary("Remove a mute that has been applied to a user.")]
         public async Task UnMute(
             [Summary("The user to be un-muted.")]
-                IGuildUser subject)
+                IEntity<ulong> subject)
         {
             await ModerationService.RescindInfractionAsync(InfractionType.Mute, subject.Id);
         }
 
+        //TODO: Make this less stupid
         [Command("ban")]
+        [Alias("forceban")]
         [Summary("Ban a user from the current guild.")]
         public async Task Ban(
             [Summary("The user to be banned.")]
-                IGuildUser subject,
+                IEntity<ulong> subject,
             [Summary("The reason for the ban.")]
             [Remainder]
                 string reason)
@@ -94,40 +96,13 @@ namespace Modix.Modules
             await Context.AddConfirmation();
         }
 
-        [Command("forceban")]
-        [Alias("ban")]
-        [Summary("Ban a user from the guild, even if they are not a member.")]
-        [Priority(10)]
-        public async Task Forceban(
-            [Summary("The id of the user to be banned.")]
-                ulong subjectId,
-            [Summary("The reason for the ban.")]
-            [Remainder]
-                string reason)
-        {
-            await ModerationService.CreateInfractionAsync(InfractionType.Ban, subjectId, reason, null);
-            await Context.AddConfirmation();
-        }
-
         [Command("unban")]
         [Summary("Remove a ban that has been applied to a user.")]
         public async Task UnBan(
             [Summary("The user to be un-banned.")]
-                IGuildUser subject)
+                IEntity<ulong> subject)
         {
             await ModerationService.RescindInfractionAsync(InfractionType.Ban, subject.Id);
-            await Context.AddConfirmation();
-        }
-
-        [Command("forceunban")]
-        [Alias("unban")]
-        [Summary("Remove a ban that has been applied to a user.")]
-        [Priority(10)]
-        public async Task ForceUnban(
-            [Summary("The id of the user to be un-banned.")]
-                ulong subjectId)
-        {
-            await ModerationService.RescindInfractionAsync(InfractionType.Ban, subjectId);
             await Context.AddConfirmation();
         }
 

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -41,15 +41,9 @@ namespace Modix.Modules
         private IMessageRepository MessageRepository { get; }
 
         [Command("info")]
-        public async Task GetUserInfo(IGuildUser user = null)
+        public async Task GetUserInfo(IEntity<ulong> subject)
         {
-            await GetUserInfoFromId(user?.Id ?? Context.User.Id);
-        }
-
-        [Command("info")]
-        public async Task GetUserInfoFromId(ulong userId)
-        {
-            var userSummary = await UserService.GetGuildUserSummaryAsync(Context.Guild.Id, userId);
+            var userSummary = await UserService.GetGuildUserSummaryAsync(Context.Guild.Id, subject.Id);
 
             if (userSummary == null)
             {
@@ -69,7 +63,7 @@ namespace Modix.Modules
 
             try
             {
-                await AddParticipationToEmbed(userId, builder);
+                await AddParticipationToEmbed(subject.Id, builder);
             }
             catch (Exception ex)
             {
@@ -81,9 +75,9 @@ namespace Modix.Modules
                 .WithColor(new Color(253, 95, 0))
                 .WithTimestamp(_utcNow);
 
-            if (await UserService.GuildUserExistsAsync(Context.Guild.Id, userId))
+            if (await UserService.GuildUserExistsAsync(Context.Guild.Id, subject.Id))
             {
-                var member = await UserService.GetGuildUserAsync(Context.Guild.Id, userId);
+                var member = await UserService.GetGuildUserAsync(Context.Guild.Id, subject.Id);
                 AddMemberInformationToEmbed(member, builder, embedBuilder);
             }
             else
@@ -94,7 +88,7 @@ namespace Modix.Modules
 
             if (await AuthorizationService.HasClaimsAsync(Context.User as IGuildUser, AuthorizationClaim.ModerationRead))
             {
-                await AddInfractionsToEmbed(userId, builder);
+                await AddInfractionsToEmbed(subject.Id, builder);
             }
 
             embedBuilder.Description = builder.ToString();

--- a/Modix.Bot/UserEntityTypeReader.cs
+++ b/Modix.Bot/UserEntityTypeReader.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+
+namespace Modix
+{
+    internal class UserEntity : IEntity<ulong>
+    {
+        public ulong Id { get; private set; }
+        public UserEntity(ulong id) { Id = id; }
+
+        public static UserEntity FromIUser(IUser user) => new UserEntity(user.Id);
+    }
+
+    public class UserEntityTypeReader : UserTypeReader<IGuildUser>
+    {
+        public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
+        {
+            var baseResult = await base.ReadAsync(context, input, services);
+
+            if (baseResult.IsSuccess)
+            {
+                return TypeReaderResult.FromSuccess(UserEntity.FromIUser(baseResult.BestMatch as IUser));
+            }
+
+            if (ulong.TryParse(input, out var uid))
+            {
+                //Any ulong is technically a valid snowflake, but we try to do some basic validation
+                //by parsing the timestamp (in ms) part out of it - if it's less than or equal to 0, it's
+                //before the Discord epoch of Jan 1, 2015, and thus invalid
+                var snowflakeTimestamp = (long)(uid >> 22);
+
+                if (snowflakeTimestamp <= 0)
+                {
+                    return TypeReaderResult.FromError(CommandError.ParseFailed, "Snowflake was almost certainly invalid.");
+                }
+
+                return TypeReaderResult.FromSuccess(new UserEntity(uid));
+            }
+
+            return TypeReaderResult.FromError(CommandError.ParseFailed, "Could not find user / parse user ID");
+        }
+    }
+}

--- a/Modix.Services/Moderation/EphemeralUser.cs
+++ b/Modix.Services/Moderation/EphemeralUser.cs
@@ -8,6 +8,8 @@ namespace Modix.Data.Models
 {
     public class EphemeralUser : IGuildUser
     {
+        private const string NotImplementedMessage = "This operation is invalid on untrackable users";
+
         public EphemeralUser(ulong userId, string name, IGuild guild)
         {
             Id = userId;
@@ -67,52 +69,52 @@ namespace Modix.Data.Models
 
         public Task AddRoleAsync(IRole role, RequestOptions options = null)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(NotImplementedMessage);
         }
 
         public Task AddRolesAsync(IEnumerable<IRole> roles, RequestOptions options = null)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(NotImplementedMessage);
         }
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(NotImplementedMessage);
         }
 
         public string GetDefaultAvatarUrl()
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(NotImplementedMessage);
         }
 
         public Task<IDMChannel> GetOrCreateDMChannelAsync(RequestOptions options = null)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(NotImplementedMessage);
         }
 
         public ChannelPermissions GetPermissions(IGuildChannel channel)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(NotImplementedMessage);
         }
 
         public Task KickAsync(string reason = null, RequestOptions options = null)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(NotImplementedMessage);
         }
 
         public Task ModifyAsync(Action<GuildUserProperties> func, RequestOptions options = null)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(NotImplementedMessage);
         }
 
         public Task RemoveRoleAsync(IRole role, RequestOptions options = null)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(NotImplementedMessage);
         }
 
         public Task RemoveRolesAsync(IEnumerable<IRole> roles, RequestOptions options = null)
         {
-            throw new NotImplementedException();
+            throw new NotImplementedException(NotImplementedMessage);
         }
     }
 }

--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -568,12 +568,21 @@ namespace Modix.Services.Moderation
         {
             var moderator = await UserService.GetGuildUserAsync(guildId, moderatorId);
 
+            //If the user doesn't exist in the guild, we outrank them
+            if (await UserService.GuildUserExistsAsync(guildId, subjectId) == false)
+                return true;
+
+            var subject = await UserService.GetGuildUserAsync(guildId, subjectId);
+
+            //If the subject is the guild owner, and we are not the owner, we do not outrank them
+            if (subject.Guild.OwnerId == subjectId && subject.Guild.OwnerId != moderatorId)
+                return false;
+
+            //If we have the "Admin" permission, we outrank everyone in the guild but the owner
             if (moderator.GuildPermissions.Administrator)
                 return true;
 
             var rankRoles = await GetRankRolesAsync(guildId);
-
-            var subject = await UserService.GetGuildUserAsync(guildId, subjectId);
 
             var subjectRankRoles = rankRoles.Where(r => subject.RoleIds.Contains(r.Id));
             var moderatorRankRoles = rankRoles.Where(r => moderator.RoleIds.Contains(r.Id));

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         });
 
                     service.AddTypeReader<IEmote>(new EmoteTypeReader());
+                    service.AddTypeReader<IEntity<ulong>>(new UserEntityTypeReader());
 
                     return service;
                 });


### PR DESCRIPTION
This adds a `UserEntityTypeReader` that allows command modules to depend on `IEntity<ulong>` instead of `IGuildUser`/similar. This type reader defers to the default user type reader (for names or mentions), but if a user isn't found, will try to validate / return the passed user id.

I've replaced the IGuildUser params in InfractionModule, ModerationModule, and UserInfoModule accordingly, and also added a more descriptive error to the unimplemented methods in `EphemeralUser` so it's more clear when certain invalid operations are performed (such as muting a user who isn't in the guild).

