### PR TITLE
Improve help

### DIFF
--- a/Modix.Bot/Modules/HelpModule.cs
+++ b/Modix.Bot/Modules/HelpModule.cs
@@ -6,107 +6,212 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.Net;
+using Humanizer;
 using Modix.Services.CommandHelp;
+using Modix.Services.Utilities;
 
 namespace Modix.Modules
 {
-    [Name("Info"), Summary("General helper module")]
+    [Name("Help")]
+    [Summary("Provides commands for helping users to understand how to interact with MODiX.")]
     public sealed class HelpModule : ModuleBase
     {
-        private readonly CommandHelpService _commandService;
+        private readonly ICommandHelpService _commandHelpService;
 
-        public HelpModule(CommandHelpService cs)
+        public HelpModule(ICommandHelpService commandHelpService)
         {
-            _commandService = cs;
+            _commandHelpService = commandHelpService;
         }
 
         [Command("help"), Summary("Prints a neat list of all commands.")]
         public async Task HelpAsync()
         {
+            var modules = _commandHelpService.GetModuleHelpData()
+                .Select(d => d.Name)
+                .OrderBy(d => d);
+
+            var descriptionBuilder = new StringBuilder()
+                .AppendLine("Modules:")
+                .AppendJoin(", ", modules)
+                .AppendLine()
+                .AppendLine()
+                .AppendLine("Do \"!help dm\" to have everything DMed to you. (Spammy!)")
+                .AppendLine("Do \"!help [module name] to have that module's commands listed.")
+                .AppendLine("Visit https://mod.gg/commands to view all the commands!");
+
             var embed = new EmbedBuilder()
                 .WithTitle("Help")
-                .WithDescription
-                (
-                    "Modules:\n" +
-                    string.Join(", ", _commandService.GetData().Select(d => d.Name)) + "\n\n" + 
-                    "Do \"!help dm\" to have everything DM'd to you (spammy!)\n" +
-                    "Do \"!help [module name] to have that module's commands listed\n" +
-                    "Visit https://mod.gg/commands to view all the commands!"
-                );
+                .WithDescription(descriptionBuilder.ToString());
 
-            await ReplyAsync("", false, embed.Build());
+            await ReplyAsync(embed: embed.Build());
         }
 
-        [Command("help"), Summary("Prints a neat list of all commands.")]
-        public async Task HelpAsync(
-            [Remainder]
-            [Summary("The name of the module for which to list commands.")]
-                string moduleName)
+        [Command("help dm")]
+        [Summary("Spams the user's DMs with a list of every command available.")]
+        public async Task HelpDMAsync()
         {
-            var eb = new EmbedBuilder();
-            var userDm = await Context.User.GetOrCreateDMChannelAsync();
+            var userDM = await Context.User.GetOrCreateDMChannelAsync();
 
-            void AddCommandFields(IEnumerable<CommandHelpData> commands)
+            foreach (var module in _commandHelpService.GetModuleHelpData().OrderBy(x => x.Name))
             {
-                foreach (var command in commands)
+                var embed = GetEmbedForModule(module);
+
+                try
                 {
-                    eb.AddField(new EmbedFieldBuilder().WithName($"Command: !{command.Alias.ToLowerInvariant() ?? ""} {GetParams(command)}").WithValue(command.Summary ?? "Unknown"));
+                    await userDM.SendMessageAsync(embed: embed.Build());
                 }
-            }
-
-            void BuildEmbedForModule(ModuleHelpData module)
-            {
-                eb = eb.WithTitle($"Module: {module.Name ?? "Unknown"}")
-                           .WithDescription(module.Summary ?? "Unknown");
-
-                AddCommandFields(module.Commands);
-            }
-
-            try
-            {
-                if (moduleName == "dm")
+                catch (HttpException ex) when (ex.DiscordCode == 50007)
                 {
-                    foreach (var module in _commandService.GetData())
+                    await ReplyAsync($"You have private messages for this server disabled, {Context.User.Mention}. Please enable them so that I can send you help.");
+                    return;
+                }
+
+            }
+
+            await ReplyAsync($"Check your private messages, {Context.User.Mention}.");
+        }
+
+        [Command("help")]
+        [Summary("Prints a neat list of all commands in the supplied module.")]
+        [Priority(-10)]
+        public async Task HelpAsync([Remainder]string moduleName)
+        {
+            var foundModule = _commandHelpService.GetModuleHelpData().FirstOrDefault(d => d.Name.IndexOf(moduleName, StringComparison.OrdinalIgnoreCase) >= 0);
+
+            if (foundModule is null)
+            {
+                await ReplyAsync($"Sorry, I couldn't find the \"{moduleName}\" module.");
+                return;
+            }
+
+            var embed = GetEmbedForModule(foundModule);
+
+            await ReplyAsync($"Results for \"{moduleName}\":", embed: embed.Build());
+
+        }
+
+        private EmbedBuilder GetEmbedForModule(ModuleHelpData module)
+        {
+            var embedBuilder = new EmbedBuilder()
+                .WithTitle($"Module: {module.Name}")
+                .WithDescription(module.Summary);
+
+            return AddCommandFields(embedBuilder, module.Commands);
+        }
+
+        private EmbedBuilder AddCommandFields(EmbedBuilder embedBuilder, IEnumerable<CommandHelpData> commands)
+        {
+            foreach (var command in commands)
+            {
+                var summaryBuilder = new StringBuilder(command.Summary ?? "No summary.").AppendLine();
+                var summary = AppendAliases(summaryBuilder, command.Aliases);
+
+                embedBuilder.AddField(new EmbedFieldBuilder()
+                    .WithName($"Command: !{command.Aliases.FirstOrDefault()} {GetParams(command)}")
+                    .WithValue(summary.ToString()));
+            }
+
+            return embedBuilder;
+        }
+
+        private StringBuilder AppendAliases(StringBuilder stringBuilder, IReadOnlyCollection<string> aliases)
+        {
+            if (aliases.Count == 0)
+                return stringBuilder;
+
+            stringBuilder.AppendLine(Format.Bold("Aliases:"));
+
+            foreach (var alias in CollapsePlurals(aliases))
+            {
+                stringBuilder.AppendLine($"• {alias}");
+            }
+
+            return stringBuilder;
+        }
+
+        private IReadOnlyCollection<string> CollapsePlurals(IReadOnlyCollection<string> aliases)
+        {
+            var splitIntoWords = aliases.Select(x => x.Split(" ", StringSplitOptions.RemoveEmptyEntries));
+
+            var withSingulars = splitIntoWords.Select(x =>
+            (
+                Singular: x.Select(y => y.Singularize(false)).ToArray(),
+                Value: x
+            ));
+
+            var groupedBySingulars = withSingulars.GroupBy(x => x.Singular, x => x.Value, new SequenceEqualityComparer<string>());
+
+            var withDistinctParts = new HashSet<string>[groupedBySingulars.Count()][];
+
+            foreach (var (singular, singularIndex) in groupedBySingulars.AsIndexable())
+            {
+                var parts = new HashSet<string>[singular.Key.Count];
+
+                for (var i = 0; i < parts.Length; i++)
+                    parts[i] = new HashSet<string>();
+
+                foreach (var variation in singular)
+                {
+                    foreach (var (part, partIndex) in variation.AsIndexable())
                     {
-                        BuildEmbedForModule(module);
-
-                        await userDm.SendMessageAsync(string.Empty, embed: eb.Build());
-                        eb = new EmbedBuilder();
+                        parts[partIndex].Add(part);
                     }
-
-                    await ReplyAsync($"Check your private messages, {Context.User.Mention}");
-
-                    return;
                 }
 
-                var foundModule = _commandService.GetData().FirstOrDefault(d => d.Name.IndexOf(moduleName, StringComparison.OrdinalIgnoreCase) >= 0);
-
-                if (foundModule == null)
-                {
-                    await ReplyAsync($"Sorry, I couldn't find the \"{moduleName}\" module.");
-                    return;
-                }
-
-                BuildEmbedForModule(foundModule);
-                await ReplyAsync($"Results for \"{moduleName}\":", embed: eb.Build());
+                withDistinctParts[singularIndex] = parts;
             }
-            catch (HttpException exc) when (exc.DiscordCode == 50007)
+
+            var parenthesized = new string[withDistinctParts.Length][];
+
+            foreach (var (alias, aliasIndex) in withDistinctParts.AsIndexable())
             {
-                await ReplyAsync($"You have private messages for this server disabled, {Context.User.Mention}. Please enable them so I can send you help.");
+                parenthesized[aliasIndex] = new string[alias.Length];
+
+                foreach (var (word, wordIndex) in alias.AsIndexable())
+                {
+                    if (word.Count > 1)
+                    {
+                        var (longestForm, shortestForm) = word.First().Length > word.Last().Length
+                            ? (word.First(), word.Last())
+                            : (word.Last(), word.First());
+
+                        var indexOfDifference = word.First()
+                            .ZipOrDefault(word.Last())
+                            .AsIndexable()
+                            .First(x => x.Value.First != x.Value.Second)
+                            .Index;
+
+                        parenthesized[aliasIndex][wordIndex] = $"{longestForm.Substring(0, indexOfDifference)}({longestForm.Substring(indexOfDifference)})";
+                    }
+                    else
+                    {
+                        parenthesized[aliasIndex][wordIndex] = word.Single();
+                    }
+                }
             }
-            
+
+            var formatted = new string[parenthesized.Length];
+
+            foreach (var (alias, aliasIndex) in parenthesized.AsIndexable())
+            {
+                formatted[aliasIndex] = string.Join(" ", alias);
+            }
+
+            return formatted;
         }
 
         private string GetParams(CommandHelpData info)
         {
             var sb = new StringBuilder();
-            info.Parameters.ToList().ForEach(x =>
+
+            foreach (var parameter in info.Parameters)
             {
-                if (x.IsOptional)
-                    sb.Append("[Optional(" + x.Name + ")]");
+                if (parameter.IsOptional)
+                    sb.Append($"[Optional({parameter.Name})]");
                 else
-                    sb.Append("[" + x.Name + "]");
-            });
+                    sb.Append($"[{parameter.Name}]");
+            }
+
             return sb.ToString();
         }
     }

