### PR TITLE
Frontend & performance updates

### DIFF
--- a/Modix.Data/Models/Moderation/DeletedMessageSummary.cs
+++ b/Modix.Data/Models/Moderation/DeletedMessageSummary.cs
@@ -72,16 +72,16 @@ namespace Modix.Data.Models.Moderation
         internal static readonly IDictionary<string, Expression<Func<DeletedMessageSummary, object>>> SortablePropertyMap
             = new Dictionary<string, Expression<Func<DeletedMessageSummary, object>>>()
             {
-                [$"{nameof(Channel)}.{nameof(DeletedMessageSummary.Channel.Name)}"]
+                [nameof(Channel)]
                     = x => x.Channel.Name,
 
-                [$"{nameof(Author)}.{nameof(DeletedMessageSummary.Author.Nickname)}"]
+                [nameof(Author)]
                     = x => x.Author.Nickname,
 
                 [nameof(Created)]
                     = x => x.Created,
 
-                [$"{nameof(CreatedBy)}.{nameof(DeletedMessageSummary.CreatedBy.Nickname)}"]
+                [nameof(CreatedBy)]
                     = x => x.CreatedBy.Nickname,
 
                 [nameof(Content)]

--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -539,7 +539,7 @@ namespace Modix.Services.Moderation
 
                     //If the infraction has already been rescinded, we don't need to actually perform the unmute/unban
                     //Doing so will return a 404 from Discord (trying to remove a nonexistant ban)
-                    if (infraction.RescindAction != null)
+                    if (infraction.RescindAction == null)
                     {
                         await guild.RemoveBanAsync(infraction.Subject.Id);
                     }

--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -536,7 +536,14 @@ namespace Modix.Services.Moderation
                     break;
 
                 case InfractionType.Ban:
-                    await guild.RemoveBanAsync(infraction.Subject.Id);
+
+                    //If the infraction has already been rescinded, we don't need to actually perform the unmute/unban
+                    //Doing so will return a 404 from Discord (trying to remove a nonexistant ban)
+                    if (infraction.RescindAction != null)
+                    {
+                        await guild.RemoveBanAsync(infraction.Subject.Id);
+                    }
+
                     break;
             }
         }

