### PR TITLE
Add starboard functionality

### DIFF
--- a/Modix.Bot/Modules/DesignatedChannelModule.cs
+++ b/Modix.Bot/Modules/DesignatedChannelModule.cs
@@ -98,6 +98,7 @@ namespace Modix.Modules
                 { DesignatedChannelType.PromotionLog,           "Promotion Log" },
                 { DesignatedChannelType.PromotionNotifications, "Promotion Notifications" },
                 { DesignatedChannelType.Unmoderated,            "Unmoderated" },
+                { DesignatedChannelType.Starboard,              "Starboard" }
             };
     }
 }

--- a/Modix.Data/Migrations/20190227164616_MessageEntity.Designer.cs
+++ b/Modix.Data/Migrations/20190227164616_MessageEntity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Modix.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -9,9 +10,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Modix.Data.Migrations
 {
     [DbContext(typeof(ModixContext))]
-    partial class ModixContextModelSnapshot : ModelSnapshot
+    [Migration("20190227164616_MessageEntity")]
+    partial class MessageEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modix.Data/Migrations/20190227164616_MessageEntity.cs
+++ b/Modix.Data/Migrations/20190227164616_MessageEntity.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Modix.Data.Migrations
+{
+    public partial class MessageEntity : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "StarboardEntryId",
+                table: "Messages",
+                type: "numeric(20)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StarboardEntryId",
+                table: "Messages");
+        }
+    }
+}

--- a/Modix.Data/Models/Core/DesignatedChannelType.cs
+++ b/Modix.Data/Models/Core/DesignatedChannelType.cs
@@ -1,7 +1,7 @@
 ﻿namespace Modix.Data.Models.Core
 {
     /// <summary>
-    /// Defines the possible types designations that may be assigned to roles.
+    /// Defines the possible types designations that may be assigned to channels.
     /// </summary>
     public enum DesignatedChannelType
     {

--- a/Modix.Data/Models/Core/DesignatedChannelType.cs
+++ b/Modix.Data/Models/Core/DesignatedChannelType.cs
@@ -24,6 +24,10 @@
         /// <summary>
         /// Defines a channel that is not subject to auto-moderation behaviors of the moderation feature.
         /// </summary>
-        Unmoderated
+        Unmoderated,
+        /// <summary>
+        /// Defines a channel to which starred messages are sent.
+        /// </summary>
+        Starboard
     }
 }

--- a/Modix.Data/Models/Core/MessageEntity.cs
+++ b/Modix.Data/Models/Core/MessageEntity.cs
@@ -22,6 +22,8 @@ namespace Modix.Data.Models.Core
         [Required]
         public DateTimeOffset Timestamp { get; set; }
 
+        public ulong? StarboardEntryId { get; set; }
+
         [OnModelCreating]
         internal static void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -42,6 +44,10 @@ namespace Modix.Data.Models.Core
 
             modelBuilder.Entity<MessageEntity>()
                 .Property(x => x.AuthorId)
+                .HasColumnType("numeric(20)");
+
+            modelBuilder.Entity<MessageEntity>()
+                .Property(x => x.StarboardEntryId)
                 .HasColumnType("numeric(20)");
 
             modelBuilder.Entity<MessageEntity>()

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -24,7 +24,7 @@ namespace Modix.Data.Repositories
 
         Task<MessageEntity> GetMessage(ulong messageId);
 
-        void UpdateStarboardColumn(MessageEntity message);
+        Task UpdateStarboardColumn(MessageEntity message);
     }
 
     public class MessageRepository : RepositoryBase, IMessageRepository

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -151,10 +151,10 @@ namespace Modix.Data.Repositories
             return await ModixContext.Messages.FindAsync(messageId);
         }
 
-        public void UpdateStarboardColumn(MessageEntity message)
+        public async Task UpdateStarboardColumn(MessageEntity message)
         {
             ModixContext.Messages.Update(message);
-            ModixContext.SaveChanges();
+            await ModixContext.SaveChangesAsync();
         }
     }
 }

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -23,6 +23,7 @@ namespace Modix.Data.Repositories
         Task DeleteAsync(ulong messageId);
 
         Task<MessageEntity> GetMessage(ulong messageId);
