### PR TITLE
Add ban data to !info

### DIFF
--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -64,7 +64,7 @@ namespace Modix.Modules
 
             if (userInfo.IsBanned)
             {
-                builder.AppendLine("Status: Banned");
+                builder.AppendLine("Status: **Banned** \\🔨");
 
                 if (await AuthorizationService.HasClaimsAsync(Context.User as IGuildUser, AuthorizationClaim.ModerationRead))
                 {

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -95,6 +95,8 @@ namespace Modix.Modules
                 await AddInfractionsToEmbed(user.Id, builder);
             }
 
+            await AddBanInformationToEmbedAsync(userInfo, builder);
+
             embedBuilder.Description = builder.ToString();
 
             await ReplyAsync(string.Empty, embed: embedBuilder.Build());
@@ -191,6 +193,21 @@ namespace Modix.Modules
                     Log.LogDebug(ex, "Unable to get the most active channel for {UserId}.", userId);
                 }
             }
+        }
+
+        private async ValueTask AddBanInformationToEmbedAsync(EphemeralUser user, StringBuilder builder)
+        {
+            if (!user.IsBanned)
+                return;
+
+            builder.AppendLine();
+            builder.AppendLine("**\u276F Ban Information **");
+            builder.AppendLine("Status: Banned");
+
+            var hasModerationRead = await AuthorizationService.HasClaimsAsync(Context.User as IGuildUser, AuthorizationClaim.ModerationRead);
+
+            if (hasModerationRead)
+                builder.AppendLine($"Reason: {user.BanReason}");
         }
 
         private string FormatTimeAgo(string prefix, DateTimeOffset ago)

--- a/Modix.Data/Models/Core/EphemeralUser.cs
+++ b/Modix.Data/Models/Core/EphemeralUser.cs
@@ -65,6 +65,10 @@ namespace Modix.Data.Models.Core
 
         public DateTimeOffset? LastSeen { get; private set; }
 
+        public bool IsBanned { get; private set; }
+
+        public string BanReason { get; private set; }
+
         public async Task AddRoleAsync(IRole role, RequestOptions options = null)
         {
             await OnGuildUserOrThrowAsync(user => user.AddRoleAsync(role, options));
@@ -270,6 +274,18 @@ namespace Modix.Data.Models.Core
         {
             Guild = guild;
             GuildId = guild.Id;
+
+            return this;
+        }
+
+        public EphemeralUser WithBanData(IBan ban)
+        {
+            if (ban is null)
+                return this;
+
+            IsBanned = true;
+
+            BanReason = ban.Reason;
 
             return this;
         }

--- a/Modix.Services/Core/UserService.cs
+++ b/Modix.Services/Core/UserService.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Discord;
 using Discord.Rest;
 using Modix.Data.Models.Core;
 using Modix.Data.Repositories;
+using Modix.Services.Moderation;
 
 namespace Modix.Services.Core
 {
@@ -153,12 +155,15 @@ namespace Modix.Services.Core
             var restUser = await DiscordRestClient.GetUserAsync(userId);
             var guildUserSummary = await GetGuildUserSummaryAsync(guildId, userId);
 
+            var ban = (await guild.GetBansAsync()).FirstOrDefault(x => x.User.Id == userId);
+
             var buildUser = new EphemeralUser()
                 .WithGuildUserSummaryData(guildUserSummary)
                 .WithIUserData(restUser)
                 .WithIUserData(user)
                 .WithIGuildUserData(guildUser)
-                .WithGuildContext(guild);
+                .WithGuildContext(guild)
+                .WithBanData(ban);
 
             return buildUser.Id == 0 ? null : buildUser;
         }


### PR DESCRIPTION
Only shows the reason if the command user has the `ModerationRead` claim.

![image](https://user-images.githubusercontent.com/2829282/52889798-a01ddd80-314f-11e9-9528-5406f5942c38.png)