--- a/Modix/Auth/ModixAuthenticationExtensions.cs
+++ b/Modix/Auth/ModixAuthenticationExtensions.cs
@@ -17,8 +17,6 @@ namespace Modix.Auth
             return builder.AddOAuth<DiscordAuthenticationOptions, ModixAuthenticationHandler>(DiscordAuthenticationDefaults.AuthenticationScheme, options =>
             {
                 options.ClaimActions.MapJsonKey(claimType: "avatarHash", jsonKey: "avatar");
-                options.Scope.Add("identify");
-                //options.Scope.Add("guilds");
 
                 options.Events.OnRemoteFailure = context =>
                 {

--- a/Modix/ClientApp/src/App.vue
+++ b/Modix/ClientApp/src/App.vue
@@ -48,13 +48,6 @@ export default class App extends ModixComponent
 
     async mounted()
     {
-        await store.retrieveUserInfo();
-
-        if (store.isLoggedIn())
-        {
-            await store.retrieveGuilds();
-        }
-
         this.initialLoadingComplete = true;
 
         themeContext("./" + config().theme.toLowerCase() + ".scss");

--- a/Modix/ClientApp/src/app/ModixRoute.ts
+++ b/Modix/ClientApp/src/app/ModixRoute.ts
@@ -2,6 +2,14 @@ import Vue, { ComponentOptions, AsyncComponent } from 'vue';
 import { RouteConfig, Route } from 'vue-router';
 import _ from 'lodash';
 
+export enum RouteType
+{
+    Redirect = "redirect",
+    Normal = "normal"
+}
+
+type MixedRoute = ModixRouteData & RedirectRouteData;
+
 export interface ModixRouteData
 {
     path: string;
@@ -12,38 +20,99 @@ export interface ModixRouteData
     showInNavbar?: boolean;
     children?: ModixRouteData[];
     requiresAuth?: boolean;
+    isButton?: boolean;
+    type: RouteType.Normal;
 
     beforeEnter?: (to: Route, from: Route, next: any) => void;
 }
 
+export interface RedirectRouteData
+{
+    path: string;
+    redirectTo: string;
+    type: RouteType.Redirect;
+}
+
 export default class ModixRoute
 {
-    routeData: ModixRouteData;
+    routeData: (ModixRouteData | RedirectRouteData);
+    optionalClaims: string[] = [];
 
-    constructor(data: ModixRouteData)
+    constructor(data: (ModixRouteData | RedirectRouteData))
     {
         this.routeData = data;
+
+        if (this.routeData.type == RouteType.Normal)
+        {
+            for (let claim of _.flatMap(this.routeData.children, child => child.requiredClaims))
+            {
+                this.optionalClaims.push(claim as any);
+            }
+        }
     }
 
     get requiresAuth()
     {
+        if (this.routeData.type == RouteType.Redirect)
+        {
+            return false;
+        }
+
         return this.routeData.requiresAuth || (this.routeData.requiredClaims && this.routeData.requiredClaims.length > 0);
+    }
+
+    get requiredClaims(): string[]
+    {
+        if (this.routeData.type == RouteType.Redirect)
+        {
+            return [];
+        }
+
+        return this.routeData.requiredClaims || [];
+    }
+
+    get isButton(): boolean
+    {
+        if (this.routeData.type == RouteType.Redirect)
+        {
+            return false;
+        }
+
+        return (this.routeData.isButton == undefined ? false : this.routeData.isButton);
     }
 
     get title(): string
     {
+        if (this.routeData.type == RouteType.Redirect)
+        {
+            return "Redirecting...";
+        }
+
         return this.routeData.title || this.routeData.name;
     }
 
     asVueRoute(): RouteConfig
     {
-        let ret: RouteConfig = {
-            path: this.routeData.path,
-            name: this.routeData.name,
-            component: this.routeData.component,
-            beforeEnter: this.routeData.beforeEnter,
-            children: _.map(this.routeData.children, route => new ModixRoute(route).asVueRoute()),
-            meta: this
+        let ret: RouteConfig = { path: "" };
+
+        switch (this.routeData.type)
+        {
+            case RouteType.Redirect:
+                ret = {
+                    path: this.routeData.path,
+                    redirect: { name: this.routeData.redirectTo }
+                };
+                break;
+            default:
+                ret = {
+                    path: this.routeData.path,
+                    name: this.routeData.name,
+                    component: this.routeData.component,
+                    beforeEnter: this.routeData.beforeEnter,
+                    children: _.map(this.routeData.children, route => new ModixRoute(route as any).asVueRoute()),
+                    meta: this
+                };
+                break;
         }
 
         return ret;

--- a/Modix/ClientApp/src/app/Util.ts
+++ b/Modix/ClientApp/src/app/Util.ts
@@ -1,4 +1,6 @@
 import * as dateformat from "dateformat";
+import * as _ from 'lodash';
+import DesignatedChannelMapping from '@/models/moderation/DesignatedChannelMapping';
 
 export const formatDate = (date: Date): string =>
 {
@@ -21,4 +23,38 @@ export const toBool = (input: any): boolean =>
 {
     if (!input) { return false; }
     return input === true || input === "true" || input === "TRUE";
+}
+
+const channelResolvingRegex = /<#(\d+)>/gm;
+const urlResolvingRegex = /<(http.*)>/gm;
+const mentionResolvingRegex = /<@(\d+)>/gm;
+
+export const resolveMentions = (channelCache: { [key: string]: DesignatedChannelMapping; } | null, content: string) =>
+{
+    let replaced = content;
+
+    if (channelCache)
+    {
+        replaced = content.replace(channelResolvingRegex, (sub, args: string) =>
+        {
+            if (!channelCache[args])
+            {
+                return args;
+            }
+
+            return `<span class='channel'>#${channelCache[args].name}</span>`;
+        });
+    }
+
+    replaced = replaced.replace(urlResolvingRegex, (sub, args: string) =>
+    {
+        return `<a target="_blank" href="${_.escape(args)}">${_.escape(args)}</a>`;
+    });
+
+    replaced = replaced.replace(mentionResolvingRegex, (sub, args: string) =>
+    {
+        return `<span class='userMention'>@${_.escape(args)}</span>`;
+    });
+
+    return replaced;
 }

--- a/Modix/ClientApp/src/components/Logs/DeletedMessages.vue
+++ b/Modix/ClientApp/src/components/Logs/DeletedMessages.vue
@@ -1,260 +1,258 @@
 <template>
     <div>
-        <section class="section">
-            <div class="container">
-                <div class="level is-mobile">
-                    <div class="level-left">
-                        <button class="button" v-on:click="refresh()" v-bind:class="{ 'is-loading': isLoading }">Refresh</button>
-                    </div>
-                </div>
-
-                <VueGoodTable v-bind:columns="mappedColumns" v-bind:rows="recordsPage.records" v-bind:sortOptions="sortOptions"
-                              v-bind:paginationOptions="paginationOptions" styleClass="vgt-table condensed bordered striped deleted-messages"
-                              mode="remote" v-bind:totalRows="recordsPage.filteredRecordCount" v-on:on-page-change="onPageChange"
-                              v-on:on-sort-change="onSortChange" v-on:on-column-filter="onColumnFilter" v-on:on-per-page-change="onPerPageChange">
-
-                    <template slot="table-row" slot-scope="props">
-                        <span v-if="props.column.html" v-html="props.formattedRow[props.column.field]" />
-                        <span v-else-if="props.column.field == 'channel'">
-                            #{{props.formattedRow[props.column.field]}}
-                        </span>
-                        <span v-else>
-                            {{props.formattedRow[props.column.field]}}
-                        </span>
-                    </template>
-
-                </VueGoodTable>
+        <div class="level is-mobile">
+            <div class="level-left">
+                <button class="button" v-on:click="refresh()" v-bind:class="{ 'is-loading': isLoading }">Refresh</button>
             </div>
-        </section>
+        </div>
+
+        <VueGoodTable v-bind:columns="mappedColumns" v-bind:rows="recordsPage.records" v-bind:sortOptions="sortOptions"
+                        v-bind:paginationOptions="paginationOptions" styleClass="vgt-table condensed bordered striped deleted-messages"
+                        mode="remote" v-bind:totalRows="recordsPage.filteredRecordCount" v-on:on-page-change="onPageChange"
+                        v-on:on-sort-change="onSortChange" v-on:on-column-filter="onColumnFilter" v-on:on-per-page-change="onPerPageChange">
+
+            <template slot="table-row" slot-scope="props">
+                <span v-if="props.column.html" v-html="props.formattedRow[props.column.field]" />
+                <span v-else-if="props.column.field == 'channel'">
+                    #{{props.formattedRow[props.column.field]}}
+                </span>
+                <span v-else>
+                    {{props.formattedRow[props.column.field]}}
+                </span>
+            </template>
+
+        </VueGoodTable>
     </div>
 </template>
 
 <script lang="ts">
-    import * as _ from 'lodash';
-    import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
-    import store from "@/app/Store";
-    import { VueGoodTable } from 'vue-good-table';
-    import DesignatedChannelMapping from '@/models/moderation/DesignatedChannelMapping';
-    import RecordsPage from '@/models/RecordsPage';
-    import DeletedMessage from '@/models/logs/DeletedMessage';
-    import LogService from '@/services/LogService';
-    import TableParameters from '@/models/TableParameters';
-    import { SortDirection } from '@/models/SortDirection';
+import * as _ from 'lodash';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import store from "@/app/Store";
+import { VueGoodTable } from 'vue-good-table';
+import DesignatedChannelMapping from '@/models/moderation/DesignatedChannelMapping';
+import RecordsPage from '@/models/RecordsPage';
+import DeletedMessage from '@/models/logs/DeletedMessage';
+import LogService from '@/services/LogService';
+import TableParameters from '@/models/TableParameters';
+import { SortDirection } from '@/models/SortDirection';
 
-    const messageResolvingRegex = /<#(\d+)>/gm;
+const messageResolvingRegex = /<#(\d+)>/gm;
 
-    function getSortDirection(direction: string): SortDirection
+function getSortDirection(direction: string): SortDirection
+{
+    return (direction == "asc")
+        ? SortDirection.Ascending
+        : SortDirection.Descending;
+}
+
+@Component({
+    components:
     {
-        return (direction == "asc")
-            ? SortDirection.Ascending
-            : SortDirection.Descending;
+        VueGoodTable
+    }
+})
+export default class DeletedMessages extends Vue
+{
+    paginationOptions: any =
+    {
+        enabled: true,
+        perPage: 10,
+        mode: 'pages'
+    };
+
+    sortOptions: any =
+    {
+        enabled: true,
+        initialSortBy: { field: 'created', type: 'desc' }
+    };
+
+    isLoading: boolean = false;
+
+    recordsPage: RecordsPage<DeletedMessage> = new RecordsPage<DeletedMessage>();
+    tableParams: TableParameters = new TableParameters();
+
+    channelCache: { [channel: string]: DesignatedChannelMapping } | null = null;
+
+    resolveMentions(description: string): string
+    {
+        let replaced = description;
+
+        if (this.channelCache)
+        {
+            replaced = description.replace(messageResolvingRegex, (sub, args: string) =>
+            {
+                let found = this.channelCache![args].name;
+
+                if (!found)
+                {
+                    found = args;
+                }
+
+                return `<span class='channel'>#${found}</span>`;
+            });
+        }
+
+        return `<span class='pre'>${replaced}</span>`;
     }
 
-    @Component({
-        components:
-        {
-            VueGoodTable
-        }
-    })
-    export default class DeletedMessages extends Vue
+    staticFilters: { [field: string]: string } = { channel: "", author: "", createdBy: "", content: "", reason: "", batchId: "" };
+
+    get mappedColumns(): Array<any>
     {
-        paginationOptions: any =
-        {
-            enabled: true,
-            perPage: 10,
-            mode: 'pages'
-        };
-
-        sortOptions: any =
-        {
-            enabled: true,
-            initialSortBy: { field: 'created', type: 'desc' }
-        };
-        
-        isLoading: boolean = false;
-
-        recordsPage: RecordsPage<DeletedMessage> = new RecordsPage<DeletedMessage>();
-        tableParams: TableParameters = new TableParameters();
-
-        channelCache: { [channel: string]: DesignatedChannelMapping } | null = null;
-
-        resolveMentions(description: string): string
-        {
-            let replaced = description;
-
-            if (this.channelCache)
+        return [
             {
-                replaced = description.replace(messageResolvingRegex, (sub, args: string) =>
+                label: 'Channel',
+                field: 'channel',
+                width: '10%',
+                filterOptions:
                 {
-                    let found = this.channelCache![args].name;
-
-                    if (!found)
-                    {
-                        found = args;
-                    }
-
-                    return `<span class='channel'>#${found}</span>`;
-                });
-            }
-
-            return `<span class='pre'>${replaced}</span>`;
-        }
-
-        staticFilters: { [field: string]: string } = { channel: "", author: "", createdBy: "", content: "", reason: "", batchId: "" };
-
-        get mappedColumns(): Array<any>
-        {
-            return [
-                {
-                    label: 'Channel',
-                    field: 'channel',
-                    width: '10%',
-                    filterOptions:
-                    {
-                        enabled: true,
-                        placeholder: "Filter",
-                        filterValue: this.staticFilters["channel"]
-                    }
-                },
-                {
-                    label: 'Author',
-                    field: 'author',
-                    width: '10%',
-                    filterOptions:
-                    {
-                        enabled: true,
-                        placeholder: "Filter",
-                        filterValue: this.staticFilters["author"]
-                    }
-                },
-                {
-                    label: 'Deleted On',
-                    field: 'created',
-                    type: 'date',
-                    width: '10%',
-                    dateInputFormat: 'YYYY-MM-DDTHH:mm:ss',
-                    dateOutputFormat: 'MM/DD/YY, h:mm:ss a'
-                },
-                {
-                    label: 'Deleted By',
-                    field: 'createdBy',
-                    width: '10%',
-                    filterOptions:
-                    {
-                        enabled: true,
-                        placeholder: "Filter",
-                        filterValue: this.staticFilters["createdBy"]
-                    }
-                },
-                {
-                    label: 'Content',
-                    field: 'content',
-                    width: '24%',
-                    formatFn: this.resolveMentions,
-                    html: true,
-                    filterOptions:
-                    {
-                        enabled: true,
-                        placeholder: "Filter",
-                        filterValue: this.staticFilters["content"]
-                    }
-                },
-                {
-                    label: 'Reason',
-                    field: 'reason',
-                    width: '24%',
-                    formatFn: this.resolveMentions,
-                    html: true,
-                    filterOptions:
-                    {
-                        enabled: true,
-                        placeholder: "Filter",
-                        filterValue: this.staticFilters["reason"]
-                    }
-                },
-                {
-                    label: 'Batch ID',
-                    field: 'batchId',
-                    type: 'number',
-                    width: '10%',
-                    filterOptions:
-                    {
-                        enabled: true,
-                        placeholder: "#",
-                        filterValue: this.staticFilters["batchId"]
-                    }
+                    enabled: true,
+                    placeholder: "Filter",
+                    filterValue: this.staticFilters["channel"]
                 }
-            ];
-        }
-
-        async refresh(): Promise<void>
-        {
-            this.isLoading = true;
-
-            this.recordsPage = await LogService.getDeletedMessages(this.tableParams);
-
-            await store.retrieveChannels();
-            this.channelCache = _.keyBy(this.$store.state.modix.channels, channel => channel.id);
-
-            this.isLoading = false;
-        }
-
-        applyFilters(): void
-        {
-            let urlParams = new URLSearchParams(window.location.search);
-
-            for (let i = 0; i < this.mappedColumns.length; i++)
+            },
             {
-                let currentField: string = this.mappedColumns[i].field;
-
-                if (urlParams.has(currentField.toLowerCase()))
+                label: 'Author',
+                field: 'author',
+                width: '10%',
+                filterOptions:
                 {
-                    this.tableParams.filters.push({ field: currentField, value: urlParams.get(currentField.toLowerCase()) || "" });
-                    this.staticFilters[currentField] = urlParams.get(currentField.toLowerCase()) || "";
+                    enabled: true,
+                    placeholder: "Filter",
+                    filterValue: this.staticFilters["author"]
+                }
+            },
+            {
+                label: 'Deleted On',
+                field: 'created',
+                type: 'date',
+                width: '10%',
+                dateInputFormat: 'YYYY-MM-DDTHH:mm:ss',
+                dateOutputFormat: 'MM/DD/YY, h:mm:ss a'
+            },
+            {
+                label: 'Deleted By',
+                field: 'createdBy',
+                width: '10%',
+                filterOptions:
+                {
+                    enabled: true,
+                    placeholder: "Filter",
+                    filterValue: this.staticFilters["createdBy"]
+                }
+            },
+            {
+                label: 'Content',
+                field: 'content',
+                width: '24%',
+                formatFn: this.resolveMentions,
+                html: true,
+                filterOptions:
+                {
+                    enabled: true,
+                    placeholder: "Filter",
+                    filterValue: this.staticFilters["content"]
+                }
+            },
+            {
+                label: 'Reason',
+                field: 'reason',
+                width: '24%',
+                formatFn: this.resolveMentions,
+                html: true,
+                filterOptions:
+                {
+                    enabled: true,
+                    placeholder: "Filter",
+                    filterValue: this.staticFilters["reason"]
+                }
+            },
+            {
+                label: 'Batch ID',
+                field: 'batchId',
+                type: 'number',
+                width: '10%',
+                filterOptions:
+                {
+                    enabled: true,
+                    placeholder: "#",
+                    filterValue: this.staticFilters["batchId"]
                 }
             }
-        }
+        ];
+    }
 
-        async created(): Promise<void>
+    async refresh(): Promise<void>
+    {
+        if (this.isLoading) { return; }
+
+        this.isLoading = true;
+
+        this.recordsPage = await LogService.getDeletedMessages(this.tableParams);
+
+        this.isLoading = false;
+    }
+
+    applyFilters(): void
+    {
+        let urlParams = new URLSearchParams(window.location.search);
+
+        for (let i = 0; i < this.mappedColumns.length; i++)
         {
-            this.applyFilters();
-            await this.refresh();
-        }
+            let currentField: string = this.mappedColumns[i].field;
 
-        async onPageChange(params: any): Promise<void>
-        {
-            this.tableParams.page = params.currentPage - 1;
-
-            await this.refresh();
-        }
-
-        async onSortChange(params: any): Promise<void>
-        {
-            this.tableParams.sort.field = this.mappedColumns[params.columnIndex].field;
-            this.tableParams.sort.direction = getSortDirection(params.sortType);
-
-            await this.refresh();
-        }
-
-        async onColumnFilter(params: any): Promise<void>
-        {
-            this.tableParams.filters = [];
-
-            for (let prop in params.columnFilters)
+            if (urlParams.has(currentField.toLowerCase()))
             {
-                this.tableParams.filters.push({ field: prop, value: params.columnFilters[prop] })
+                this.tableParams.filters.push({ field: currentField, value: urlParams.get(currentField.toLowerCase()) || "" });
+                this.staticFilters[currentField] = urlParams.get(currentField.toLowerCase()) || "";
             }
-
-            await this.refresh();
-        }
-
-        async onPerPageChange(params: any): Promise<void>
-        {
-            this.tableParams.perPage = (params.currentPerPage == "all")
-                ? 2147483647
-                : params.currentPerPage;
-
-            await this.refresh();
         }
     }
+
+    async created(): Promise<void>
+    {
+        this.applyFilters();
+        await this.refresh();
+
+        await store.retrieveChannels();
+        this.channelCache = _.keyBy(this.$store.state.modix.channels, channel => channel.id);
+    }
+
+    async onPageChange(params: any): Promise<void>
+    {
+        this.tableParams.page = params.currentPage - 1;
+
+        await this.refresh();
+    }
+
+    async onSortChange(params: any): Promise<void>
+    {
+        this.tableParams.sort.field = params[0].field;
+        this.tableParams.sort.direction = getSortDirection(params[0].type);
+
+        await this.refresh();
+    }
+
+    async onColumnFilter(params: any): Promise<void>
+    {
+        this.tableParams.filters = [];
+
+        for (let prop in params.columnFilters)
+        {
+            this.tableParams.filters.push({ field: prop, value: params.columnFilters[prop] })
+        }
+
+        await this.refresh();
+    }
+
+    async onPerPageChange(params: any): Promise<void>
+    {
+        this.tableParams.perPage = (params.currentPerPage == "all")
+            ? 2147483647
+            : params.currentPerPage;
+
+        await this.refresh();
+    }
+}
 </script>

--- a/Modix/ClientApp/src/components/Logs/DeletedMessages.vue
+++ b/Modix/ClientApp/src/components/Logs/DeletedMessages.vue
@@ -27,6 +27,7 @@
 
 <script lang="ts">
 import * as _ from 'lodash';
+import { resolveMentions } from '@/app/Util';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import store from "@/app/Store";
 import { VueGoodTable } from 'vue-good-table';
@@ -76,24 +77,7 @@ export default class DeletedMessages extends Vue
 
     resolveMentions(description: string): string
     {
-        let replaced = description;
-
-        if (this.channelCache)
-        {
-            replaced = description.replace(messageResolvingRegex, (sub, args: string) =>
-            {
-                let found = this.channelCache![args].name;
-
-                if (!found)
-                {
-                    found = args;
-                }
-
-                return `<span class='channel'>#${found}</span>`;
-            });
-        }
-
-        return `<span class='pre'>${replaced}</span>`;
+        return resolveMentions(this.channelCache ,description);
     }
 
     staticFilters: { [field: string]: string } = { channel: "", author: "", createdBy: "", content: "", reason: "", batchId: "" };

--- a/Modix/ClientApp/src/components/Logs/Infractions.vue
+++ b/Modix/ClientApp/src/components/Logs/Infractions.vue
@@ -188,6 +188,7 @@
 
 <script lang="ts">
 import * as _ from 'lodash';
+import { resolveMentions } from '@/app/Util';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import HeroHeader from '@/components/HeroHeader.vue';
 import TinyUserView from '@/components/TinyUserView.vue';
@@ -206,8 +207,6 @@ import InfractionCreationData from '@/models/infractions/InfractionCreationData'
 import RecordsPage from '@/models/RecordsPage';
 import TableParameters from '@/models/TableParameters';
 import { SortDirection } from '@/models/SortDirection';
-
-const messageResolvingRegex = /<#(\d+)>/gm;
 
 function getSortDirection(direction: string): SortDirection
 {
@@ -393,24 +392,7 @@ export default class Infractions extends Vue
 
     resolveMentions(description: string)
     {
-        let replaced = description;
-
-        if (this.channelCache)
-        {
-            replaced = description.replace(messageResolvingRegex, (sub, args: string) =>
-            {
-                if (this.channelCache == null || this.channelCache[args] == null)
-                {
-                    return args;
-                }
-
-                let found = (this.channelCache[args] ? this.channelCache[args].name : args);
-
-                return `<span class='channel'>#${found}</span>`;
-            });
-        }
-
-        return `<span class='pre'>${replaced}</span>`;
+        return resolveMentions(this.channelCache, description);
     }
 
     fileChange(input: HTMLInputElement)

--- a/Modix/ClientApp/src/components/Logs/Infractions.vue
+++ b/Modix/ClientApp/src/components/Logs/Infractions.vue
@@ -1,59 +1,54 @@
 <template>
-    <div>
-        <section class="section">
-            <div class="container">
-
-                <div class="level is-mobile">
-                    <div class="level-left">
-                        <button class="button" v-if="canCreate" v-on:click="showCreateModal = true">Create</button>
-                        &nbsp;
-                        <button class="button" @click="refresh()" :class="{'is-loading': isLoading}">Refresh</button>
-                        &nbsp;
-                        <button class="button" disabled title="Coming Soon™" @click="showModal = true">Import</button>
-                    </div>
-                    <div class="level-right">
-                        <label>
-                            Show State
-                            <input type="checkbox" v-model="showState">
-                        </label> &nbsp;&nbsp;
-                        <label>
-                            Show Deleted
-                            <input type="checkbox" v-model="showDeleted">
-                        </label>
-                    </div>
-                </div>
-
-                <VueGoodTable :columns="mappedColumns" :rows="mappedRows" :sortOptions="sortOptions"
-                              :paginationOptions="paginationOptions" styleClass="vgt-table condensed bordered striped"
-                              mode="remote" :totalRows="recordsPage.filteredRecordCount" @on-page-change="onPageChange"
-                              @on-sort-change="onSortChange" @on-column-filter="onColumnFilter" @on-per-page-change="onPerPageChange">
-
-                    <template slot="table-row" slot-scope="props">
-                        <span v-if="props.column.field == 'type'">
-                            <span :title="props.formattedRow[props.column.field]" class="typeCell"
-                                  v-html="emojiFor(props.formattedRow[props.column.field]) + ' ' + props.formattedRow[props.column.field]">
-                            </span>
-                        </span>
-                        <span v-else-if="props.column.field == 'reason'" v-html="props.formattedRow[props.column.field]">
-                        </span>
-                        <span v-else-if="props.column.field == 'actions'">
-                            <span class="level">
-                                <button class="button is-link is-small level-left" v-show="props.row.canDelete" v-on:click="onInfractionDelete(props.row.id)">
-                                    Delete
-                                </button>
-                                <button class="button is-link is-small level-right" v-if="props.row.canRescind" v-on:click="onInfractionRescind(props.row.id)">
-                                    Rescind
-                                </button>
-                            </span>
-                        </span>
-                        <span v-else>
-                            {{props.formattedRow[props.column.field]}}
-                        </span>
-                    </template>
-
-                </VueGoodTable>
+    <div class="infractions">
+        <div class="level is-mobile">
+            <div class="level-left">
+                <button class="button" v-if="canCreate" v-on:click="showCreateModal = true">Create</button>
+                &nbsp;
+                <button class="button" @click="refresh()" :class="{'is-loading': isLoading}">Refresh</button>
+                &nbsp;
+                <button class="button" disabled title="Coming Soon™" @click="showModal = true">Import</button>
             </div>
-        </section>
+            <div class="level-right">
+                <label>
+                    Show State
+                    <input type="checkbox" v-model="showState">
+                </label> &nbsp;&nbsp;
+                <label>
+                    Show Deleted
+                    <input type="checkbox" v-model="showDeleted">
+                </label>
+            </div>
+        </div>
+
+        <VueGoodTable :columns="mappedColumns" :rows="mappedRows" :sortOptions="sortOptions"
+                        :paginationOptions="paginationOptions" styleClass="vgt-table condensed bordered striped"
+                        mode="remote" :totalRows="recordsPage.filteredRecordCount" @on-page-change="onPageChange"
+                        @on-sort-change="onSortChange" @on-column-filter="onColumnFilter" @on-per-page-change="onPerPageChange">
+
+            <template slot="table-row" slot-scope="props">
+                <span v-if="props.column.field == 'type'">
+                    <span :title="props.formattedRow[props.column.field]" class="typeCell"
+                            v-html="emojiFor(props.formattedRow[props.column.field]) + ' ' + props.formattedRow[props.column.field]">
+                    </span>
+                </span>
+                <span v-else-if="props.column.field == 'reason'" v-html="props.formattedRow[props.column.field]">
+                </span>
+                <span v-else-if="props.column.field == 'actions'">
+                    <span class="level">
+                        <button class="button is-link is-small level-left" v-show="props.row.canDelete" v-on:click="onInfractionDelete(props.row.id)">
+                            Delete
+                        </button>
+                        <button class="button is-link is-small level-right" v-if="props.row.canRescind" v-on:click="onInfractionRescind(props.row.id)">
+                            Rescind
+                        </button>
+                    </span>
+                </span>
+                <span v-else>
+                    {{props.formattedRow[props.column.field]}}
+                </span>
+            </template>
+
+        </VueGoodTable>
 
         <div class="modal" :class="{'is-active': showModal}">
             <div class="modal-background" @click="showModal = !showModal"></div>
@@ -461,6 +456,7 @@ export default class Infractions extends Vue
                 field: 'id',
                 sortFn: (x: number, y: number) => (x < y ? -1 : (x > y ? 1 : 0)),
                 type: 'number',
+                width: '10%',
                 filterOptions:
                 {
                     enabled: true,
@@ -471,6 +467,7 @@ export default class Infractions extends Vue
             {
                 label: 'Type',
                 field: 'type',
+                width: '10%',
                 filterOptions:
                 {
                     enabled: true,
@@ -483,9 +480,9 @@ export default class Infractions extends Vue
                 label: 'Created On',
                 field: 'date',
                 type: 'date', //Needed to bypass vue-good-table regression
+                width: '20%',
                 dateInputFormat: 'YYYY-MM-DDTHH:mm:ss',
-                dateOutputFormat: 'MM/DD/YY, h:mm:ss a',
-                width: '160px'
+                dateOutputFormat: 'MM/DD/YY, h:mm:ss a'
             },
             {
                 label: 'Subject',
@@ -514,6 +511,7 @@ export default class Infractions extends Vue
             {
                 label: 'Reason',
                 field: 'reason',
+                width: '50%',
                 formatFn: this.resolveMentions,
                 html: true,
                 sortable: false
@@ -596,13 +594,11 @@ export default class Infractions extends Vue
 
     async refresh()
     {
+        if (this.isLoading) { return; }
+
         this.isLoading = true;
 
         this.recordsPage = await GeneralService.getInfractions(this.tableParams);
-
-        await store.retrieveChannels();
-
-        this.channelCache = _.keyBy(this.$store.state.modix.channels, channel => channel.id);
 
         this.clearNewInfractionData();
 
@@ -643,6 +639,9 @@ export default class Infractions extends Vue
 
         this.showState = config().showInfractionState;
         this.showDeleted = config().showDeletedInfractions;
+
+        await store.retrieveChannels();
+        this.channelCache = _.keyBy(this.$store.state.modix.channels, channel => channel.id);
 
         this.applyFilters();
     }

--- a/Modix/ClientApp/src/components/Logs/Tabs.vue
+++ b/Modix/ClientApp/src/components/Logs/Tabs.vue
@@ -79,11 +79,6 @@ export default class Tabs extends Vue
 
         return "Required Claims: " + route.requiredClaims.toString();
     }
-
-    mounted()
-    {
-
-    }
 }
 
 </script>

--- a/Modix/ClientApp/src/components/Logs/Tabs.vue
+++ b/Modix/ClientApp/src/components/Logs/Tabs.vue
@@ -1,20 +1,30 @@
 <template>
     <div class="section">
 
-        <div class="tabs">
-            <ul>
-                <li v-for="route in routes" v-bind:key="route.path">
-                    <router-link v-bind:class="{ 'is-disabled': !hasClaimsForRoute(route) }" v-tooltip.right-end="claimsFor(route)"
-                                 v-bind:key="route.routeData.name" v-bind:to="{ 'name': route.routeData.name }" exact-active-class="is-active"
-                                 v-bind:event="!hasClaimsForRoute(route) ? '' : 'click'">
-                        {{toTitleCase(route.title)}}
-                    </router-link>
-                </li>
-            </ul>
-        </div>
+        <div class="columns">
+            <div class="column is-narrow">
+                <aside class="menu">
+                    <div>
+                        <p class="menu-label">
+                            Logs
+                        </p>
+                        <ul class="menu-list">
+                            <li v-for="route in routes" v-bind:key="route.path">
+                                <router-link v-bind:class="{ 'is-disabled': !hasClaimsForRoute(route) }" v-tooltip.right-end="claimsFor(route)"
+                                            v-bind:key="route.routeData.name" v-bind:to="{ 'name': route.routeData.name }" exact-active-class="is-active"
+                                            v-bind:event="!hasClaimsForRoute(route) ? '' : 'click'">
+                                    {{toTitleCase(route.title)}}
+                                </router-link>
+                            </li>
+                        </ul>
+                    </div>
+                </aside>
+            </div>
 
-        <div class="container">
-            <router-view />
+            <div class="column">
+                <router-view />
+            </div>
+
         </div>
 
     </div>
@@ -22,53 +32,58 @@
 
 <script lang="ts">
 
-    import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
-    import ModixRoute from '@/app/ModixRoute';
-    import { toTitleCase } from '@/app/Util';
-    import store from "@/app/Store";
-    import * as _ from 'lodash';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
+import ModixRoute from '@/app/ModixRoute';
+import { toTitleCase } from '@/app/Util';
+import store from "@/app/Store";
+import * as _ from 'lodash';
 
-    @Component({})
-    export default class Tabs extends Vue
+@Component({})
+export default class Tabs extends Vue
+{
+    @Prop({ default: "" })
+    public title!: string;
+
+    @Prop({ default: "" })
+    public routeName!: string;
+
+    get routes(): ModixRoute[]
     {
-        @Prop({ default: "" })
-        public title!: string;
+        let allRoutes = (<any>this.$router).options.routes;
+        let currentChildren = _.find(allRoutes, route => route.name == this.routeName).children;
 
-        @Prop({ default: "" })
-        public routeName!: string;
-
-        get routes(): ModixRoute[]
-        {
-            let allRoutes = (<any>this.$router).options.routes;
-            let currentChildren = _.find(allRoutes, route => route.name == this.routeName).children;
-
-            return <any>_.map(currentChildren, child => child.meta as ModixRoute);
-        }
-
-        hasClaimsForRoute(route: ModixRoute): boolean
-        {
-            return store.userHasClaims(route.routeData.requiredClaims || []);
-        }
-
-        toTitleCase(input: string): string
-        {
-            return toTitleCase(input);
-        }
-
-        claimsFor(route: ModixRoute): string
-        {
-            if (this.hasClaimsForRoute(route))
-            {
-                return "";
-            }
-
-            if (!route.routeData.requiredClaims)
-            {
-                return "Disallowed";
-            }
-
-            return "Required Claims: " + route.routeData.requiredClaims.toString();
-        }
+        return <any>_.map(currentChildren, child => child.meta as ModixRoute);
     }
+
+    hasClaimsForRoute(route: ModixRoute): boolean
+    {
+        return store.userHasClaims(route.requiredClaims);
+    }
+
+    toTitleCase(input: string): string
+    {
+        return toTitleCase(input);
+    }
+
+    claimsFor(route: ModixRoute): string
+    {
+        if (this.hasClaimsForRoute(route))
+        {
+            return "";
+        }
+
+        if (route.requiredClaims.length == 0)
+        {
+            return "Disallowed";
+        }
+
+        return "Required Claims: " + route.requiredClaims.toString();
+    }
+
+    mounted()
+    {
+
+    }
+}
 
 </script>

--- a/Modix/ClientApp/src/components/MiniProfile.vue
+++ b/Modix/ClientApp/src/components/MiniProfile.vue
@@ -1,9 +1,11 @@
 <template>
     <div class="profile">
         <template v-if="user && user.userId">
-            <img class="avatar-icon" v-if="user.avatarHash" :src="user.avatarUrl">
+
 
             <v-popover>
+                <img class="avatar-icon" v-if="user.avatarHash" :src="user.avatarUrl">
+
                 <p class="title is-4">
                     <span class="username">
                         {{user.name}}

--- a/Modix/ClientApp/src/components/Promotions/PromotionCommentEditModal.vue
+++ b/Modix/ClientApp/src/components/Promotions/PromotionCommentEditModal.vue
@@ -1,11 +1,11 @@
 ﻿<template>
     <div class="modal" v-bind:class="{'is-active': showUpdateModal}">
-        <div class="modal-background" v-on:click="showUpdateModal = false" />
+        <div class="modal-background" v-on:click="close()" />
         <div class="modal-card">
             <header class="modal-card-head">
                 <p class="modal-card-title">Edit Comment</p>
 
-                <button class="delete" aria-label="close" v-on:click="showUpdateModal = false"></button>
+                <button class="delete" aria-label="close" v-on:click="close()"></button>
             </header>
 
             <section class="modal-card-body control">
@@ -31,7 +31,7 @@
 
             <footer class="modal-card-foot level">
                 <div class="level-left">
-                    <button class="button" v-on:click="showUpdateModal = false">Cancel</button>
+                    <button class="button" v-on:click="close()">Cancel</button>
                 </div>
                 <div class="level-right">
                     <button class="button is-success" v-bind:class="{'is-loading': loadingCommentUpdate}"
@@ -92,6 +92,11 @@ export default class PromotionCommentEditModal extends Vue
     get allowUpdate(): boolean
     {
         return this.newComment.body.length > 3;
+    }
+
+    close()
+    {
+        this.$emit('comment-edit-modal-closed');
     }
 
     async updateComment()

--- a/Modix/ClientApp/src/models/User.ts
+++ b/Modix/ClientApp/src/models/User.ts
@@ -8,6 +8,6 @@ export default class User
 
     get avatarUrl(): string
     {
-        return `https://cdn.discordapp.com/avatars/${this.userId}/${this.avatarHash}`;
+        return this.avatarHash;
     }
 }

--- a/Modix/ClientApp/src/models/User.ts
+++ b/Modix/ClientApp/src/models/User.ts
@@ -5,9 +5,4 @@ export default class User
     avatarHash: string = "";
     claims: string[] = [];
     selectedGuild: string = "";
-
-    get avatarUrl(): string
-    {
-        return this.avatarHash;
-    }
 }

--- a/Modix/ClientApp/src/services/GeneralService.ts
+++ b/Modix/ClientApp/src/services/GeneralService.ts
@@ -129,6 +129,3 @@ export default class GeneralService
         return (await client.get(`infractions/${subjectId}/doesModeratorOutrankUser`)).data;
     }
 }
-
-//For debugging
-(<any>window).service = GeneralService;

--- a/Modix/ClientApp/src/services/LogService.ts
+++ b/Modix/ClientApp/src/services/LogService.ts
@@ -11,6 +11,3 @@ export default class LogService
         return (await client.put(`logs/deletedMessages`, tableParams)).data;
     }
 }
-
-//For debugging
-(<any>window).service = LogService;

--- a/Modix/ClientApp/src/services/TagService.ts
+++ b/Modix/ClientApp/src/services/TagService.ts
@@ -26,6 +26,3 @@ export default class TagService
         await client.delete(`tags/${name}`);
     }
 }
-
-//For debugging
-(<any>window).service = TagService;

--- a/Modix/ClientApp/src/styles/components/infractions.scss
+++ b/Modix/ClientApp/src/styles/components/infractions.scss
@@ -16,9 +16,9 @@
     }
 }
 