--- a/Modix.Services/CommandHelp/CommandHelpData.cs
+++ b/Modix.Services/CommandHelp/CommandHelpData.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Discord.Commands;
 
 namespace Modix.Services.CommandHelp
@@ -6,30 +7,24 @@ namespace Modix.Services.CommandHelp
     public class CommandHelpData
     {
         public string Name { get; set; }
-        public string Alias { get; set; }
+
         public string Summary { get; set; }
-        public List<ParameterHelpData> Parameters { get; set; } = new List<ParameterHelpData>();
 
-        public static IEnumerable<CommandHelpData> FromCommandInfo(CommandInfo command)
+        public IReadOnlyCollection<string> Aliases { get; set; }
+
+        public IReadOnlyCollection<ParameterHelpData> Parameters { get; set; }
+
+        public static CommandHelpData FromCommandInfo(CommandInfo command)
         {
-            var ret = new List<CommandHelpData>();
-
-            foreach (var alias in command.Aliases)
+            var ret = new CommandHelpData()
             {
-                var data = new CommandHelpData
-                {
-                    Alias = alias,
-                    Name = command.Name,
-                    Summary = command.Summary
-                };
-
-                foreach (var param in command.Parameters)
-                {
-                    data.Parameters.Add(ParameterHelpData.FromParameterInfo(param));
-                }
-
-                ret.Add(data);
-            }
+                Name = command.Name,
+                Summary = command.Summary,
+                Aliases = command.Aliases,
+                Parameters = command.Parameters
+                    .Select(x => ParameterHelpData.FromParameterInfo(x))
+                    .ToArray(),
+            };
 
             return ret;
         }

