### PR TITLE
Fixed :x: for quotes, other small fixes/cleanups

### DIFF
--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -65,7 +65,7 @@ namespace Modix.Services.Quote
                             channel is ISocketMessageChannel messageChannel)
                         {
                             var msg = await messageChannel.GetMessageAsync(messageId);
-                            if (msg == null || await IsQuote(msg))
+                            if (msg == null || IsQuote(msg))
                                 return;
 
                             await SendQuoteEmbedAsync(msg, guildUser, userMessage.Channel);
@@ -86,9 +86,6 @@ namespace Modix.Services.Quote
                 var embed = quoteService.BuildQuoteEmbed(message, quoter);
                 if (embed == null) return;
 
-                embed.Fields.First(d => d.Name == "Quoted by")
-                .Value += $" from **[#{message.Channel.Name}]({message.GetJumpUrl()})**";
-
                 embed.WithFooter("React with ❌ to remove this embed.");
                 embed.WithTimestamp(message.Timestamp);
 
@@ -98,7 +95,7 @@ namespace Modix.Services.Quote
             });
         }
 
-        private async Task<bool> IsQuote(IMessage message)
+        private bool IsQuote(IMessage message)
         {
             var hasQuoteField =
                 message

--- a/Modix.Services/Quote/QuoteService.cs
+++ b/Modix.Services/Quote/QuoteService.cs
@@ -118,7 +118,7 @@ namespace Modix.Services.Quote
                 .WithAuthor(message.Author)
                 .WithFooter(GetPostedMeta(message))
                 .WithColor(new Color(95, 186, 125))
-                .AddField("Quoted by", executingUser.Mention, true);
+                .AddField("Quoted by", $"{executingUser.Mention} from **[#{message.Channel.Name}]({message.GetJumpUrl()})**", true);
         }
 
         private static string GetPostedMeta(IMessage message)

--- a/Modix.Services/Quote/QuoteService.cs
+++ b/Modix.Services/Quote/QuoteService.cs
@@ -71,7 +71,7 @@ namespace Modix.Services.Quote
             embed = message.Embeds
                     .First()
                     .ToEmbedBuilder()
-                    .AddField("Quoted by", executingUser.Mention, true);
+                    .AddField("Quoted by", $"{executingUser.Mention} from **[#{message.Channel.Name}]({message.GetJumpUrl()})**", true);
 
             if (firstEmbed.Color == null)
             {

--- a/Modix/ClientApp/package-lock.json
+++ b/Modix/ClientApp/package-lock.json
@@ -2388,7 +2388,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -4505,7 +4505,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "dev": true,
       "requires": {


### PR DESCRIPTION
* Adds the ability to remove a quote with the :x: reaction.
* The quote now also contains a jump-link to the quoted message itself.
* It no longer freaks out when someone links a message that the bot cannot see. (i.e. a message from another guild, or a channel that it doesn't have access to.)


The end result can be seen below.

### From this: 

![discord_2019-03-03_18-51-03](https://user-images.githubusercontent.com/22471295/53699185-e167eb80-3de5-11e9-91ae-a2abaaf38f78.png)

### To this:
![bild](https://user-images.githubusercontent.com/22471295/53699333-833c0800-3de7-11e9-82bc-65a651e76402.png)

Fixes #322 