### PR TITLE
Fix starboard formatting

### DIFF
--- a/Modix.Services/Starboard/StarboardHandler.cs
+++ b/Modix.Services/Starboard/StarboardHandler.cs
@@ -99,7 +99,7 @@ namespace Modix.Services.Starboard
                 builder.Description = null;
                 builder.AddField("Message", $"{message.Content}");
             }
-            builder.AddField("\u200B", $"_Posted in [**#{message.Channel.Name}**]({message.GetJumpUrl()})_");
+            builder.AddField("\u200B", $"_Posted in **[#{message.Channel.Name}]({message.GetJumpUrl()})**_");
             //------------------^ zero-width character
             return builder.Build();
         }


### PR DESCRIPTION
The asterisks were visible on the Android Discord mobile app, possibly a bug in the app. Regardless, this should make it so that the asterisks are no longer visible.