### PR TITLE
Remove ReplToken

### DIFF
--- a/Modix.Bot/Modules/IlModule.cs
+++ b/Modix.Bot/Modules/IlModule.cs
@@ -10,9 +10,6 @@ using Modix.Services.AutoCodePaste;
 using Modix.Services.AutoRemoveMessage;
 using Modix.Services.Utilities;
 using Serilog;
-using Microsoft.Extensions.Options;
-using Modix.Data.Models.Core;
-using System.Net.Http.Headers;
 
 namespace Modix.Modules
 {
@@ -57,7 +54,7 @@ namespace Modix.Modules
             HttpResponseMessage res;
             try
             {
-                var client = _httpClientFactory.CreateClient(nameof(ReplModule));
+                var client = _httpClientFactory.CreateClient();
 
                 using (var tokenSrc = new CancellationTokenSource(30000))
                 {

--- a/Modix.Bot/Modules/ReplModule.cs
+++ b/Modix.Bot/Modules/ReplModule.cs
@@ -7,8 +7,6 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
-using Microsoft.Extensions.Options;
-using Modix.Data.Models.Core;
 using Modix.Services.AutoCodePaste;
 using Modix.Services.AutoRemoveMessage;
 using Modix.Services.Utilities;
@@ -71,7 +69,7 @@ namespace Modix.Modules
             HttpResponseMessage res;
             try
             {
-                var client = _httpClientFactory.CreateClient(nameof(ReplModule));
+                var client = _httpClientFactory.CreateClient();
 
                 using (var tokenSrc = new CancellationTokenSource(30000))
                 {

--- a/Modix.Data/Models/Core/ModixConfig.cs
+++ b/Modix.Data/Models/Core/ModixConfig.cs
@@ -3,13 +3,17 @@
     public class ModixConfig
     {
         public string DiscordToken { get; set; }
+
         public string StackoverflowToken { get; set; }
-        public string ReplToken { get; set; }
+
         public string DbConnection { get; set; }
+
         public string LogWebhookToken { get; set; }
+
         public ulong LogWebhookId { get; set; }
 
         public string DiscordClientId { get; set; }
+
         public string DiscordClientSecret { get; set; }
 
         public int MessageCacheSize { get; set; } = 10;

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using Discord;
 using Discord.Commands;
 using Discord.Rest;
@@ -30,11 +29,10 @@ using Modix.Services.NotificationDispatch;
 using Modix.Services.PopularityContest;
 using Modix.Services.Promotions;
 using Modix.Services.Quote;
-using Modix.Services.Starboard;
 using Modix.Services.StackExchange;
+using Modix.Services.Starboard;
 using Modix.Services.Tags;
 using Modix.Services.Wikipedia;
-using Modix.Modules;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -43,13 +41,6 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddModixHttpClients(this IServiceCollection services)
         {
             services.AddHttpClient();
-
-            services.AddHttpClient(nameof(ReplModule))
-                .ConfigureHttpClient((serviceProvider, client) =>
-                {
-                    var config = serviceProvider.GetRequiredService<IOptions<ModixConfig>>().Value;
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", config.ReplToken);
-                });
 
             services.AddHttpClient(nameof(CodePasteService))
                 .ConfigureHttpClient(client =>

--- a/Modix/developmentSettings.default.json
+++ b/Modix/developmentSettings.default.json
@@ -1,11 +1,10 @@
 ﻿{
-    "DbConnection": "",
-    "DiscordClientId": "",
-    "DiscordClientSecret": "",
-    "LogWebhookId": "",
-    "LogWebhookToken": "",
-    "DiscordToken": "",
-    "ReplToken": "",
-    "StackoverflowToken": "",
-    "MessageCacheSize": ""
+  "DbConnection": "",
+  "DiscordClientId": "",
+  "DiscordClientSecret": "",
+  "LogWebhookId": "",
+  "LogWebhookToken": "",
+  "DiscordToken": "",
+  "StackoverflowToken": "",
+  "MessageCacheSize": ""
 }


### PR DESCRIPTION
According to @Cisien, it isn't in use anymore, so I figured it could just be removed.

https://ptb.discordapp.com/channels/143867839282020352/536023005164470303/551569079446798337
![image](https://user-images.githubusercontent.com/2829282/53705113-28f37500-3df0-11e9-8875-deed2e1e9457.png)
https://github.com/discord-csharp/MODiX/blob/b42454a790ec33366cd07fe92af35d48238d5776/Modix/developmentSettings.default.json#L8