--- a/Modix.Services/CommandHelp/CommandHelpService.cs
+++ b/Modix.Services/CommandHelp/CommandHelpService.cs
@@ -14,7 +14,7 @@ namespace Modix.Services.CommandHelp
         /// Retrieves help data for all available modules.
         /// </summary>
         /// <returns>
-        /// An readonly collection of data about all available modules.
+        /// A readonly collection of data about all available modules.
         /// </returns>
         IReadOnlyCollection<ModuleHelpData> GetModuleHelpData();
     }

--- a/Modix.Services/CommandHelp/CommandHelpSetup.cs
+++ b/Modix.Services/CommandHelp/CommandHelpSetup.cs
@@ -1,4 +1,4 @@
-using MediatR;
+﻿using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Modix.Services.Messages.Discord;
 
@@ -16,7 +16,7 @@ namespace Modix.Services.CommandHelp
         /// <returns><paramref name="services"/></returns>
         public static IServiceCollection AddCommandHelp(this IServiceCollection services)
             => services
-                .AddSingleton<CommandHelpService>()
+                .AddSingleton<ICommandHelpService, CommandHelpService>()
                 .AddSingleton<CommandErrorHandler>()
                 .AddSingleton<INotificationHandler<ReactionAdded>>(x => x.GetService<CommandErrorHandler>())
                 .AddSingleton<INotificationHandler<ReactionRemoved>>(x => x.GetService<CommandErrorHandler>());

