### PR TITLE
Change the !info sidebar color based on the user's profile picture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ COPY . .
 RUN apt-get update && apt install curl -y
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install nodejs -y
+RUN apt-get install libgdiplus -y
+RUN apt-get install libc6-dev -y
+RUN ln -s /usr/lib/libgdiplus.so /usr/lib/gdiplus.dll
 
 RUN dotnet publish Modix.sln -c Release -r linux-x64 -o /app
 

--- a/Modix.Services/Modix.Services.csproj
+++ b/Modix.Services/Modix.Services.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncEvent" Version="0.2.0" />
@@ -12,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="System.Drawing.Common" Version="4.6.0-preview.19073.11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Modix.Data\Modix.Data.csproj" />


### PR DESCRIPTION
Also fixes the issue where default Discord profile pictures weren't showing up.

I tested in a Linux VM, so I *think* things won't blow up in prod if we merge this.

![image](https://user-images.githubusercontent.com/2829282/52916054-23067b80-32a9-11e9-9f7f-b14f22ab2859.png)