-.vgt-responsive
+.vgt-wrap
 {
-    @include fullwidth-desktop();
+    width: 100%;
 }
 
 .vgt-input, .vgt-select

--- a/Modix/ClientApp/src/styles/components/infractions.scss
+++ b/Modix/ClientApp/src/styles/components/infractions.scss
@@ -40,7 +40,7 @@
     }
 }
 
-.channel
+.channel, .userMention
 {
     font-weight: bold;
 }

--- a/Modix/ClientApp/src/styles/components/miniProfile.scss
+++ b/Modix/ClientApp/src/styles/components/miniProfile.scss
@@ -27,6 +27,13 @@
     {
         margin-bottom: 0;
     }
+
+    .v-popover .trigger
+    {
+        display: flex !important;
+        flex-direction: row;
+        align-items: center;
+    }
 }
 
 .options .option

--- a/Modix/ClientApp/src/styles/components/promotionListItem.scss
+++ b/Modix/ClientApp/src/styles/components/promotionListItem.scss
@@ -1,3 +1,5 @@
+$transition: all 0.33s cubic-bezier(0.23, 1, 0.32, 1);
+
 .commentBox
 {
     flex-basis: 100%;
@@ -17,17 +19,11 @@
 {
     position: relative;
     left: 8px;
-
-    @include mobile()
-    {
-        left: 16px;
-        top: -12px;
-    }
 }
 
 .ratings
 {
-    padding: 0.85rem 0.75rem 0em 0.75em;
+    padding: 0.5rem 0.75rem 0em 0.75em;
 
     .rating
     {
@@ -42,19 +38,19 @@
 
     @include mobile()
     {
-        margin-top: 0.5em;
+        margin-top: 0em;
+        margin-right: 0.5em;
     }
 }
 
 .campaign
 {
     position: relative;
-    padding: 1.35em 1.2em 1.2em 1.2em;
+    padding: 1.35em 1.2em 0.5em 1.2em;
 
-    max-height: 70px;
     overflow: hidden;
 
-    transition: box-shadow 0.33s cubic-bezier(0.23, 1, 0.32, 1);
+    transition: $transition;
 
     & > .columns
     {
@@ -64,14 +60,27 @@
     &.expanded
     {
         box-shadow: 0px 0px 24px rgba(0, 0, 0, 0.33);
-        max-height: none;
-
-        //overflow-y: auto;
 
         & .comment
         {
             transform: rotateZ(0deg);
             opacity: 1;
+        }
+
+        .details
+        {
+            max-height: 9999px;
+            overflow: visible;
+        }
+
+        @include mobile()
+        {
+            max-height: 9999px;
+
+            .adminButtons, .ratings
+            {
+                display: block;
+            }
         }
     }
 
@@ -98,6 +107,11 @@
         margin-bottom: -10px;
     }
 
+    .title
+    {
+        margin-bottom: 0;
+    }
+
     .toRole
     {
         font-size: 14px;
@@ -113,16 +127,81 @@
 
         @include mobile()
         {
-            display: table;
-
-            margin-left: 2em;
-            margin-top: -0.6em;
+            display: inline-block;
         }
+    }
+
+    .expander
+    {
+        top: 0px;
+    }
+
+    .nameBar
+    {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        line-height: normal;
+
+        .roleColumn
+        {
+            white-space: nowrap;
+        }
+
+        .leftSide
+        {
+            display: flex;
+            flex-direction: row;
+            align-items: flex-start;
+
+            @include mobile()
+            {
+                flex-basis: 50%;
+                flex-grow: 1;
+            }
+        }
+
+        @include mobile()
+        {
+            align-items: flex-start;
+        }
+    }
+
+    .details
+    {
+        transition: $transition;
+        max-height: 0px;
+        overflow: hidden;
+    }
+
+    .titleBar
+    {
+        margin-bottom: 0;
+        display: flex;
+        align-items: center;
+    }
+
+    .commentLoader
+    {
+        display: inline-block;
+        width: 32px;
     }
 
     @include mobile()
     {
-        padding: 1em;
+        padding: 1.25em 0.5em 0.5em 1em;
+        margin: 0;
+
+        .adminButtons, .ratings
+        {
+            transition: $transition;
+            display: none;
+        }
+
+        .nameBar
+        {
+            padding: 12px 12px 0 12px;
+        }
     }
 }
 
@@ -134,6 +213,7 @@
 .statusIcon
 {
     display: inline-block;
+    font-size: 1.5em;
     width: 1.3em;
 }
 
@@ -145,13 +225,13 @@
 .adminButtons
 {
     margin-top: 0.1em;
+    margin-left: 0.75em;
 }
 
 .mobile-expander
 {
-    display: block;
-    float: right;
     margin-right: 0.5em;
+    margin-left: 1.75em;
 
     @include tablet()
     {

--- a/Modix/ClientApp/src/styles/variables.scss
+++ b/Modix/ClientApp/src/styles/variables.scss
@@ -9,28 +9,9 @@ $box-shadow: 0 2px 3px rgba($black, 0.1), 0 0 0 1px rgba($black, 0.1) !default;
     opacity: 1;
 }
 
-@mixin fullwidth-desktop()
-{
-    @include widescreen-only
-    {
-        width: 96vw;
-
-        margin-left: calc(-96vw / 2 + 1152px / 2);
-        margin-right: calc(-96vw / 2 + 1152px / 2);
-    }
-
-    @include fullhd
-    {
-        width: 96vw;
-
-        margin-left: calc(-96vw / 2 + 1344px / 2);
-        margin-right: calc(-96vw / 2 + 1344px / 2);
-    }
-}
-
 @mixin tiny()
 {
-    @media screen and (max-width: 450px)
+    @media screen and (max-width: 550px)
     {
         @content
     }
@@ -97,7 +78,7 @@ a.is-disabled
 
     vertical-align: top;
     position: relative;
-    top: 10px;
+    top: 0.66em;
 }
 
 @keyframes fadeIn

--- a/Modix/ClientApp/src/tslint.json
+++ b/Modix/ClientApp/src/tslint.json
@@ -1,0 +1,3 @@
+{
+  "defaultSeverity": "off"
+}

--- a/Modix/ClientApp/src/views/Configuration/Configuration.vue
+++ b/Modix/ClientApp/src/views/Configuration/Configuration.vue
@@ -67,7 +67,7 @@ export default class Configuration extends Vue
 
     hasClaimsForRoute(route: ModixRoute): boolean
     {
-        return store.userHasClaims(route.routeData.requiredClaims || []);
+        return store.userHasClaims(route.requiredClaims || []);
     }
 
     toTitleCase(input: string)
@@ -82,12 +82,12 @@ export default class Configuration extends Vue
             return "";
         }
 
-        if (!route.routeData.requiredClaims)
+        if (!route.requiredClaims)
         {
             return "Disallowed";
         }
 
-        return "Required Claims: " + route.routeData.requiredClaims.toString();
+        return "Required Claims: " + route.requiredClaims.toString();
     }
 }
 </script>

