### PR TITLE
Sanitize/improve exceptions

### DIFF
--- a/Modix.Bot/ModixBot.cs
+++ b/Modix.Bot/ModixBot.cs
@@ -20,6 +20,7 @@ using Modix.Services;
 using Modix.Services.BehaviourConfiguration;
 using Modix.Services.CommandHelp;
 using Modix.Services.Core;
+using Modix.Services.Utilities;
 
 namespace Modix
 {
@@ -275,7 +276,8 @@ namespace Modix
                     }
                     else
                     {
-                        await context.Channel.SendMessageAsync("Error: " + error);
+                        var sanitizedReason = FormatUtilities.SanitizeEveryone(result.ErrorReason);
+                        await context.Channel.SendMessageAsync($"Error: {sanitizedReason}");
                     }
                 }
             }

--- a/Modix.Services/Tags/TagService.cs
+++ b/Modix.Services/Tags/TagService.cs
@@ -217,7 +217,7 @@ namespace Modix.Services.Tags
                 if (!(channel is IMessageChannel messageChannel))
                     throw new InvalidOperationException($"The channel '{channel.Name}' is not a message channel.");
 
-                var sanitizedContent = FormatUtilities.Sanitize(tag.Content);
+                var sanitizedContent = FormatUtilities.SanitizeEveryone(tag.Content);
 
                 try
                 {

--- a/Modix.Services/Utilities/FormatUtilities.cs
+++ b/Modix.Services/Utilities/FormatUtilities.cs
@@ -5,6 +5,7 @@ using Humanizer;
 using Modix.Data.Models.Moderation;
 using Modix.Services.AutoCodePaste;
 using Modix.Services.Utilities.ColorQuantization;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -115,7 +116,7 @@ namespace Modix.Services.Utilities
             return $"This user has {formatted}";
         }
 
-        public static string Sanitize(string text)
+        public static string SanitizeEveryone(string text)
             => text.Replace("@everyone", "@\x200beveryone")
                    .Replace("@here", "@\x200bhere");
 


### PR DESCRIPTION
Sanitizes `@everyone`/`@here` mentions in exception output. Additionally, removes the "Exception:" wording from the output so that instead of displaying as "Error: Exception: <message>", it'll display as "Error: <message>".