--- a/Modix.Services/CommandHelp/ModuleHelpData.cs
+++ b/Modix.Services/CommandHelp/ModuleHelpData.cs
@@ -12,7 +12,7 @@ namespace Modix.Services.CommandHelp
 
         public string Summary { get; set; }
 
-        public IReadOnlyCollection<CommandHelpData> Commands { get; set; } = new List<CommandHelpData>();
+        public IReadOnlyCollection<CommandHelpData> Commands { get; set; }
 
         public static ModuleHelpData FromModuleInfo(ModuleInfo module)
         {

--- a/Modix.Services/CommandHelp/ModuleHelpData.cs
+++ b/Modix.Services/CommandHelp/ModuleHelpData.cs
@@ -1,17 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Discord.Commands;
 using Humanizer;
 
 namespace Modix.Services.CommandHelp
 {
-    using System;
-
     public class ModuleHelpData
     {
         public string Name { get; set; }
+
         public string Summary { get; set; }
-        public List<CommandHelpData> Commands { get; set; } = new List<CommandHelpData>();
+
+        public IReadOnlyCollection<CommandHelpData> Commands { get; set; } = new List<CommandHelpData>();
 
         public static ModuleHelpData FromModuleInfo(ModuleInfo module)
         {
@@ -23,24 +24,23 @@ namespace Modix.Services.CommandHelp
                 moduleName = module.Name.Substring(0, suffixPosition).Humanize();
             }
 
+            moduleName = moduleName.ApplyCase(LetterCasing.Title);
+
             var ret = new ModuleHelpData
             {
                 Name = moduleName,
-                Summary = string.IsNullOrWhiteSpace(module.Summary) ? "No Summary" : module.Summary
+                Summary = string.IsNullOrWhiteSpace(module.Summary) ? "No Summary" : module.Summary,
+                Commands = module.Commands
+                    .Where(x => !ShouldBeHidden(x))
+                    .Select(x => CommandHelpData.FromCommandInfo(x))
+                    .ToArray(),
             };
 
-            foreach (var command in module.Commands)
-            {
-                if (command.Preconditions.Any(precon => precon is RequireOwnerAttribute) ||
-                    command.Attributes.Any(attr => attr is HiddenFromHelpAttribute))
-                {
-                    continue;
-                }
-
-                ret.Commands.AddRange(CommandHelpData.FromCommandInfo(command));
-            }
-
             return ret;
+
+            bool ShouldBeHidden(CommandInfo command)
+                => command.Preconditions.Any(x => x is RequireOwnerAttribute)
+                || command.Attributes.Any(x => x is HiddenFromHelpAttribute);
         }
     }
 }

