### PR TITLE
Include Public Test Build links in MessageLinkBehavior regex

### DIFF
--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -13,7 +13,7 @@ namespace Modix.Services.Quote
     public class MessageLinkBehavior : BehaviorBase
     {
         private static readonly Regex Pattern = new Regex(
-            @"https?://(canary\.)?discordapp\.com/channels/(?<GuildId>\d+)/(?<ChannelId>\d+)/(?<MessageId>\d+)",
+            @"https?://(?:(?:ptb|canary)\.)?discordapp\.com/channels/(?<GuildId>\d+)/(?<ChannelId>\d+)/(?<MessageId>\d+)",
             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         public MessageLinkBehavior(DiscordSocketClient discordClient, IServiceProvider serviceProvider)


### PR DESCRIPTION
I'm the only person in the world that uses the public test build instead of stable or canary, and I noticed my message links weren't being picked up.