--- a/Modix/ClientApp/src/views/Promotions.vue
+++ b/Modix/ClientApp/src/views/Promotions.vue
@@ -32,16 +32,14 @@
 
                 </div>
 
-                <a v-if="loading" class="button is-loading campaignLoader"></a>
+                <a v-if="loading" class="button is-primary is-loading campaignLoader"></a>
 
                 <p v-else-if="campaigns.length == 0">
                     There's no active campaigns at the moment. You could start one, though!
                 </p>
-                <div v-else>
-                    <PromotionListItem v-for="campaign in campaigns" :campaign="campaign" :key="campaign.id"
-                                       :dialogLoading="currentlyLoadingInfractions == campaign.id" @commentSubmitted="refresh()" @showPanel="showPanel(campaign)"
-                                       v-on:comment-edit-modal-opened="onCommentEditModalOpened" />
-                </div>
+                <PromotionListItem v-for="campaign in campaigns" :campaign="campaign" :key="campaign.id"
+                                   :dialogLoading="currentlyLoadingInfractions == campaign.id" @commentSubmitted="refresh()" @showPanel="showPanel(campaign)"
+                                   v-on:comment-edit-modal-opened="onCommentEditModalOpened" />
             </div>
         </section>
 

--- a/Modix/ClientApp/src/views/Tags/Tags.vue
+++ b/Modix/ClientApp/src/views/Tags/Tags.vue
@@ -127,6 +127,7 @@
 
 <script lang="ts">
 import * as _ from 'lodash';
