### PR TITLE
Make commands nonblocking

### DIFF
--- a/Modix.Bot/ModixBot.cs
+++ b/Modix.Bot/ModixBot.cs
@@ -154,6 +154,12 @@ namespace Modix
                 _restClient.Log -= _serilogAdapter.HandleLog;
 
                 _commands.CommandExecuted -= HandleCommandResultAsync;
+
+                foreach (var context in _commandScopes.Keys)
+                {
+                    _commandScopes.TryRemove(context, out var commandScope);
+                    commandScope?.Dispose();
+                }
             }
         }
 
@@ -246,7 +252,9 @@ namespace Modix
 
         private async Task HandleCommandResultAsync(Optional<CommandInfo> command, ICommandContext context, IResult result)
         {
-            using (var commandScope = _commandScopes[context])
+            _commandScopes.TryRemove(context, out var commandScope);
+
+            using (commandScope)
             {
                 if (!result.IsSuccess)
                 {

--- a/Modix.Bot/ModixBot.cs
+++ b/Modix.Bot/ModixBot.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -31,7 +32,9 @@ namespace Modix
         private readonly ModixConfig _config;
         private readonly DiscordSerilogAdapter _serilogAdapter;
         private readonly IApplicationLifetime _applicationLifetime;
+        private readonly CommandErrorHandler _commandErrorHandler;
         private IServiceScope _scope;
+        private readonly ConcurrentDictionary<ICommandContext, IServiceScope> _commandScopes = new ConcurrentDictionary<ICommandContext, IServiceScope>();
 
         public ModixBot(
             DiscordSocketClient discordClient,
@@ -41,7 +44,8 @@ namespace Modix
             DiscordSerilogAdapter serilogAdapter,
             IApplicationLifetime applicationLifetime,
             IServiceProvider serviceProvider,
-            ILogger<ModixBot> logger)
+            ILogger<ModixBot> logger,
+            CommandErrorHandler commandErrorHandler)
         {
             _client = discordClient ?? throw new ArgumentNullException(nameof(discordClient));
             _restClient = restClient ?? throw new ArgumentNullException(nameof(restClient));
@@ -51,10 +55,10 @@ namespace Modix
             _serilogAdapter = serilogAdapter ?? throw new ArgumentNullException(nameof(serilogAdapter));
             _applicationLifetime = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));
             Log = logger ?? throw new ArgumentNullException(nameof(logger));
+            _commandErrorHandler = commandErrorHandler;
         }
 
         private ILogger<ModixBot> Log { get; }
-        private DiscordSerilogAdapter SerilogAdapter { get; }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
@@ -77,6 +81,8 @@ namespace Modix
                 _client.Log += _serilogAdapter.HandleLog;
                 _restClient.Log += _serilogAdapter.HandleLog;
                 _commands.Log += _serilogAdapter.HandleLog;
+
+                _commands.CommandExecuted += HandleCommandResultAsync;
 
                 // Register with the cancellation token so we can stop listening to client events if the service is
                 // shutting down or being disposed.
@@ -145,8 +151,9 @@ namespace Modix
 
                 _client.Log -= _serilogAdapter.HandleLog;
                 _commands.Log -= _serilogAdapter.HandleLog;
-
                 _restClient.Log -= _serilogAdapter.HandleLog;
+
+                _commands.CommandExecuted -= HandleCommandResultAsync;
             }
         }
 
@@ -224,14 +231,23 @@ namespace Modix
 
             var context = new CommandContext(_client, message);
 
-            using (var scope = _scope.ServiceProvider.CreateScope())
+            var commandScope = _scope.ServiceProvider.CreateScope();
+            _commandScopes[context] = commandScope;
+
+            await commandScope.ServiceProvider
+                .GetRequiredService<IAuthorizationService>()
+                .OnAuthenticatedAsync(context.User as IGuildUser);
+
+            await _commands.ExecuteAsync(context, argPos, commandScope.ServiceProvider);
+
+            stopwatch.Stop();
+            Log.LogInformation($"Took {stopwatch.ElapsedMilliseconds}ms to process: {message}");
+        }
+
+        private async Task HandleCommandResultAsync(Optional<CommandInfo> command, ICommandContext context, IResult result)
+        {
+            using (var commandScope = _commandScopes[context])
             {
-                await scope.ServiceProvider
-                    .GetRequiredService<IAuthorizationService>()
-                    .OnAuthenticatedAsync(context.User as IGuildUser);
-
-                var result = await _commands.ExecuteAsync(context, argPos, scope.ServiceProvider);
-
                 if (!result.IsSuccess)
                 {
                     var error = $"{result.Error}: {result.ErrorReason}";
@@ -247,8 +263,7 @@ namespace Modix
 
                     if (result.Error != CommandError.Exception)
                     {
-                        var handler = scope.ServiceProvider.GetRequiredService<CommandErrorHandler>();
-                        await handler.AssociateError(message, error);
+                        await _commandErrorHandler.AssociateError(context.Message, error);
                     }
                     else
                     {
@@ -256,9 +271,6 @@ namespace Modix
                     }
                 }
             }
-
-            stopwatch.Stop();
-            Log.LogInformation($"Took {stopwatch.ElapsedMilliseconds}ms to process: {message}");
         }
     }
 }

--- a/Modix.Bot/Modules/IlModule.cs
+++ b/Modix.Bot/Modules/IlModule.cs
@@ -34,7 +34,7 @@ namespace Modix.Modules
             _httpClientFactory = httpClientFactory;
         }
 
-        [Command("il", RunMode = RunMode.Sync), Summary("Compile & return the resulting IL of C# code")]
+        [Command("il"), Summary("Compile & return the resulting IL of C# code")]
         public async Task ReplInvoke([Remainder] string code)
         {
             if (!(Context.Channel is SocketGuildChannel))

--- a/Modix.Bot/Modules/ReplModule.cs
+++ b/Modix.Bot/Modules/ReplModule.cs
@@ -48,7 +48,7 @@ namespace Modix.Modules
             _pasteService = pasteService;
         }
 
-        [Command("exec", RunMode = RunMode.Sync), Alias("eval"), Summary("Executes the given C# code and returns the result")]
+        [Command("exec"), Alias("eval"), Summary("Executes the given C# code and returns the result")]
         public async Task ReplInvoke([Remainder] string code)
         {
             if (!(Context.Channel is SocketGuildChannel))

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         new CommandServiceConfig
                         {
                             LogLevel = LogSeverity.Debug,
-                            DefaultRunMode = RunMode.Sync,
+                            DefaultRunMode = RunMode.Async,
                             CaseSensitiveCommands = false,
                             SeparatorChar = ' '
                         });


### PR DESCRIPTION
Fixes #321.

This PR changes the default `RunMode` to `RunMode.Async` for all commands.

Scope disposal and error handling have been moved to the new `CommandExecuted` event handler available in Discord.Net 2.0.