### PR TITLE
UserInfo embed should include how a user's activity compares to others

### DIFF
--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -213,9 +213,9 @@ namespace Modix.Modules
             if (monthTotal > 0)
             {
                 builder.AppendFormat(
-                    "Avg. per day: {0} messages (p{1})\n",
+                    "Avg. per day: {0} messages (top {1} percentile)\n",
                     decimal.Round(userRank.AveragePerDay, 3),
-                    userRank.Percentile);
+                    userRank.Percentile.Ordinalize());
 
                 try
                 {

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Dapper;
 using Discord;
 using Discord.Commands;
 using Humanizer;

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -49,6 +50,8 @@ namespace Modix.Modules
         public async Task GetUserInfoAsync(DiscordUserEntity user = null)
         {
             user = user ?? new DiscordUserEntity(Context.User.Id);
+
+            var timer = Stopwatch.StartNew();
 
             var userInfo = await UserService.GetUserInformationAsync(Context.Guild.Id, user.Id);
 
@@ -115,6 +118,9 @@ namespace Modix.Modules
             }
 
             embedBuilder.Description = builder.ToString();
+
+            timer.Stop();
+            embedBuilder.WithFooter(footer => footer.Text = $"Completed after {timer.ElapsedMilliseconds} ms");
 
             await ReplyAsync(string.Empty, embed: embedBuilder.Build());
         }

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -204,7 +204,7 @@ namespace Modix.Modules
 
             if (userRank?.Rank > 0)
             {
-                builder.AppendFormat("Rank: {0} {1}\n", userRank.Rank.Ordinalize(), userRank.GetParticipationEmoji());
+                builder.AppendFormat("Rank: {0} {1}\n", userRank.Rank.Ordinalize(), GetParticipationEmoji(userRank));
             }
 
             builder.AppendLine("Last 7 days: " + weekTotal + " messages");
@@ -248,6 +248,28 @@ namespace Modix.Modules
                 : "a few seconds";
 
             return string.Format(CultureInfo.InvariantCulture, Format, prefix, humanizedTimeAgo, ago.UtcDateTime);
