### PR TITLE
Use HttpClientFactory in place of HttpClient

### DIFF
--- a/Modix.Bot/Modix.Bot.csproj
+++ b/Modix.Bot/Modix.Bot.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Discord.Net" Version="2.0.1" />
     <PackageReference Include="Humanizer.Core" Version="2.4.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />

--- a/Modix.Bot/Modules/DocumentationModule.cs
+++ b/Modix.Bot/Modules/DocumentationModule.cs
@@ -9,10 +9,15 @@ namespace Modix.Modules
     [Name("Documentation"), Summary("Search for information within the .NET docs")]
     public class DocumentationModule : ModuleBase
     {
+        public DocumentationModule(DocumentationService documentationService)
+        {
+            DocumentationService = documentationService;
+        }
+
         [Command("docs"), Summary("Shows class/method reference from the new unified .NET reference")]
         public async Task GetDocumentationAsync([Remainder]string term)
         {
-            var response = await new DocumentationService().GetDocumentationResultsAsync(term);
+            var response = await DocumentationService.GetDocumentationResultsAsync(term);
 
             if (response.Count == 0)
             {
@@ -43,5 +48,7 @@ namespace Modix.Modules
                 await ReplyAsync("", embed: builder.Build());
             }
         }
+
+        protected DocumentationService DocumentationService { get; }
     }
 }

--- a/Modix.Bot/Modules/FunModule.cs
+++ b/Modix.Bot/Modules/FunModule.cs
@@ -10,6 +10,11 @@ namespace Modix.Modules
     [Name("Fun"), Summary("A bunch of miscellaneous, fun commands")]
     public class FunModule : ModuleBase
     {
+        public FunModule(IHttpClientFactory httpClientFactory)
+        {
+            HttpClientFactory = httpClientFactory;
+        }
+
         [Command("jumbo"), Summary("Jumbofy an emoji")]
         public async Task Jumbo(string emoji)
         {
@@ -29,7 +34,7 @@ namespace Modix.Modules
 
             try
             {
-                var client = new HttpClient();
+                var client = HttpClientFactory.CreateClient();
                 var req = await client.GetStreamAsync(emojiUrl);
 
                 await Context.Channel.SendFileAsync(req, Path.GetFileName(emojiUrl), Context.User.Mention);
@@ -48,5 +53,7 @@ namespace Modix.Modules
                 await ReplyAsync($"Sorry {Context.User.Mention}, I don't recognize that emoji.");
             }
         }
+
+        protected IHttpClientFactory HttpClientFactory { get; }
     }
 }