--- a/Modix.Services/CommandHelp/ParameterHelpData.cs
+++ b/Modix.Services/CommandHelp/ParameterHelpData.cs
@@ -1,15 +1,20 @@
-﻿using Discord.Commands;
+﻿using System;
+using System.Collections.Generic;
+using Discord.Commands;
 
 namespace Modix.Services.CommandHelp
 {
     public class ParameterHelpData
     {
         public string Name { get; set; }
+
         public string Summary { get; set; }
+
         public string Type { get; set; }
+
         public bool IsOptional { get; set; }
 
-        public string[] Options { get; set; }
+        public IReadOnlyCollection<string> Options { get; set; }
 
         public static ParameterHelpData FromParameterInfo(ParameterInfo parameter)
         {
@@ -19,7 +24,9 @@ namespace Modix.Services.CommandHelp
                 Summary = parameter.Summary,
                 Type = parameter.Type.Name,
                 IsOptional = parameter.IsOptional,
-                Options = parameter.Type.IsEnum ? parameter.Type.GetEnumNames() : new string[0]
+                Options = parameter.Type.IsEnum
+                    ? parameter.Type.GetEnumNames()
+                    : Array.Empty<string>(),
             };
 
             return ret;

--- a/Modix.Services/Utilities/EnumerableExtensions.cs
+++ b/Modix.Services/Utilities/EnumerableExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+
+namespace Modix.Services.Utilities
+{
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<(T Value, int Index)> AsIndexable<T>(this IEnumerable<T> source)
+        {
+            var index = 0;
+
+            foreach (var item in source)
+            {
+                yield return (item, index);
+                index++;
+            }
+        }
+
+        public static IEnumerable<(TFirst First, TSecond Second)> ZipOrDefault<TFirst, TSecond>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second)
+        {
+            using (var e1 = first.GetEnumerator())
+            using (var e2 = second.GetEnumerator())
+            {
+                while (true)
+                {
+                    var e1Moved = e1.MoveNext();
+                    var e2Moved = e2.MoveNext();
+
+                    if (!e1Moved && !e2Moved)
+                        break;
+
+                    yield return
+                    (
+                        e1Moved ? e1.Current : default,
+                        e2Moved ? e2.Current : default
+                    );
+                }
+            }
+        }
+    }
+}

--- a/Modix.Services/Utilities/SequenceEqualityComparer.cs
+++ b/Modix.Services/Utilities/SequenceEqualityComparer.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Modix.Services.Utilities
+{
+    public class SequenceEqualityComparer<T> : IEqualityComparer<IReadOnlyCollection<T>>
+    {
+        public bool Equals(IReadOnlyCollection<T> x, IReadOnlyCollection<T> y)
+            => x.SequenceEqual(y);
+
+        public int GetHashCode(IReadOnlyCollection<T> obj)
+        {
+            var hashCode = new HashCode();
+
+            foreach (var item in obj)
+            {
+                hashCode.Add(item);
+            }
+
+            return hashCode.ToHashCode();
+        }
+    }
+}

--- a/Modix/ClientApp/src/components/Commands/CommandView.vue
+++ b/Modix/ClientApp/src/components/Commands/CommandView.vue
@@ -2,23 +2,20 @@
 
     <li class="command box">
 
-        <div :class="{'field is-grouped is-grouped-multiline': overload.parameters.length > 0}" v-for="(overload, index) in commandGroup" :key="index">
-            <span class="commandName" v-if="overload.alias == commandGroup[0].alias || isAlias(overload)">
-                !{{overload.alias.toLowerCase()}}
-            </span>
-            <span class="commandName overload" v-else>
-                or
+        <div :class="{'field is-grouped is-grouped-multiline': command.parameters.length > 0}" v-for="(alias, index) in command.aliases" :key="index">
+            <span class="commandName">
+                !{{alias.toLowerCase()}}
             </span>
 
-            <div class="summary" v-if="!isAlias(overload)">
-                {{overload.summary}}
+            <div class="summary" v-if="alias == command.aliases[0]">
+                {{command.summary}}
             </div>
 
-            <template v-if="!isAlias(overload)">
-                <ParameterView v-for="param in overload.parameters" :key="param.name" :param="param" />
+            <template v-if="alias == command.aliases[0]">
+                <ParameterView v-for="param in command.parameters" :key="param.name" :param="param" />
             </template>
             <template v-else>
-                <div v-if="overload.parameters.length > 0" class="spacer">&nbsp;</div>
+                <div v-if="command.parameters.length > 0" class="spacer">&nbsp;</div>
             </template>
 
         </div>
