### PR TITLE
Add starboard functionality

### DIFF
--- a/Modix.Services/Starboard/StarboardHandler.cs
+++ b/Modix.Services/Starboard/StarboardHandler.cs
@@ -17,9 +17,11 @@ namespace Modix.Services.Starboard
         private readonly StarboardService _service;
         private readonly IDesignatedChannelService _designatedChannelService;
         private readonly IQuoteService _quoteService;
-        private const string _contentString = "**{0}** {1}";
 
-        public StarboardHandler(StarboardService service, IDesignatedChannelService designatedChannelService, IQuoteService quoteService)
+        public StarboardHandler(
+            StarboardService service,
+            IDesignatedChannelService designatedChannelService,
+            IQuoteService quoteService)
         {
             _service = service;
             _designatedChannelService = designatedChannelService;
@@ -32,7 +34,7 @@ namespace Modix.Services.Starboard
         public Task Handle(ReactionRemoved notification, CancellationToken cancellationToken)
             => HandleReaction(notification.Message, notification.Reaction);
 
-        private async Task HandleReaction(Cacheable<IUserMessage, ulong> cachedMessage, SocketReaction reaction)
+        private async Task HandleReaction(Cacheable<IUserMessage, ulong> cachedMessage, IReaction reaction)
         {
             var emote = reaction.Emote;
             if (!_service.IsStarEmote(emote))
@@ -59,8 +61,8 @@ namespace Modix.Services.Starboard
                 }
                 else
                 {
-                    await starboardMessage.ModifyAsync((messageProperties)
-                        => messageProperties.Content = FormatContent(message, emote));
+                    await starboardMessage.ModifyAsync(messageProps
+                        => messageProps.Content = FormatContent(message, emote));
                 }
             }
             else
@@ -80,7 +82,7 @@ namespace Modix.Services.Starboard
         private string FormatContent(IUserMessage message, IEmote emote)
         {
             var reactionCount = _service.GetReactionCount(message, emote);
-            return string.Format(_contentString, reactionCount, _service.GetStarEmote(reactionCount), message.Id);
+            return $"**{reactionCount}** {_service.GetStarEmote(reactionCount)}";
         }
         
         private Embed GetStarEmbed(IUserMessage message)

--- a/Modix.Services/Starboard/StarboardService.cs
+++ b/Modix.Services/Starboard/StarboardService.cs
@@ -15,7 +15,7 @@ namespace Modix.Services.Starboard
         /// <summary>
         /// Fetches a message from the specified guilds starboard.
         /// </summary>
-        /// <param name="channel">Which guilds starboard to fetch from</param>
+        /// <param name="channel">Which guild's starboard to fetch from</param>
         /// <param name="message">The message to fetch</param>
         /// <returns>
         /// A <see cref="Task"/> that will complete when the operation has completed,
@@ -122,8 +122,8 @@ namespace Modix.Services.Starboard
 
         public string GetStarEmote(int reactionCount)
         {
-            var valIdx = _emojis.Keys.First((val) => reactionCount >= val);
-            return _emojis[valIdx];
+            var emoteIndex = _emojis.Keys.First((val) => reactionCount >= val);
+            return _emojis[emoteIndex];
         }
     }
 }

--- a/Modix.Services/Starboard/StarboardService.cs
+++ b/Modix.Services/Starboard/StarboardService.cs
@@ -118,7 +118,7 @@ namespace Modix.Services.Starboard
 
         /// <inheritdoc />
         public bool IsAboveReactionThreshold(IUserMessage message, IEmote emote)
-            => GetReactionCount(message, emote) >= 1;
+            => GetReactionCount(message, emote) >= 2;
 
         public string GetStarEmote(int reactionCount)
         {

--- a/Modix/ClientApp/src/models/moderation/ChannelDesignation.ts
+++ b/Modix/ClientApp/src/models/moderation/ChannelDesignation.ts
@@ -4,5 +4,6 @@ export enum ChannelDesignation
     MessageLog = "MessageLog",
     PromotionLog = "PromotionLog",
     PromotionNotifications = "PromotionNotifications",
-    Unmoderated = "Unmoderated"
+    Unmoderated = "Unmoderated",
+    Starboard = "Starboard"
 }


### PR DESCRIPTION
### Continuation of #305 

* Now uses a dictionary for the star-emotes with its associated values.
* Added hyperlink to the original message.
* Ignoring `Unmoderated` channels as to not leak stars to the public.
* Added interface for the service.
* Making use of `IQuoteService` to better handle starred messages that are embedded.
* Added `ChannelDesignation` type to the webinterface