--- a/Modix.Bot/Modules/IlModule.cs
+++ b/Modix.Bot/Modules/IlModule.cs
@@ -57,8 +57,11 @@ namespace Modix.Modules
             try
             {
                 var client = _httpClientFactory.CreateClient("ReplClient");
-                var tokenSrc = new CancellationTokenSource(30000);
-                res = await client.PostAsync(ReplRemoteUrl, content, tokenSrc.Token);
+
+                using (var tokenSrc = new CancellationTokenSource(30000))
+                {
+                    res = await client.PostAsync(ReplRemoteUrl, content, tokenSrc.Token);
+                }
             }
             catch (TaskCanceledException)
             {

--- a/Modix.Bot/Modules/IlModule.cs
+++ b/Modix.Bot/Modules/IlModule.cs
@@ -1,17 +1,15 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
-using Modix.Data.Models.Core;
-using System.Threading;
 using Discord.WebSocket;
-using Serilog;
 using Modix.Services.AutoCodePaste;
-using Modix.Services.Utilities;
 using Modix.Services.AutoRemoveMessage;
+using Modix.Services.Utilities;
+using Serilog;
 
 namespace Modix.Modules
 {
@@ -23,16 +21,16 @@ namespace Modix.Modules
 
         private readonly IAutoRemoveMessageService _autoRemoveMessageService;
 
-        private static readonly HttpClient _client = new HttpClient();
+        private readonly IHttpClientFactory _httpClientFactory;
 
         public IlModule(
-            ModixConfig config,
             CodePasteService pasteService,
-            IAutoRemoveMessageService autoRemoveMessageService)
+            IAutoRemoveMessageService autoRemoveMessageService,
+            IHttpClientFactory httpClientFactory)
         {
             _pasteService = pasteService;
             _autoRemoveMessageService = autoRemoveMessageService;
-            _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", config.ReplToken);
+            _httpClientFactory = httpClientFactory;
         }
 
         [Command("il", RunMode = RunMode.Sync), Summary("Compile & return the resulting IL of C# code")]
@@ -58,8 +56,9 @@ namespace Modix.Modules
             HttpResponseMessage res;
             try
             {
+                var client = _httpClientFactory.CreateClient("ReplClient");
                 var tokenSrc = new CancellationTokenSource(30000);
-                res = await _client.PostAsync(ReplRemoteUrl, content, tokenSrc.Token);
+                res = await client.PostAsync(ReplRemoteUrl, content, tokenSrc.Token);
             }
             catch (TaskCanceledException)
             {

--- a/Modix.Bot/Modules/StackExchangeModule.cs
+++ b/Modix.Bot/Modules/StackExchangeModule.cs
@@ -14,9 +14,12 @@ namespace Modix.Modules
     {
         private readonly ModixConfig _config;
 
-        public StackExchangeModule(ModixConfig config)
+        public StackExchangeModule(
+            ModixConfig config,
+            StackExchangeService stackExchangeService)
         {
             _config = config;
+            StackExchangeService = stackExchangeService;
         }
 
         [Command("stack"), Summary("Returns top results from a Stack Exchange site."), Remarks("Usage: `!stack how do i parse json with c#? [site=stackoverflow tags=c#,json]`")]
@@ -58,7 +61,7 @@ namespace Modix.Modules
                 tags = "c#";
             }
 
-            var response = await new StackExchangeService().GetStackExchangeResultsAsync(_config.StackoverflowToken, phrase, site, tags);
+            var response = await StackExchangeService.GetStackExchangeResultsAsync(_config.StackoverflowToken, phrase, site, tags);
             var filteredRes = response.Items.Where(x => x.Tags.Contains(tags));
             foreach (var res in filteredRes.Take(3))
             {
@@ -77,5 +80,7 @@ namespace Modix.Modules
 
             await ReplyAsync("", embed: footer.Build());
         }
+
+        protected StackExchangeService StackExchangeService { get; }
     }
 }

--- a/Modix.Bot/Modules/WikipediaModule.cs
+++ b/Modix.Bot/Modules/WikipediaModule.cs
@@ -11,10 +11,15 @@ namespace Modix.Modules
     [Name("Wikipedia"), Summary("Search Wikipedia from Discord!")]
     public class WikipediaModule : ModuleBase
     {
+        public WikipediaModule(WikipediaService wikipediaService)
+        {
+            WikipediaService = wikipediaService;
+        }
+
         [Command("wiki"), Summary("Returns a Wikipedia page result matching the search phrase.")]
         public async Task Run([Remainder] string phrase)
         {
-            var response = await new WikipediaService().GetWikipediaResultsAsync(phrase);
+            var response = await WikipediaService.GetWikipediaResultsAsync(phrase);
 
             // Empty response.
             if (response == null || response.Query == null || !response.Query.Pages.Any())
@@ -69,5 +74,7 @@ namespace Modix.Modules
                 await ReplyAsync("", embed: builder.Build());
             }
         }
+
+        protected WikipediaService WikipediaService { get; }
     }
 }

--- a/Modix.Services/AutoCodePaste/CodePasteService.cs
+++ b/Modix.Services/AutoCodePaste/CodePasteService.cs
@@ -21,10 +21,13 @@ namespace Modix.Services.AutoCodePaste
 
         private const string ApiReferenceUrl = "https://paste.mod.gg/";
         private const string FallbackApiReferenceUrl = "https://haste.charlesmilette.net/";