@@ -40,15 +37,6 @@ import ParameterView from '@/components/Commands/ParameterView.vue';
 })
 export default class CommandView extends Vue
 {
-    @Prop() private commandGroup!: CommandHelpData[];
-
-    isAlias(overload: CommandHelpData)
-    {
-        return (
-            overload.alias != this.commandGroup[0].alias &&
-            overload.alias != this.commandGroup[0].summary &&
-            overload.alias != overload.name
-        );
-    }
+    @Prop() private command!: CommandHelpData;
 }
 </script>

--- a/Modix/ClientApp/src/components/Commands/ModuleView.vue
+++ b/Modix/ClientApp/src/components/Commands/ModuleView.vue
@@ -11,7 +11,7 @@
             {{commandModule.summary}}
         </h2>
         <ul>
-            <CommandView v-for="(commandGroup, key) in overloads(commandModule.commands)" :key="key" :commandGroup="commandGroup" />
+            <CommandView v-for="(command, key) in commandModule.commands" :key="key" :command="command" />
         </ul>
         <br />
     </div>
@@ -44,11 +44,6 @@ export default class ModuleView extends Vue
     emitClick(module: ModuleHelpData)
     {
         this.$emit('moduleClicked', module);
-    }
-
-    overloads(commands: CommandHelpData[])
-    {
-        return _.groupBy(commands, command => command.name);
     }
 }
 </script>

--- a/Modix/ClientApp/src/models/ModuleHelpData.ts
+++ b/Modix/ClientApp/src/models/ModuleHelpData.ts
@@ -7,7 +7,7 @@ export interface ModuleHelpData
 
 export interface CommandHelpData
 {
-    alias: string;
+    aliases: string[];
     name: string;
     summary: string;
     parameters: ParameterHelpData[];

--- a/Modix/Controllers/CommandsController.cs
+++ b/Modix/Controllers/CommandsController.cs
@@ -6,9 +6,9 @@ namespace Modix.Controllers
     [Route("~/api")]
     public class CommandsController : Controller
     {
-        private readonly CommandHelpService _commandHelpService;
+        private readonly ICommandHelpService _commandHelpService;
 
-        public CommandsController(CommandHelpService commandHelpService)
+        public CommandsController(ICommandHelpService commandHelpService)
         {
             _commandHelpService = commandHelpService;
         }
@@ -16,7 +16,7 @@ namespace Modix.Controllers
         [HttpGet("commands")]
         public IActionResult Commands()
         {
-            return Ok(_commandHelpService.GetData());
+            return Ok(_commandHelpService.GetModuleHelpData());
         }
     }
 }

--- a/Modix/Controllers/CommandsController.cs
+++ b/Modix/Controllers/CommandsController.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Linq;
+using Microsoft.AspNetCore.Mvc;
 using Modix.Services.CommandHelp;
+using Modix.Services.Utilities;
 
 namespace Modix.Controllers
 {
@@ -16,7 +18,22 @@ namespace Modix.Controllers
         [HttpGet("commands")]
         public IActionResult Commands()
         {
-            return Ok(_commandHelpService.GetModuleHelpData());
+            var modules = _commandHelpService.GetModuleHelpData();
+
+            var mapped = modules.Select(m => new
+            {
+                Name = m.Name,
+                Summary = m.Summary,
+                Commands = m.Commands.Select(c => new
+                {
+                    Name = c.Name,
+                    Summary = c.Summary,
+                    Aliases = FormatUtilities.CollapsePlurals(c.Aliases),
+                    Parameters = c.Parameters,
+                }),
+            });
+
+            return Ok(mapped);
         }
     }
 }


### PR DESCRIPTION
Fixes the issue where `!help tags` would throw an exception for having too many fields.

Condenses aliases into a single field per command, collapses plurals into a "singular(s)"-type format.

![image](https://user-images.githubusercontent.com/2829282/54084937-14424000-430e-11e9-88f4-2e55bc1e715e.png)

![image](https://user-images.githubusercontent.com/2829282/54084930-05f42400-430e-11e9-8bbb-6e1265e71406.png)
