### PR TITLE
Allow removal of !eval results by reacting with ❌

### DIFF
--- a/Modix.Services/Adapters/DiscordAdapter.cs
+++ b/Modix.Services/Adapters/DiscordAdapter.cs
@@ -1,26 +1,22 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Discord;
 using Discord.WebSocket;
-using MediatR;
-using Microsoft.Extensions.DependencyInjection;
-using Modix.Services.Core;
 using Modix.Services.Messages.Discord;
-using Serilog;
+using Modix.Services.NotificationDispatch;
 
 namespace Modix.Services.Adapters
 {
     public class DiscordAdapter : IBehavior
     {
         private readonly DiscordSocketClient _discordClient;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly INotificationDispatchService _notificationDispatchService;
 
         public DiscordAdapter(
             DiscordSocketClient discordClient,
-            IServiceProvider serviceProvider)
+            INotificationDispatchService notificationDispatchService)
         {
             _discordClient = discordClient;
-            _serviceProvider = serviceProvider;
+            _notificationDispatchService = notificationDispatchService;
         }
 
         public Task StartAsync()
@@ -35,48 +31,21 @@ namespace Modix.Services.Adapters
 
         private Task OnReactionRemoved(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel,
             SocketReaction reaction)
-            => PublishScoped(new ReactionRemoved { Channel = channel, Message = message, Reaction = reaction });
+            => _notificationDispatchService.PublishScopedAsync(new ReactionRemoved { Channel = channel, Message = message, Reaction = reaction });
 
         private Task OnReactionAdded(Cacheable<IUserMessage, ulong> message, ISocketMessageChannel channel,
             SocketReaction reaction)
-            => PublishScoped(new ReactionAdded { Channel = channel, Message = message, Reaction = reaction});
+            => _notificationDispatchService.PublishScopedAsync(new ReactionAdded { Channel = channel, Message = message, Reaction = reaction});
 
         private Task OnMessageUpdated(Cacheable<IMessage, ulong> oldMessage, SocketMessage newMessage,
             ISocketMessageChannel channel)
-            => PublishScoped(new ChatMessageUpdated {  OldMessage = oldMessage, NewMessage = newMessage, Channel = channel });
+            => _notificationDispatchService.PublishScopedAsync(new ChatMessageUpdated {  OldMessage = oldMessage, NewMessage = newMessage, Channel = channel });
 
         private Task OnMessageReceived(SocketMessage message)
-            => PublishScoped(new ChatMessageReceived { Message = message });
+            => _notificationDispatchService.PublishScopedAsync(new ChatMessageReceived { Message = message });
 
         private Task OnUserJoined(SocketGuildUser user)
-            => PublishScoped(new UserJoined { Guild = user.Guild, User = user });
-
-        private async Task PublishScoped(INotification message)
-        {
-            Log.Debug($"Beginning to publish a {message.GetType().Name} message");
-            
-            try
-            {
-                using (var scope = _serviceProvider.CreateScope())
-                {
-                    var provider = scope.ServiceProvider;
-    
-                    // setup context for handlers
-                    var botUser = provider.GetRequiredService<ISelfUser>();
-                    await provider.GetRequiredService<IAuthorizationService>()
-                        .OnAuthenticatedAsync(botUser);
-    
-                    var mediator = provider.GetRequiredService<IMediator>();
-                    await mediator.Publish(message);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "An exception was thrown in the Discord MediatR adapter.");
-            }
-
-            Log.Debug($"Finished invoking {message.GetType().Name} handlers");
-        }
+            => _notificationDispatchService.PublishScopedAsync(new UserJoined { Guild = user.Guild, User = user });
 
         public Task StopAsync()
         {

--- a/Modix.Services/AutoRemoveMessage/AutoRemoveMessageHandler.cs
+++ b/Modix.Services/AutoRemoveMessage/AutoRemoveMessageHandler.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Caching.Memory;
+using Modix.Services.Messages.Discord;
+using Modix.Services.Messages.Modix;
+
+namespace Modix.Services.AutoRemoveMessage
+{
+    public class AutoRemoveMessageHandler :
+        INotificationHandler<RemovableMessageSent>,
+        INotificationHandler<ReactionAdded>,
+        INotificationHandler<RemovableMessageRemoved>
+    {
+        public AutoRemoveMessageHandler(
+            IMemoryCache cache,
+            IAutoRemoveMessageService autoRemoveMessageService)
+        {
+            Cache = cache;
+            AutoRemoveMessageService = autoRemoveMessageService;
+        }
+
+        public Task Handle(RemovableMessageSent notification, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return Task.CompletedTask;
+
+            Cache.Set(
+                GetKey(notification.Message.Id),
+                new RemovableMessage()
+                {
+                    Message = notification.Message,
+                    User = notification.User,
+                },
+                _messageCacheOptions);
+
+            return Task.CompletedTask;
+        }
+
+        public async Task Handle(ReactionAdded notification, CancellationToken cancellationToken)
+        {
+            var key = GetKey(notification.Message.Id);
+
+            if (cancellationToken.IsCancellationRequested
+                || notification.Reaction.Emote.Name != "❌"
+                || !Cache.TryGetValue(key, out RemovableMessage cachedMessage)
+                || notification.Reaction.UserId != cachedMessage.User.Id)
+            {
+                return;
+            }
+
+            await cachedMessage.Message.DeleteAsync();
+
+            await AutoRemoveMessageService.UnregisterRemovableMessageAsync(cachedMessage.Message);
+        }
+
+        public Task Handle(RemovableMessageRemoved notification, CancellationToken cancellationToken)
+        {
+            var key = GetKey(notification.Message.Id);
+
+            if (cancellationToken.IsCancellationRequested
+                || !Cache.TryGetValue(key, out _))
+            {
+                return Task.CompletedTask;
+            }
+
+            Cache.Remove(key);
+
+            return Task.CompletedTask;
+        }
+
+        protected IMemoryCache Cache { get; }
+
+        protected IAutoRemoveMessageService AutoRemoveMessageService { get; }
+
+        private static object GetKey(ulong messageId)
+            => new
+            {
+                MessageId = messageId,
+                Target = "RemovableMessage",
+            };
+
+        private static readonly MemoryCacheEntryOptions _messageCacheOptions =
+            new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromMinutes(60));
+    }
+}

--- a/Modix.Services/AutoRemoveMessage/AutoRemoveMessageService.cs
+++ b/Modix.Services/AutoRemoveMessage/AutoRemoveMessageService.cs
@@ -1,0 +1,58 @@
+﻿using System.Threading.Tasks;
+using Discord;
+using Modix.Services.Messages.Modix;
+using Modix.Services.NotificationDispatch;
+
+namespace Modix.Services.AutoRemoveMessage
+{
+    /// <summary>
+    /// Defines a service used to track removable messages.
+    /// </summary>
+    public interface IAutoRemoveMessageService
+    {
+        /// <summary>
+        /// Registers a removable message with the service.
+        /// </summary>
+        /// <param name="message">The removable message.</param>
+        /// <param name="user">The user who can remove the message.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that will complete when the operation completes.
+        /// </returns>
+        Task RegisterRemovableMessageAsync(IMessage message, IUser user);
+
+        /// <summary>
+        /// Unregisters a removable message from the service.
+        /// </summary>
+        /// <param name="message">The removable message.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that will complete when the operation completes.
+        /// </returns>
+        Task UnregisterRemovableMessageAsync(IMessage message);
+    }
+
+    /// <inheritdoc />
+    internal class AutoRemoveMessageService : IAutoRemoveMessageService
+    {
+        public AutoRemoveMessageService(INotificationDispatchService notificationDispatchService)
+        {
+            NotificationDispatchService = notificationDispatchService;
+        }
+
+        /// <inheritdoc />
+        public async Task RegisterRemovableMessageAsync(IMessage message, IUser user)
+            => await NotificationDispatchService.PublishScopedAsync(new RemovableMessageSent()
+            {
+                Message = message,
+                User = user,
+            });
+
+        /// <inheritdoc />
+        public async Task UnregisterRemovableMessageAsync(IMessage message)
+            => await NotificationDispatchService.PublishScopedAsync(new RemovableMessageRemoved()
+            {
+                Message = message,
+            });
+
+        protected INotificationDispatchService NotificationDispatchService { get; }
+    }
+}

--- a/Modix.Services/AutoRemoveMessage/AutoRemoveMessageSetup.cs
+++ b/Modix.Services/AutoRemoveMessage/AutoRemoveMessageSetup.cs
@@ -1,0 +1,25 @@
+﻿using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Modix.Services.Messages.Discord;
+using Modix.Services.Messages.Modix;
+
+namespace Modix.Services.AutoRemoveMessage
+{
+    /// <summary>
+    /// Contains extension methods for configuring the auto remove message feature upon application startup.
+    /// </summary>
+    public static class AutoRemoveMessageSetup
+    {
+        /// <summary>
+        /// Adds the services and classes that make up the auto remove message service to a service collection.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to which the auto remove message services are to be added.</param>
+        /// <returns><paramref name="services"/></returns>
+        public static IServiceCollection AddAutoRemoveMessage(this IServiceCollection services)
+            => services
+                .AddScoped<IAutoRemoveMessageService, AutoRemoveMessageService>()
+                .AddScoped<INotificationHandler<RemovableMessageSent>, AutoRemoveMessageHandler>()
+                .AddScoped<INotificationHandler<ReactionAdded>, AutoRemoveMessageHandler>()
+                .AddScoped<INotificationHandler<RemovableMessageRemoved>, AutoRemoveMessageHandler>();
+    }
+}

--- a/Modix.Services/AutoRemoveMessage/RemovableMessage.cs
+++ b/Modix.Services/AutoRemoveMessage/RemovableMessage.cs
@@ -1,0 +1,11 @@
+﻿using Discord;
+
+namespace Modix.Services.AutoRemoveMessage
+{
+    public class RemovableMessage
+    {
+        public IMessage Message { get; set; }
+
+        public IUser User { get; set; }
+    }
+}

--- a/Modix.Services/Messages/Modix/RemovableMessageRemoved.cs
+++ b/Modix.Services/Messages/Modix/RemovableMessageRemoved.cs
@@ -1,0 +1,10 @@
+﻿using Discord;
+using MediatR;
+
+namespace Modix.Services.Messages.Modix
+{
+    public class RemovableMessageRemoved : INotification
+    {
+        public IMessage Message { get; set; }
+    }
+}

--- a/Modix.Services/Messages/Modix/RemovableMessageSent.cs
+++ b/Modix.Services/Messages/Modix/RemovableMessageSent.cs
@@ -1,0 +1,12 @@
+﻿using Discord;
+using MediatR;
+
+namespace Modix.Services.Messages.Modix
+{
+    public class RemovableMessageSent : INotification
+    {
+        public IMessage Message { get; set; }
+
+        public IUser User { get; set; }
+    }
+}

--- a/Modix.Services/NotificationDispatch/NotificationDispatchService.cs
+++ b/Modix.Services/NotificationDispatch/NotificationDispatchService.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Threading.Tasks;
+using Discord;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Modix.Services.Core;
+using Serilog;
+
+namespace Modix.Services.NotificationDispatch
+{
+    /// <summary>
+    /// Defines a service to manage notification dispatch.
+    /// </summary>
+    public interface INotificationDispatchService
+    {
+        /// <summary>
+        /// Publishes the supplied notification within a scope.
+        /// </summary>
+        /// <param name="notification">The notification to be published.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that will complete when the operation completes.
+        /// </returns>
+        Task PublishScopedAsync(INotification notification);
+    }
+
+    /// <inheritdoc />
+    internal class NotificationDispatchService : INotificationDispatchService
+    {
+        public NotificationDispatchService(IServiceProvider serviceProvider)
+        {
+            ServiceProvider = serviceProvider;
+        }
+
+        /// <inheritdoc />
+        public async Task PublishScopedAsync(INotification notification)
+        {
+            Log.Debug($"Beginning to publish a {notification.GetType().Name} message");
+
+            try
+            {
+                using (var scope = ServiceProvider.CreateScope())
+                {
+                    var provider = scope.ServiceProvider;
+
+                    // setup context for handlers
+                    var botUser = provider.GetRequiredService<ISelfUser>();
+                    await provider.GetRequiredService<IAuthorizationService>()
+                        .OnAuthenticatedAsync(botUser);
+
+                    var mediator = provider.GetRequiredService<IMediator>();
+                    await mediator.Publish(notification);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An exception was thrown in the Discord MediatR adapter.");
+            }
+
+            Log.Debug($"Finished invoking {notification.GetType().Name} handlers");
+        }
+
+        protected IServiceProvider ServiceProvider { get; }
+    }
+}

--- a/Modix.Services/NotificationDispatch/NotificationDispatchSetup.cs
+++ b/Modix.Services/NotificationDispatch/NotificationDispatchSetup.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Modix.Services.NotificationDispatch
+{
+    /// <summary>
+    /// Contains extension methods for configuring the nodification dispatch feature upon application startup.
+    /// </summary>
+    public static class NotificationDispatchSetup
+    {
+        /// <summary>
+        /// Adds the services and classes that make up the notification dispatch service to a service collection.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to which the notification dispatch services are to be added.</param>
+        /// <returns><paramref name="services"/></returns>
+        public static IServiceCollection AddNotificationDispatch(this IServiceCollection services)
+            => services
+                .AddSingleton<INotificationDispatchService, NotificationDispatchService>();
+    }
+}

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Modix.Data.Repositories;
 using Modix.Services;
 using Modix.Services.Adapters;
 using Modix.Services.AutoCodePaste;
+using Modix.Services.AutoRemoveMessage;
 using Modix.Services.BehaviourConfiguration;
 using Modix.Services.CodePaste;
 using Modix.Services.CommandHelp;
@@ -20,6 +21,7 @@ using Modix.Services.DocsMaster;
 using Modix.Services.GuildStats;
 using Modix.Services.Mentions;
 using Modix.Services.Moderation;
+using Modix.Services.NotificationDispatch;
 using Modix.Services.PopularityContest;
 using Modix.Services.Promotions;
 using Modix.Services.Quote;
@@ -75,7 +77,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddCommandHelp()
                 .AddGuildStats()
                 .AddMentions()
-                .AddModixTags();
+                .AddModixTags()
+                .AddNotificationDispatch()
+                .AddAutoRemoveMessage();
 
             services.AddSingleton<IBehavior, DiscordAdapter>();
             services.AddScoped<IQuoteService, QuoteService>();


### PR DESCRIPTION
Closes #299.

Emote is ❌ (`:x:`).

Only works if the user who invoked `!eval` adds the reaction.


Works by using a cache of "removable" messages, which are registered by the module (currently only the `ReplModule`). Messages in the cache expire after 60 minutes.

Additionally adds a `NotificationDispatchService` to abstract out the `PublishScoped()` method into a common location.