### PR TITLE
Refactored quoteservice/autoremovemessage behavior-related stuff

### DIFF
--- a/Modix.Bot/Modules/IlModule.cs
+++ b/Modix.Bot/Modules/IlModule.cs
@@ -86,6 +86,8 @@ namespace Modix.Modules
 
             var embed = await BuildEmbed(guildUser, code, parsedResult);
 
+            await _autoRemoveMessageService.RegisterRemovableMessageAsync(message, Context.User, embed);
+
             await message.ModifyAsync(a =>
             {
                 a.Content = string.Empty;
@@ -93,8 +95,6 @@ namespace Modix.Modules
             });
 
             await Context.Message.DeleteAsync();
-
-            await _autoRemoveMessageService.RegisterRemovableMessageAsync(message, Context.User);
         }
 
         private async Task<EmbedBuilder> BuildEmbed(SocketGuildUser guildUser, string code, string result)
@@ -113,8 +113,6 @@ namespace Modix.Modules
                  .WithValue(Format.Code(result.TruncateTo(990), "asm")));
 
             await embed.UploadToServiceIfBiggerThan(result, "asm", 990, _pasteService);
-
-            embed.WithFooter("React with ❌ to remove this embed.");
 
             return embed;
         }

--- a/Modix.Bot/Modules/QuoteModule.cs
+++ b/Modix.Bot/Modules/QuoteModule.cs
@@ -64,9 +64,8 @@ namespace Modix.Modules
         {
             if (message != null)
             {
-                var quoteEmbed = _quoteService.BuildQuoteEmbed(message, Context.User);
-
-                await ReplyAsync(string.Empty, false, quoteEmbed.Build());
+                await _quoteService.BuildRemovableEmbed(message, Context.User,
+                    async (embed) => await ReplyAsync(embed: embed?.Build()));
             }
             else
             {

--- a/Modix.Bot/Modules/ReplModule.cs
+++ b/Modix.Bot/Modules/ReplModule.cs
@@ -100,6 +100,8 @@ namespace Modix.Modules
 
             var embed = await BuildEmbed(guildUser, parsedResult);
 
+            await _autoRemoveMessageService.RegisterRemovableMessageAsync(message, Context.User, embed);
+
             await message.ModifyAsync(a =>
             {
                 a.Content = string.Empty;
@@ -107,8 +109,6 @@ namespace Modix.Modules
             });
 
             await Context.Message.DeleteAsync();
-
-            await _autoRemoveMessageService.RegisterRemovableMessageAsync(message, Context.User);
         }
 
         private async Task<EmbedBuilder> BuildEmbed(SocketGuildUser guildUser, Result parsedResult)
@@ -121,8 +121,7 @@ namespace Modix.Modules
                 .WithDescription(string.IsNullOrEmpty(parsedResult.Exception) ? "Successful" : "Failed")
                 .WithColor(string.IsNullOrEmpty(parsedResult.Exception) ? new Color(0, 255, 0) : new Color(255, 0, 0))
                 .WithAuthor(a => a.WithIconUrl(Context.User.GetAvatarUrl()).WithName(guildUser?.Nickname ?? Context.User.Username))
-                .WithFooter(a => a.WithText($"Compile: {parsedResult.CompileTime.TotalMilliseconds:F}ms | Execution: {parsedResult.ExecutionTime.TotalMilliseconds:F}ms"
-                    + " | React with ❌ to remove this embed."));
+                .WithFooter(a => a.WithText($"Compile: {parsedResult.CompileTime.TotalMilliseconds:F}ms | Execution: {parsedResult.ExecutionTime.TotalMilliseconds:F}ms"));
 
             embed.AddField(a => a.WithName("Code").WithValue(Format.Code(parsedResult.Code, "cs")));
 

--- a/Modix.Services/AutoRemoveMessage/AutoRemoveMessageService.cs
+++ b/Modix.Services/AutoRemoveMessage/AutoRemoveMessageService.cs
@@ -18,7 +18,7 @@ namespace Modix.Services.AutoRemoveMessage
         /// <returns>
         /// A <see cref="Task"/> that will complete when the operation completes.
         /// </returns>
-        Task RegisterRemovableMessageAsync(IMessage message, IUser user);
+        Task<EmbedBuilder> RegisterRemovableMessageAsync(IMessage message, IUser user, EmbedBuilder embed);
 
         /// <summary>
         /// Unregisters a removable message from the service.
@@ -33,18 +33,32 @@ namespace Modix.Services.AutoRemoveMessage
     /// <inheritdoc />
     internal class AutoRemoveMessageService : IAutoRemoveMessageService
     {
+        private const string _footerReactMessage = "React with ❌ to remove this embed.";
+
         public AutoRemoveMessageService(INotificationDispatchService notificationDispatchService)
         {
             NotificationDispatchService = notificationDispatchService;
         }
 
         /// <inheritdoc />
-        public async Task RegisterRemovableMessageAsync(IMessage message, IUser user)
-            => await NotificationDispatchService.PublishScopedAsync(new RemovableMessageSent()
+        public async Task<EmbedBuilder> RegisterRemovableMessageAsync(IMessage message, IUser user, EmbedBuilder embed)
+        {
+            await NotificationDispatchService.PublishScopedAsync(new RemovableMessageSent()
             {
                 Message = message,
                 User = user,
             });
+
+            if(embed.Footer != null)
+            {
+                embed.Footer.Text += $" | {_footerReactMessage}";
+            }
+            else
+            {
+                embed.WithFooter(_footerReactMessage);
+            }
+            return embed;
+        }
 
         /// <inheritdoc />
         public async Task UnregisterRemovableMessageAsync(IMessage message)

--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -7,7 +6,6 @@ using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Modix.Services.AutoRemoveMessage;
 
 namespace Modix.Services.Quote
 {
@@ -44,18 +42,19 @@ namespace Modix.Services.Quote
 
         private async Task OnMessageReceivedAsync(SocketMessage message)
         {
-            if (!(message is SocketUserMessage userMessage) ||
-                !(userMessage.Author is SocketGuildUser guildUser) ||
-                guildUser.IsBot || guildUser.IsWebhook)
+            if (!(message is SocketUserMessage userMessage)
+                || !(userMessage.Author is SocketGuildUser guildUser)
+                || guildUser.IsBot
+                || guildUser.IsWebhook)
             {
                 return;
             }
 
             foreach (Match match in Pattern.Matches(message.Content))
             {
-                if (ulong.TryParse(match.Groups["GuildId"].Value, out var guildId) &&
-                    ulong.TryParse(match.Groups["ChannelId"].Value, out var channelId) &&
-                    ulong.TryParse(match.Groups["MessageId"].Value, out var messageId))
+                if (ulong.TryParse(match.Groups["GuildId"].Value, out var guildId)
+                    && ulong.TryParse(match.Groups["ChannelId"].Value, out var channelId)
+                    && ulong.TryParse(match.Groups["MessageId"].Value, out var messageId))
                 {
                     try
                     {
@@ -65,10 +64,10 @@ namespace Modix.Services.Quote
                             channel is ISocketMessageChannel messageChannel)
                         {
                             var msg = await messageChannel.GetMessageAsync(messageId);
-                            if (msg == null || IsQuote(msg))
-                                return;
+                            if (msg == null) return;
 
-                            await SendQuoteEmbedAsync(msg, guildUser, userMessage.Channel);
+                            var success = await SendQuoteEmbedAsync(msg, guildUser, userMessage.Channel);
+                            if(success) await userMessage.DeleteAsync();
                         }
                     }
                     catch (Exception ex)
@@ -79,31 +78,20 @@ namespace Modix.Services.Quote
             }
         }
 
-        private async Task SendQuoteEmbedAsync(IMessage message, SocketGuildUser quoter, ISocketMessageChannel targetChannel)
+        private async Task<bool> SendQuoteEmbedAsync(IMessage message, SocketGuildUser quoter, ISocketMessageChannel targetChannel)
         {
+            bool success = false;
             await SelfExecuteRequest<IQuoteService>(async quoteService =>
             {
-                var embed = quoteService.BuildQuoteEmbed(message, quoter);
-                if (embed == null) return;
-
-                embed.WithFooter("React with ❌ to remove this embed.");
-                embed.WithTimestamp(message.Timestamp);
-
-                var removableMessage = await targetChannel.SendMessageAsync(string.Empty, embed: embed.Build());
-                await SelfExecuteRequest<IAutoRemoveMessageService>(async messageRemoveService
-                    => await messageRemoveService.RegisterRemovableMessageAsync(removableMessage, quoter));
+                await quoteService.BuildRemovableEmbed(message, quoter,
+                    async (embed) => //If embed building is unsuccessful, this won't execute
+                    {
+                        success = true;
+                        return await targetChannel.SendMessageAsync(embed: embed.Build());
+                    });
             });
-        }
 
-        private bool IsQuote(IMessage message)
-        {
-            var hasQuoteField =
-                message
-                .Embeds?
-                .SelectMany(d=>d.Fields)
-                .Any(d => d.Name == "Quoted by");
-
-            return hasQuoteField.HasValue && hasQuoteField.Value;
+            return success;
         }
     }
 }


### PR DESCRIPTION
* Responsibility for putting :x: on the footer is now moved to `AutoRemoveMessageService` to reduce redundant code.
* Links are now removed upon a successful quote.
* Cleaned up `QuoteService` and refactored it a bit.
* Any and all quotes, regardless of how they were conceived (`!quote` or links) are now removable.