+import { resolveMentions } from '@/app/Util';
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import HeroHeader from '@/components/HeroHeader.vue';
 import TinyUserView from '@/components/TinyUserView.vue';
@@ -212,24 +213,7 @@ export default class Tags extends Vue
 
     resolveMentions(description: string)
     {
-        let replaced = description;
-
-        if (this.channelCache)
-        {
-            replaced = description.replace(messageResolvingRegex, (sub, args: string) =>
-            {
-                if (this.channelCache == null || this.channelCache[args] == null)
-                {
-                    return args;
-                }
-
-                let found = (this.channelCache[args] ? this.channelCache[args].name : args);
-
-                return `<span class='channel'>#${found}</span>`;
-            });
-        }
-
-        return `<span class='pre'>${replaced}</span>`;
+        return resolveMentions(this.channelCache, description);
     }
 
     staticFilters: {[field: string]: string} = {name: "", creator: "", content: ""};

--- a/Modix/ClientApp/vue.config.js
+++ b/Modix/ClientApp/vue.config.js
@@ -19,6 +19,11 @@ module.exports = {
         extract: false
     },
 
+    configureWebpack:
+    {
+        devtool: 'source-map'
+    },
+
     chainWebpack: config =>
     {
         config.resolve

--- a/Modix/Controllers/AutocompleteController.cs
+++ b/Modix/Controllers/AutocompleteController.cs
@@ -48,7 +48,7 @@ namespace Modix.Controllers
                 : UserGuild.Users
                     .Where(d => d.Username.OrdinalContains(query))
                     .Take(10)
-                    .Select(d => new ModixUser { Name = $"{d.Username}#{d.Discriminator}", UserId = d.Id, AvatarHash = d.AvatarId });
+                    .Select(d => ModixUser.FromSocketGuildUser(d));
 
             return Ok(result);
         }