+
         void UpdateStarboardColumn(MessageEntity message);
     }
 

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -18,6 +18,9 @@ namespace Modix.Data.Repositories
         Task CreateAsync(MessageEntity message);
 
         Task DeleteAsync(ulong messageId);
+
+        Task<MessageEntity> GetMessage(ulong messageId);
+        void UpdateStarboardColumn(MessageEntity message);
     }
 
     public class MessageRepository : RepositoryBase, IMessageRepository
@@ -33,7 +36,7 @@ namespace Modix.Data.Repositories
 
         public async Task DeleteAsync(ulong messageId)
         {
-            if (await ModixContext.Messages.FindAsync(messageId) is MessageEntity message)
+            if (await GetMessage(messageId) is MessageEntity message)
             {
                 ModixContext.Messages.Remove(message);
                 await ModixContext.SaveChangesAsync();
@@ -92,6 +95,17 @@ namespace Modix.Data.Repositories
 
             return ModixContext.Messages.AsNoTracking()
                 .Where(x => x.GuildId == guildId && x.AuthorId == userId && x.Timestamp >= earliestDateTime);
+        }
+
+        public async Task<MessageEntity> GetMessage(ulong messageId)
+        {
+            return await ModixContext.Messages.FindAsync(messageId);
+        }
+
+        public void UpdateStarboardColumn(MessageEntity message)
+        {
+            ModixContext.Messages.Update(message);
+            ModixContext.SaveChanges();
         }
     }
 }