-        private static readonly HttpClient _client = new HttpClient
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public CodePasteService(IHttpClientFactory httpClientFactory)
         {
-            Timeout = TimeSpan.FromSeconds(5)
-        };
+            _httpClientFactory = httpClientFactory;
+        }
+
         /// <summary>
         /// Uploads a given piece of code to the service, and returns the URL to the post.
         /// </summary>
@@ -36,14 +39,16 @@ namespace Modix.Services.AutoCodePaste
             var content = FormatUtilities.BuildContent(code);
             HttpResponseMessage response;
 
+            var client = _httpClientFactory.CreateClient("CodePasteClient");
+
             try
             {
-                response = await _client.PostAsync($"{ApiReferenceUrl}documents", content);
+                response = await client.PostAsync($"{ApiReferenceUrl}documents", content);
             }
             catch (TaskCanceledException)
             {
                 usingFallback = true;
-                response = await _client.PostAsync($"{FallbackApiReferenceUrl}documents", content);
+                response = await client.PostAsync($"{FallbackApiReferenceUrl}documents", content);
             }
 
             if (!response.IsSuccessStatusCode)

--- a/Modix.Services/Csharp/DocumentationService.cs
+++ b/Modix.Services/Csharp/DocumentationService.cs
@@ -9,9 +9,14 @@ namespace Modix.Services.Csharp
     {
         private const string ApiReferenceUrl = "https://docs.microsoft.com/api/apibrowser/dotnet/search?search=";
 
+        public DocumentationService(IHttpClientFactory httpClientFactory)
+        {
+            HttpClientFactory = httpClientFactory;
+        }
+
         public async Task<DocumentationApiResponse> GetDocumentationResultsAsync(string term)
         {
-            var client = new HttpClient();
+            var client = HttpClientFactory.CreateClient();
             var response = await client.GetAsync(ApiReferenceUrl + term);
 
             if (!response.IsSuccessStatusCode)
@@ -21,5 +26,7 @@ namespace Modix.Services.Csharp
             var jsonResponse = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<DocumentationApiResponse>(jsonResponse);
         }
+
+        protected IHttpClientFactory HttpClientFactory { get; }
     }
 }