+        }
+
+        private string GetParticipationEmoji(GuildUserParticipationStatistics stats)
+        {
+            if (stats.Percentile == 100 || stats.Rank == 1)
+            {
+                return "🥇";
+            }
+            else if (stats.Percentile == 99 || stats.Rank == 2)
+            {
+                return "🥈";
+            }
+            else if (stats.Percentile == 98 || stats.Rank == 3)
+            {
+                return "🥉";
+            }
+            else if (stats.Percentile > 95 && stats.Percentile < 98)
+            {
+                return "🏆";
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/Modix.Data/Models/Core/GuildUserParticipationStatistics.cs
+++ b/Modix.Data/Models/Core/GuildUserParticipationStatistics.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Modix.Data.Models.Core
+{
+    public class GuildUserParticipationStatistics
+    {
+        public ulong GuildId { get; set; }
+
+        public ulong UserId { get; set; }
+
+        public int Rank { get; set; }
+
+        public decimal AveragePerDay { get; set; }
+
+        public int Percentile { get; set; }
+
+        public string GetParticipationEmoji()
+        {
+            if (Percentile == 100 || Rank == 1)
+            {
+                return "🥇";
+            }
+            else if (Percentile == 99 || Rank == 2)
+            {
+                return "🥈";
+            }
+            else if (Percentile == 98 || Rank == 3)
+            {
+                return "🥉";
+            }
+            else if (Percentile > 95 && Percentile < 98)
+            {
+                return "🏆";
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/Modix.Data/Models/Core/GuildUserParticipationStatistics.cs
+++ b/Modix.Data/Models/Core/GuildUserParticipationStatistics.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Modix.Data.Models.Core
+﻿namespace Modix.Data.Models.Core
 {
     public class GuildUserParticipationStatistics
     {
@@ -15,27 +11,5 @@ namespace Modix.Data.Models.Core
         public decimal AveragePerDay { get; set; }
 
         public int Percentile { get; set; }
-
-        public string GetParticipationEmoji()
-        {
-            if (Percentile == 100 || Rank == 1)
-            {
-                return "🥇";
-            }
-            else if (Percentile == 99 || Rank == 2)
-            {
-                return "🥈";
-            }
-            else if (Percentile == 98 || Rank == 3)
-            {
-                return "🥉";
-            }
-            else if (Percentile > 95 && Percentile < 98)
-            {
-                return "🏆";
-            }
-
-            return string.Empty;
-        }
     }
 }

--- a/Modix.Data/Modix.Data.csproj
+++ b/Modix.Data/Modix.Data.csproj
@@ -7,6 +7,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Dapper" Version="1.50.7" />
     <PackageReference Include="Discord.Net" Version="2.0.1" />
     <PackageReference Include="MediatR" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.4" />

--- a/Modix.Data/Modix.Data.csproj
+++ b/Modix.Data/Modix.Data.csproj
@@ -7,7 +7,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.7" />
     <PackageReference Include="Discord.Net" Version="2.0.1" />
     <PackageReference Include="MediatR" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.4" />

--- a/Modix.Data/ModixContext.cs
+++ b/Modix.Data/ModixContext.cs
@@ -71,6 +71,8 @@ namespace Modix.Data
 
             foreach(var method in onModelCreatingMethods)
                 method.Invoke(null, new [] { modelBuilder });
+
+            modelBuilder.Query<GuildUserParticipationStatistics>();
         }
     }
 }

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Dapper;
 using Microsoft.EntityFrameworkCore;
 using Modix.Data.Models.Core;
 
@@ -14,6 +15,8 @@ namespace Modix.Data.Repositories
         Task<IReadOnlyDictionary<ulong, int>> GetGuildUserMessageCountByChannel(ulong guildId, ulong userId, TimeSpan timespan);
 
         Task<IReadOnlyDictionary<GuildUserEntity, int>> GetPerUserMessageCounts(ulong guildId, TimeSpan timespan, int userCount = 10);
+
+        Task<GuildUserParticipationStatistics> GetGuildUserParticipationStatistics(ulong guildId, ulong userId);
 
         Task CreateAsync(MessageEntity message);
 
@@ -84,6 +87,49 @@ namespace Modix.Data.Repositories
                 .ToDictionaryAsync(x => x.UserId, x => x);
 
             return result.ToDictionary(x => userQuery[x.Key], x => x.Count());
+        }
+
+        public async Task<GuildUserParticipationStatistics> GetGuildUserParticipationStatistics(ulong guildId, ulong userId)
+        {
+            var stats = await ModixContext.Database.GetDbConnection()
+                .QueryFirstOrDefaultAsync<GuildUserParticipationStatistics>(
+                    @"with msgs as (
+                        select ""AuthorId"", ""Id"" as ""MessageId""
+                        from ""Messages""
+                        where ""GuildId"" = cast(:GuildId as numeric(20))
+                        and ""Timestamp"" >= (current_date - interval '30 day')
+                    ),
+                    user_count as (
+                        select ""AuthorId"", count(1) as ""MessageCount""
+                        from msgs
+                        group by ""AuthorId""
+                    ),
+                    user_avg as (
+                        select ""AuthorId"", ""MessageCount"", (cast(""MessageCount"" as decimal) / cast(30 as decimal)) as ""AveragePerDay""
+                        from user_count
+                        group by ""AuthorId"", ""MessageCount""
+                    ),
+                    ntiles as (
+                        select ""AuthorId"", ntile(100) over (order by ""AveragePerDay"") as ""Percentile""
+                        from user_avg
+                        group by ""AuthorId"", ""AveragePerDay""
+                    ),
+                    ranked_users as (
+	                    select user_avg.""AuthorId"" as ""UserId"", ""AveragePerDay"", ""Percentile"", dense_rank() over (order by ""AveragePerDay"" desc) as ""Rank""
+	                    from user_avg
+	                    inner join ntiles on user_avg.""AuthorId"" = ntiles.""AuthorId""
+                    )
+                    select ""AveragePerDay"", ""Percentile"", ""Rank""
+                    from ranked_users
+                    where ""UserId"" = cast(:UserId as numeric(20))
+                    order by ""AveragePerDay"" desc",
+                    new { GuildId = guildId.ToString(), UserId = userId.ToString() }).ConfigureAwait(false)
+                    ?? new GuildUserParticipationStatistics();
+
+            stats.GuildId = guildId;
+            stats.UserId = userId;
+
+            return stats;
         }
 
         private IQueryable<MessageEntity> GetGuildUserMessages(ulong guildId, ulong userId, TimeSpan timespan)


### PR DESCRIPTION
Adds information about how the user's activity compares to other users on the server, based on the average number of messages the user has sent per day over the past 30 days. A medal or trophy will be displayed next to their rank for users who are in or above the 95th percentile. 

<img width="174" alt="capture" src="https://user-images.githubusercontent.com/423549/53305810-fe377880-3853-11e9-8cc2-5a2919ae0bad.PNG">