--- a/Modix.Services/Starboard/StarboardHandler.cs
+++ b/Modix.Services/Starboard/StarboardHandler.cs
@@ -13,12 +13,12 @@ namespace Modix.Services.Starboard
         INotificationHandler<ReactionAdded>,
         INotificationHandler<ReactionRemoved>
     {
-        private readonly StarboardService _service;
+        private readonly IStarboardService _service;
         private readonly IDesignatedChannelService _designatedChannelService;
         private readonly IQuoteService _quoteService;
 
         public StarboardHandler(
-            StarboardService service,
+            IStarboardService service,
             IDesignatedChannelService designatedChannelService,
             IQuoteService quoteService)
         {

--- a/Modix.Services/Starboard/StarboardHandler.cs
+++ b/Modix.Services/Starboard/StarboardHandler.cs
@@ -1,7 +1,4 @@
 ﻿using Discord;
-using Discord.WebSocket;
-using System.Collections.Generic;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -13,7 +10,6 @@ using Modix.Data.Models.Core;
 
 namespace Modix.Services.Starboard
 {
-
     public class StarboardHandler :
         INotificationHandler<ReactionAdded>,
         INotificationHandler<ReactionRemoved>
@@ -31,18 +27,18 @@ namespace Modix.Services.Starboard
         public async Task Handle(ReactionAdded notification, CancellationToken cancellationToken)
         {
             var reaction = notification.Reaction;
-            if(!await _service.IsStarReaction(reaction))
+            if(!_service.IsStarReaction(reaction))
             {
                 return;
             }
-
+             
             var message = await notification.Message.GetOrDownloadAsync();
             if (!(message.Channel is IGuildChannel channel))
             {
                 return;
             }
 
-            if (await _service.IsAboveReactionThreshold(message, notification))
+            if (_service.IsAboveReactionThreshold(message, notification))
             {
 
                 //Get existing message from starboardservice?
@@ -53,25 +49,24 @@ namespace Modix.Services.Starboard
                     .WithColor(new Color(255, 234, 174))
                     .Build();
 
-                var quoteUrl = await _service.BuildQuoteUrl(channel, message);
+                var quoteUrl = _service.BuildQuoteUrl(channel, message);
                 await _designatedChannelService.SendToDesignatedChannelsAsync(
                     channel.Guild,
                     DesignatedChannelType.Starboard,
-                    $"**{await _service.GetReactionCount(message, notification)}** {await GetStarEmote(message, notification)} {quoteUrl}",
+                    $"**{_service.GetReactionCount(message, notification)}** {GetStarEmote(message, notification)} {quoteUrl}",
                     embed);
             }
         }
 
-        public async Task<string> GetStarEmote(IUserMessage message, ReactionAdded notification)
+        public string GetStarEmote(IUserMessage message, ReactionAdded notification)
         {
-            var reactionCount = await _service.GetReactionCount(message, notification);
+            var reactionCount = _service.GetReactionCount(message, notification);
             return reactionCount >= 5 ? _service.GreaterEmote : _service.ReactionEmote;
         }
 
         public Task Handle(ReactionRemoved notification, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();  }
-            //=> ModifyRatings(notification.Message, notification.Reaction);
-
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Modix.Services/Starboard/StarboardHandler.cs
+++ b/Modix.Services/Starboard/StarboardHandler.cs
@@ -17,9 +17,11 @@ namespace Modix.Services.Starboard
         private readonly StarboardService _service;
         private readonly IDesignatedChannelService _designatedChannelService;
         private readonly IQuoteService _quoteService;
-        private const string _contentString = "**{0}** {1}";
 
-        public StarboardHandler(StarboardService service, IDesignatedChannelService designatedChannelService, IQuoteService quoteService)
+        public StarboardHandler(
+            StarboardService service,
+            IDesignatedChannelService designatedChannelService,
+            IQuoteService quoteService)
         {
             _service = service;
             _designatedChannelService = designatedChannelService;
@@ -32,7 +34,7 @@ namespace Modix.Services.Starboard
         public Task Handle(ReactionRemoved notification, CancellationToken cancellationToken)
             => HandleReaction(notification.Message, notification.Reaction);
 
-        private async Task HandleReaction(Cacheable<IUserMessage, ulong> cachedMessage, SocketReaction reaction)
+        private async Task HandleReaction(Cacheable<IUserMessage, ulong> cachedMessage, IReaction reaction)
         {
             var emote = reaction.Emote;
             if (!_service.IsStarEmote(emote))
@@ -59,8 +61,8 @@ namespace Modix.Services.Starboard
                 }
                 else
                 {
-                    await starboardMessage.ModifyAsync((messageProperties)
-                        => messageProperties.Content = FormatContent(message, emote));
+                    await starboardMessage.ModifyAsync(messageProps
+                        => messageProps.Content = FormatContent(message, emote));
                 }
             }
             else
@@ -80,7 +82,7 @@ namespace Modix.Services.Starboard
         private string FormatContent(IUserMessage message, IEmote emote)
         {
             var reactionCount = _service.GetReactionCount(message, emote);
-            return string.Format(_contentString, reactionCount, _service.GetStarEmote(reactionCount), message.Id);
+            return $"**{reactionCount}** {_service.GetStarEmote(reactionCount)}";
         }
         
         private Embed GetStarEmbed(IUserMessage message)

--- a/Modix.Services/Starboard/StarboardHandler.cs
+++ b/Modix.Services/Starboard/StarboardHandler.cs
@@ -15,6 +15,7 @@ namespace Modix.Services.Starboard
     {
         private readonly StarboardService _service;
         private readonly IDesignatedChannelService _designatedChannelService;
+        private const string _contentString = "**{0}** {1} ID: {2}";
 
         public StarboardHandler(StarboardService service, IDesignatedChannelService designatedChannelService)
         {
@@ -79,7 +80,7 @@ namespace Modix.Services.Starboard
         public string FormatContent(IUserMessage message, IReaction reaction)
         {
             var reactionCount = _service.GetReactionCount(message, reaction);
-            return $"**{reactionCount}** {GetStarEmote(reactionCount)} ID: {message.Id}";
+            return string.Format(_contentString, reactionCount, GetStarEmote(reactionCount), message.Id);
         }
 
         //TODO: Figure out where to put clickable link to original message

--- a/Modix.Services/Starboard/StarboardHandler.cs
+++ b/Modix.Services/Starboard/StarboardHandler.cs
@@ -47,10 +47,12 @@ namespace Modix.Services.Starboard
                 return;
             }
 
-            if(await _designatedChannelService
-                .ChannelHasDesignationAsync(channel.Guild, channel, DesignatedChannelType.Unmoderated)
-                || !await _designatedChannelService
-                .AnyDesignatedChannelAsync(channel.GuildId, DesignatedChannelType.Starboard))
+            bool isUnmoderated = await _designatedChannelService
+                .ChannelHasDesignationAsync(channel.Guild, channel, DesignatedChannelType.Unmoderated);
+
+            bool starboardExists = await _designatedChannelService
+                .AnyDesignatedChannelAsync(channel.GuildId, DesignatedChannelType.Starboard);
+            if (isUnmoderated|| !starboardExists)
             {
                 return;
             }

--- a/Modix.Services/Starboard/StarboardHandler.cs
+++ b/Modix.Services/Starboard/StarboardHandler.cs
@@ -52,7 +52,7 @@ namespace Modix.Services.Starboard
 
             bool starboardExists = await _designatedChannelService
                 .AnyDesignatedChannelAsync(channel.GuildId, DesignatedChannelType.Starboard);
-            if (isUnmoderated|| !starboardExists)
+            if (isUnmoderated || !starboardExists)
             {
                 return;
             }

--- a/Modix.Services/Starboard/StarboardHandler.cs
+++ b/Modix.Services/Starboard/StarboardHandler.cs
@@ -1,0 +1,77 @@
+﻿using Discord;
+using Discord.WebSocket;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Modix.Services.Messages.Discord;
+using Modix.Services.Quote;
+using Modix.Services.Core;
+using System;
+using Modix.Data.Models.Core;
+
+namespace Modix.Services.Starboard
+{
+
+    public class StarboardHandler :
+        INotificationHandler<ReactionAdded>,
+        INotificationHandler<ReactionRemoved>
+    {
+        private StarboardService _service;
+        private IQuoteService _quoteService;
+        private IDesignatedChannelService _designatedChannelService;
+        public StarboardHandler(StarboardService service, IQuoteService quoteService, IDesignatedChannelService designatedChannelService)
+        {
+            _service = service;
+            _quoteService = quoteService;
+            _designatedChannelService = designatedChannelService;
+        }
+        
+        public async Task Handle(ReactionAdded notification, CancellationToken cancellationToken)
+        {
+            var reaction = notification.Reaction;
+            if(!await _service.IsStarReaction(reaction))
+            {
+                return;
+            }
+
+            var message = await notification.Message.GetOrDownloadAsync();
+            if (!(message.Channel is IGuildChannel channel))
+            {
+                return;
+            }
+
+            if (await _service.IsAboveReactionThreshold(message, notification))
+            {
+
+                //Get existing message from starboardservice?
+                //if != null -> edit with returned message (selfmessage)?
+                var embed = _quoteService
+                    .BuildQuoteEmbed(message, message.Author)
+                    .AddField("Posted by", message.Author.Mention, true)
+                    .WithColor(new Color(255, 234, 174))
+                    .Build();
+
+                var quoteUrl = await _service.BuildQuoteUrl(channel, message);
+                await _designatedChannelService.SendToDesignatedChannelsAsync(
+                    channel.Guild,
+                    DesignatedChannelType.Starboard,
+                    $"**{await _service.GetReactionCount(message, notification)}** {await GetStarEmote(message, notification)} {quoteUrl}",
+                    embed);
+            }
+        }
+
+        public async Task<string> GetStarEmote(IUserMessage message, ReactionAdded notification)
+        {
+            var reactionCount = await _service.GetReactionCount(message, notification);
+            return reactionCount >= 5 ? _service.GreaterEmote : _service.ReactionEmote;
+        }
+
+        public Task Handle(ReactionRemoved notification, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();  }
+            //=> ModifyRatings(notification.Message, notification.Reaction);
+
+    }
+}

--- a/Modix.Services/Starboard/StarboardService.cs
+++ b/Modix.Services/Starboard/StarboardService.cs
@@ -180,7 +180,7 @@ namespace Modix.Services.Starboard
             }
 
             messageEntity.StarboardEntryId = starEntry.Id;
-            _messageRepository.UpdateStarboardColumn(messageEntity);
+            await _messageRepository.UpdateStarboardColumn(messageEntity);
         }
 
         /// <inheritdoc />

--- a/Modix.Services/Starboard/StarboardService.cs
+++ b/Modix.Services/Starboard/StarboardService.cs
@@ -65,6 +65,16 @@ namespace Modix.Services.Starboard
         /// <param name="content">The content to modify with</param>
         /// <returns>A <see cref="Task"/> that will complete when the operation has completed.</returns>
         Task ModifyEntry(IGuild guild, IUserMessage message, string content);
+
+        /// <summary>
+        /// Adds an <see cref="IUserMessage"/> to the starboard
+        /// </summary>
+        /// <param name="guild">The guild on which starboard to post</param>
+        /// <param name="message">The message to add to the starboard</param>
+        /// <param name="content">Meta-data that contains relevant information about the starred message</param>
+        /// <param name="embed">The embed to include in the starboard-message</param>
+        /// /// <returns>A <see cref="Task"/> that will complete when the operation has completed.</returns>
+        Task AddToStarboard(IGuild guild, IUserMessage message, string content, Embed embed);
     }
 
     /// <inheritdoc />

--- a/Modix.Services/Starboard/StarboardService.cs
+++ b/Modix.Services/Starboard/StarboardService.cs
@@ -29,18 +29,16 @@ namespace Modix.Services.Starboard
         //TODO: Function: => Update starred message in designated starboard channel
 
 
-        public Task<bool> IsStarReaction(SocketReaction reaction)
-            => Task.FromResult(reaction.Emote.Name == ReactionEmote);
+        public bool IsStarReaction(SocketReaction reaction)
+            => reaction.Emote.Name == ReactionEmote;
 
-        public Task<int> GetReactionCount(IUserMessage message, ReactionAdded reaction)
-            => Task.FromResult(message.Reactions[reaction.Reaction.Emote].ReactionCount);
+        public int GetReactionCount(IUserMessage message, ReactionAdded reaction)
+            => message.Reactions[reaction.Reaction.Emote].ReactionCount;
 
-        public async Task<bool> IsAboveReactionThreshold(IUserMessage message, ReactionAdded reaction)
-        {
-            return await GetReactionCount(message, reaction) >= 2;
-        }
+        public bool IsAboveReactionThreshold(IUserMessage message, ReactionAdded reaction)
+            => GetReactionCount(message, reaction) >= 2;
 
-        public Task<string> BuildQuoteUrl(IGuildChannel channel, IMessage message)
-            => Task.FromResult(string.Join("/", _baseQuoteUrl, channel.Guild.Id, channel.Id, message.Author.Id));
+        public string BuildQuoteUrl(IGuildChannel channel, IMessage message)
+            => string.Join("/", _baseQuoteUrl, channel.Guild.Id, channel.Id, message.Author.Id);
     }
 }