--- a/Modix/Controllers/ModixController.cs
+++ b/Modix/Controllers/ModixController.cs
@@ -57,6 +57,7 @@ namespace Modix.Controllers
             //Do it again here to assign claims (this is very lazy of us)
             ModixUser = ModixUser.FromClaimsPrincipal(HttpContext.User);
             ModixUser.SelectedGuild = SocketUser.Guild.Id;
+            ModixUser.AvatarHash = SocketUser.GetAvatarUrl() ?? SocketUser.GetDefaultAvatarUrl();
 
             await next();
         }

--- a/Modix/Models/ModixUser.cs
+++ b/Modix/Models/ModixUser.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using Discord;
+using Discord.WebSocket;
 
 namespace Modix.Models
 {
@@ -20,8 +22,19 @@ namespace Modix.Models
             {
                 Name = user.Identity.Name,
                 UserId = ulong.Parse(user.Claims.FirstOrDefault(d => d.Type == ClaimTypes.NameIdentifier).Value),
-                AvatarHash = user.Claims.FirstOrDefault(d=>d.Type == "avatarHash")?.Value ?? "",
                 Claims = user.Claims.Where(d=>d.Type == ClaimTypes.Role).Select(d=>d.Value).ToList()
+            };
+
+            return ret;
+        }
+
+        public static ModixUser FromSocketGuildUser(SocketGuildUser user)
+        {
+            var ret = new ModixUser
+            {
+                Name = $"{user.Username}#{user.Discriminator}",
+                UserId = user.Id,
+                AvatarHash = user.GetAvatarUrl() ?? user.GetDefaultAvatarUrl()
             };
 
             return ret;


### PR DESCRIPTION
### Frontend
- Improve performance of promotions page by making comments only load when a campaign is expanded
- Improve / centralize resolving of discord channel, user, and URL tags 
- Move Infractions to Logs page
- Add Redirect route type (currently to redirect `/infractions` to `/logs/infractions`)
- Added `isButton ` property to `ModixRoute.ts` - if set, the route will show up on the right side of the navbar (the title should be an emoji)
- Add optional claims to routes - these are claims that the user needs to have at least one of (instead of all of) for the route to show up in navigation. This is automatically populated with the route's children's required claims.
- Stopped checking for login twice on load by removing the check from the root App component
- Set devtool to source-map in `vue.config.js` to allow debugging from vscode
- Add `tslint.json` with `"defaultSeverity"` set to off to stop VSCode from yelling (we can figure out standards later)
- Various minor layout improvements, and improvements to cases where table filtering/sorting wasn't working

### Backend
- `DeletedMessageSummary` sort fields are now named by the actual property rather than the navigation property
- Deleting a Ban infraction will not try to remove the ban if the infraction was already rescinded
- Removed explicit `"identify"` scope from `ModixAuthenticationExtensions` because it comes implicitly from `DiscordAuthenticationOptions`
- Added `ModixUser.FromSocketGuildUser`, used in `AutocompleteController`
- Retrieve avatar URLs from discord.net instead of OAuth

Reviewer Protip: hide whitespace changes.