--- a/Modix.Services/DocsMaster/DocsMasterRetrievalService.cs
+++ b/Modix.Services/DocsMaster/DocsMasterRetrievalService.cs
@@ -8,30 +8,30 @@ namespace Modix.Services.DocsMaster
 {
     public class DocsMasterRetrievalService
     {
-        private readonly HttpClient _client;
+        private readonly IHttpClientFactory _httpClientFactory;
 
-        public DocsMasterRetrievalService(HttpClient client)
+        public DocsMasterRetrievalService(IHttpClientFactory httpClientFactory)
         {
-            _client = client;
+            _httpClientFactory = httpClientFactory;
         }
 
         public async Task<ManualEntryModel> GetManualEntryFromLatestAsync(string manualName, string entryName)
         {
             var formattableString = $"http://docsmaster.net/ManualEntry/{manualName}/{entryName}";
-            var result = await _client.GetAsync(formattableString);
+            var result = await _httpClientFactory.CreateClient().GetAsync(formattableString);
             var str = await result.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<ManualEntryModel>(str);
         }
 
         public async Task<ManualEntryModel> GetManualEntryFromVersionAsync(string manualName, string entryName, string version)
         {
-            var result = await _client.GetAsync($"http://docsmaster.net/ManualEntry/{manualName}/{entryName}/{version}");
+            var result = await _httpClientFactory.CreateClient().GetAsync($"http://docsmaster.net/ManualEntry/{manualName}/{entryName}/{version}");
             return JsonConvert.DeserializeObject<ManualEntryModel>(await result.Content.ReadAsStringAsync());
         }
 
         public async Task<IEnumerable<string>> GetAllVersionsAsync(string manualName)
         {
-            var result = await _client.GetAsync($"http://docsmaster.net/ManualEntry/{manualName}");
+            var result = await _httpClientFactory.CreateClient().GetAsync($"http://docsmaster.net/ManualEntry/{manualName}");
             return JsonConvert.DeserializeObject<List<string>>(await result.Content.ReadAsStringAsync());
         }
     }

--- a/Modix.Services/Modix.Services.csproj
+++ b/Modix.Services/Modix.Services.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Kitsu" Version="1.4.1" />
     <PackageReference Include="MediatR" Version="5.1.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />

--- a/Modix.Services/Wikipedia/WikipediaService.cs
+++ b/Modix.Services/Wikipedia/WikipediaService.cs
@@ -1,19 +1,24 @@
-﻿namespace Modix.Services.Wikipedia
-{
-    using System.Net;
-    using System.Net.Http;
-    using System.Threading.Tasks;
-    using Newtonsoft.Json;
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
 
+namespace Modix.Services.Wikipedia
+{
     public class WikipediaService
     {
         private const string WikipediaApiScheme = "https://en.wikipedia.org/w/api.php?format=json&action=query&prop=extracts&exlimit=max&explaintext&exintro&titles={0}&redirects=";
+
+        public WikipediaService(IHttpClientFactory httpClientFactory)
+        {
+            HttpClientFactory = httpClientFactory;
+        }
 
         public async Task<WikipediaResponse> GetWikipediaResultsAsync(string phrase)
         {
             var query = string.Join(" ", phrase);
             query = WebUtility.UrlEncode(query);
-            var client = new HttpClient();
+            var client = HttpClientFactory.CreateClient();
             var response = await client.GetAsync(string.Format(WikipediaApiScheme, query));
 
             if (!response.IsSuccessStatusCode)
@@ -24,5 +29,7 @@
             var jsonResponse = await response.Content.ReadAsStringAsync();
             return JsonConvert.DeserializeObject<WikipediaResponse>(jsonResponse);
         }
+
+        protected IHttpClientFactory HttpClientFactory { get; }
     }
 }

--- a/Modix/Program.cs
+++ b/Modix/Program.cs
@@ -4,9 +4,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Modix.Data.Models.Core;
-using Modix.Services.Utilities;
 using Serilog;
-using Serilog.Events;
 
 namespace Modix
 {
@@ -14,39 +12,6 @@ namespace Modix
     {
         public static int Main(string[] args)
         {
-            var loggerConfig = new LoggerConfiguration()
-                .MinimumLevel.Verbose()
-                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
-                .MinimumLevel.Override("Modix.DiscordSerilogAdapter", LogEventLevel.Information)
-                .Enrich.FromLogContext()
-                .WriteTo.Console()
-                .WriteTo.RollingFile(@"logs\{Date}", restrictedToMinimumLevel: LogEventLevel.Debug);
-
-            var webhookId = Environment.GetEnvironmentVariable("log_webhook_id");
-            var webhookToken = Environment.GetEnvironmentVariable("log_webhook_token");
-            var sentryToken = Environment.GetEnvironmentVariable("SentryToken");
-
-            if (!string.IsNullOrWhiteSpace(webhookToken) &&
-                ulong.TryParse(webhookId, out var id))
-            {
-                loggerConfig.WriteTo.DiscordWebhookSink(id, webhookToken, LogEventLevel.Error);
-            }
-            else
-            {
-                Log.Information("The webhook token and/or ID were not set. Logging to Discord has been disabled.");
-            }
-
-            if (!string.IsNullOrWhiteSpace(sentryToken))
-            {
-                loggerConfig.WriteTo.Sentry(sentryToken, restrictedToMinimumLevel: LogEventLevel.Warning);
-            }
-            else
-            {
-                Log.Information("The Sentry token was not set. Logging to Sentry has been disabled.");
-            }
-
-            Log.Logger = loggerConfig.CreateLogger();
-
             try
             {
                 CreateWebHostBuilder(args).Build().Run();


### PR DESCRIPTION
Replaces use of individual `HttpClient` instances throughout the bot with `IHttpClientFactory`.

Supposedly this scales better and is more robust and idiomatic. More importantly, however, `IHttpClientFactory` is the cool new kid on the block, and we need to raise our coolness factor.