--- a/Modix.Services/Starboard/StarboardService.cs
+++ b/Modix.Services/Starboard/StarboardService.cs
@@ -15,7 +15,7 @@ namespace Modix.Services.Starboard
         /// <summary>
         /// Fetches a message from the specified guilds starboard.
         /// </summary>
-        /// <param name="channel">Which guilds starboard to fetch from</param>
+        /// <param name="channel">Which guild's starboard to fetch from</param>
         /// <param name="message">The message to fetch</param>
         /// <returns>
         /// A <see cref="Task"/> that will complete when the operation has completed,
@@ -122,8 +122,8 @@ namespace Modix.Services.Starboard
 
         public string GetStarEmote(int reactionCount)
         {
-            var valIdx = _emojis.Keys.First((val) => reactionCount >= val);
-            return _emojis[valIdx];
+            var emoteIndex = _emojis.Keys.First((val) => reactionCount >= val);
+            return _emojis[emoteIndex];
         }
     }
 }

--- a/Modix.Services/Starboard/StarboardService.cs
+++ b/Modix.Services/Starboard/StarboardService.cs
@@ -118,7 +118,7 @@ namespace Modix.Services.Starboard
 
         /// <inheritdoc />
         public bool IsAboveReactionThreshold(IUserMessage message, IEmote emote)
-            => GetReactionCount(message, emote) >= 1;
+            => GetReactionCount(message, emote) >= 2;
 
         public string GetStarEmote(int reactionCount)
         {

--- a/Modix.Services/Starboard/StarboardService.cs
+++ b/Modix.Services/Starboard/StarboardService.cs
@@ -138,12 +138,14 @@ namespace Modix.Services.Starboard
         public bool IsAboveReactionThreshold(IUserMessage message, IEmote emote)
             => GetReactionCount(message, emote) >= 2;
 
+        /// <inheritdoc />
         public string GetStarEmote(int reactionCount)
         {
             var emoteIndex = _emojis.Keys.First((val) => reactionCount >= val);
             return _emojis[emoteIndex];
         }
 
+        /// <inheritdoc />
         public async Task AddToStarboard(IGuild guild, IUserMessage message, string content, Embed embed)
         {
             var starChannel = await GetStarboardChannel(guild);
@@ -168,6 +170,7 @@ namespace Modix.Services.Starboard
             _messageRepository.UpdateStarboardColumn(messageEntity);
         }
 
+        /// <inheritdoc />
         public async Task ModifyEntry(IGuild guild, IUserMessage message, string content)
         {
             var starEntry = await GetStarboardEntry(guild, message);

--- a/Modix.Services/Starboard/StarboardService.cs
+++ b/Modix.Services/Starboard/StarboardService.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+using Modix.Services.Core;
+using Modix.Services.Messages.Discord;
+
+namespace Modix.Services.Starboard
+{
+    public class StarboardService
+    {
+        private const string _baseQuoteUrl = "https://discordapp.com/channels";
+        public string ReactionEmote { get; } = "⭐";
+        public string GreaterEmote { get; } = "🌟";
+
+        private IDiscordClient _discordClient;
+
+        public StarboardService(IDiscordClient discordClient, IDesignatedChannelService designatedChannelService)
+        {
+            _discordClient = discordClient;
+        }
+
+        //TODO: Function<bool>: => Starred message exists in designated starboard channel
+
+        //TODO: Function: => Delete starred message in designated starboard channel
+
+        //TODO: Function: => Update starred message in designated starboard channel
+
+
+        public Task<bool> IsStarReaction(SocketReaction reaction)
+            => Task.FromResult(reaction.Emote.Name == ReactionEmote);
+
+        public Task<int> GetReactionCount(IUserMessage message, ReactionAdded reaction)
+            => Task.FromResult(message.Reactions[reaction.Reaction.Emote].ReactionCount);
+
+        public async Task<bool> IsAboveReactionThreshold(IUserMessage message, ReactionAdded reaction)
+        {
+            return await GetReactionCount(message, reaction) >= 2;
+        }
+
+        public Task<string> BuildQuoteUrl(IGuildChannel channel, IMessage message)
+            => Task.FromResult(string.Join("/", _baseQuoteUrl, channel.Guild.Id, channel.Id, message.Author.Id));
+    }
+}

--- a/Modix.Services/Starboard/StarboardService.cs
+++ b/Modix.Services/Starboard/StarboardService.cs
@@ -1,44 +1,64 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Discord;
 using Discord.WebSocket;
 using Modix.Services.Core;
-using Modix.Services.Messages.Discord;
+using Modix.Data.Models.Core;
 
 namespace Modix.Services.Starboard
 {
     public class StarboardService
     {
-        private const string _baseQuoteUrl = "https://discordapp.com/channels";
-        public string ReactionEmote { get; } = "⭐";
-        public string GreaterEmote { get; } = "🌟";
+        private const string _baseContextUrl = "https://discordapp.com/channels";
 
-        private IDiscordClient _discordClient;
+        //TODO: Dictionary<Emoji, int>
+        public string GoodEmote { get; } = "⭐";
+        public string GreatEmote { get; } = "🌟";
+        public string GreaterEmote { get; } = "💫";
+        public string GreatestEmote { get; } = "✨";
 
-        public StarboardService(IDiscordClient discordClient, IDesignatedChannelService designatedChannelService)
+        private IDesignatedChannelService _designatedChannelService;
+
+        public StarboardService(IDesignatedChannelService designatedChannelService)
         {
-            _discordClient = discordClient;
+            _designatedChannelService = designatedChannelService;
         }
 
-        //TODO: Function<bool>: => Starred message exists in designated starboard channel
+        public async Task<IUserMessage> GetFromStarboard(IGuildChannel channel, IMessage message)
+        {
+            var starboardChannels = await _designatedChannelService
+                .GetDesignatedChannelsAsync(channel.Guild, DesignatedChannelType.Starboard);
 
-        //TODO: Function: => Delete starred message in designated starboard channel
+            var starMessages = await starboardChannels
+                .First()
+                .GetMessagesAsync()
+                .FlattenAsync();
 
-        //TODO: Function: => Update starred message in designated starboard channel
+            return starMessages
+                .Cast<IUserMessage>()
+                .FirstOrDefault(x => x.Content.EndsWith(message.Id.ToString()));
+        }
 
+        public async Task RemoveFromStarboard(IGuildChannel channel, IMessage message)
+        {
+            var messageToRemove = await GetFromStarboard(channel, message);
+            await messageToRemove.DeleteAsync();
+        }
 
         public bool IsStarReaction(SocketReaction reaction)
-            => reaction.Emote.Name == ReactionEmote;
+            => reaction.Emote.Name == GoodEmote;
 
-        public int GetReactionCount(IUserMessage message, ReactionAdded reaction)
-            => message.Reactions[reaction.Reaction.Emote].ReactionCount;
+        public int GetReactionCount(IUserMessage message, IReaction reaction)
+        {
+            if (!message.Reactions.TryGetValue(reaction.Emote, out var metadata))
+                return 0;
+            return message.Reactions[reaction.Emote].ReactionCount;
+        }
 
-        public bool IsAboveReactionThreshold(IUserMessage message, ReactionAdded reaction)
+        public bool IsAboveReactionThreshold(IUserMessage message, IReaction reaction)
             => GetReactionCount(message, reaction) >= 2;
 
-        public string BuildQuoteUrl(IGuildChannel channel, IMessage message)
-            => string.Join("/", _baseQuoteUrl, channel.Guild.Id, channel.Id, message.Author.Id);
+        public string BuildContextUrl(IGuildChannel channel, IMessage message)
+            => string.Join("/", _baseContextUrl, channel.Guild.Id, channel.Id, message.Author.Id);
     }
 }

--- a/Modix.Services/Starboard/StarboardSetup.cs
+++ b/Modix.Services/Starboard/StarboardSetup.cs
@@ -8,7 +8,7 @@ namespace Modix.Services.Starboard
     {
         public static IServiceCollection AddStarboard(this IServiceCollection services)
             => services
-                .AddSingleton<StarboardService>()
+                .AddScoped<StarboardService>()
                 .AddScoped<INotificationHandler<ReactionAdded>, StarboardHandler>()
                 .AddScoped<INotificationHandler<ReactionRemoved>, StarboardHandler>();
     }

--- a/Modix.Services/Starboard/StarboardSetup.cs
+++ b/Modix.Services/Starboard/StarboardSetup.cs
@@ -1,0 +1,15 @@
+﻿using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Modix.Services.Messages.Discord;
+
+namespace Modix.Services.Starboard
+{
+    public static class StarboardSetup
+    {
+        public static IServiceCollection AddStarboard(this IServiceCollection services)
+            => services
+                .AddSingleton<StarboardService>()
+                .AddScoped<INotificationHandler<ReactionAdded>, StarboardHandler>()
+                .AddScoped<INotificationHandler<ReactionRemoved>, StarboardHandler>();
+    }
+}

--- a/Modix.Services/Starboard/StarboardSetup.cs
+++ b/Modix.Services/Starboard/StarboardSetup.cs
@@ -8,7 +8,7 @@ namespace Modix.Services.Starboard
     {
         public static IServiceCollection AddStarboard(this IServiceCollection services)
             => services
-                .AddScoped<StarboardService>()
+                .AddScoped<IStarboardService, StarboardService>()
                 .AddScoped<INotificationHandler<ReactionAdded>, StarboardHandler>()
                 .AddScoped<INotificationHandler<ReactionRemoved>, StarboardHandler>();
     }

--- a/Modix/ClientApp/src/models/moderation/ChannelDesignation.ts
+++ b/Modix/ClientApp/src/models/moderation/ChannelDesignation.ts
@@ -4,5 +4,6 @@ export enum ChannelDesignation
     MessageLog = "MessageLog",
     PromotionLog = "PromotionLog",
     PromotionNotifications = "PromotionNotifications",
-    Unmoderated = "Unmoderated"
+    Unmoderated = "Unmoderated",
+    Starboard = "Starboard"
 }

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ using Modix.Services.Moderation;
 using Modix.Services.PopularityContest;
 using Modix.Services.Promotions;
 using Modix.Services.Quote;
+using Modix.Services.Starboard;
 using Modix.Services.Tags;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -75,7 +76,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddCommandHelp()
                 .AddGuildStats()
                 .AddMentions()
-                .AddModixTags();
+                .AddModixTags()
+                .AddStarboard();
 
             services.AddSingleton<IBehavior, DiscordAdapter>();
             services.AddScoped<IQuoteService, QuoteService>();


### PR DESCRIPTION
It's time lads.

Continuation of #305 and #311 

As discussed, the implementation is now using the database to keep track of which message is starred or not instead of querying discord.