### PR TITLE
Fixed multi-character emojis

### DIFF
--- a/Modix.Bot/Modules/FunModule.cs
+++ b/Modix.Bot/Modules/FunModule.cs
@@ -1,5 +1,7 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
@@ -25,13 +27,31 @@ namespace Modix.Modules
             if (Emote.TryParse(emoji, out var found))
             {
                 emojiUrl = found.Url;
-            }   
+            }
             else
             {
-                var codepoint = char.ConvertToUtf32(emoji, 0);
-                var codepointHex = codepoint.ToString("X").ToLower();
+                var sb = new StringBuilder();
+                sb.Append("https://raw.githubusercontent.com/twitter/twemoji/gh-pages/2/72x72/");
 
-                emojiUrl = $"https://raw.githubusercontent.com/twitter/twemoji/gh-pages/2/72x72/{codepointHex}.png";
+                for(int i = 0; i < emoji.Length; i++)
+                {
+                    var codepoint = char.ConvertToUtf32(emoji, i);
+                    var codepointHex = codepoint.ToString("x");
+
+                    //ConvertToUtf32() might have parsed an extra character
+                    //Therefore we make sure to skip the next one
+                    //We still need to increment through the string in a char by char manner though since
+                    //some characters used in emojis sometimes only occupy one character (16 bit) in size.
+                    if (codepoint > 0xFFFF)
+                        i++;
+
+                    sb.Append(codepointHex);
+
+                    if (i+1 < emoji.Length) sb.Append("-");
+                }
+
+                sb.Append(".png");
+                emojiUrl = sb.ToString();
             }
 
             try

--- a/Modix.Bot/Modules/FunModule.cs
+++ b/Modix.Bot/Modules/FunModule.cs
@@ -37,11 +37,11 @@ namespace Modix.Modules
                     var codepoint = char.ConvertToUtf32(emoji, i);
                     var codepointHex = codepoint.ToString("x");
 
-                    //ConvertToUtf32() might have parsed an extra character
-                    //Therefore we make sure to skip the next one
-                    //We still need to increment through the string in a char by char manner though since
-                    //some characters used in emojis sometimes only occupy one character (16 bit) in size.
-                    if (codepoint > 0xFFFF)
+                    //ConvertToUtf32() might have parsed an extra character as some characters are combinations of two 16-bit characters
+                    //Which start at 0x00d800 and end at 0x00dfff (Called surrogate low and surrogate high)
+                    //If the character is in this span, we have already essentially parsed the next index of the string as well.
+                    //Therefore we make sure to skip the next one.
+                    if (char.IsSurrogate(emoji, i))
                         i++;
 
                     sb.Append(codepointHex);

--- a/Modix.Bot/Modules/FunModule.cs
+++ b/Modix.Bot/Modules/FunModule.cs
@@ -1,6 +1,6 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
@@ -29,13 +29,12 @@ namespace Modix.Modules
             }
             else
             {
-                var sb = new StringBuilder();
-                sb.Append("https://raw.githubusercontent.com/twitter/twemoji/gh-pages/2/72x72/");
-
+                const string emojiLink = "https://raw.githubusercontent.com/twitter/twemoji/gh-pages/2/72x72/";
+                var hexValues = new List<string>();
                 for(int i = 0; i < emoji.Length; i++)
                 {
                     var codepoint = char.ConvertToUtf32(emoji, i);
-                    var codepointHex = codepoint.ToString("x");
+                    hexValues.Add(codepoint.ToString("x"));
 
                     //ConvertToUtf32() might have parsed an extra character as some characters are combinations of two 16-bit characters
                     //Which start at 0x00d800 and end at 0x00dfff (Called surrogate low and surrogate high)
@@ -43,15 +42,9 @@ namespace Modix.Modules
                     //Therefore we make sure to skip the next one.
                     if (char.IsSurrogate(emoji, i))
                         i++;
-
-                    sb.Append(codepointHex);
-
-                    if (i+1 < emoji.Length)
-                        sb.Append("-");
                 }
 
-                sb.Append(".png");
-                emojiUrl = sb.ToString();
+                emojiUrl = $"{emojiLink}{string.Join('-', hexValues)}.png";
             }
 
             try

--- a/Modix.Bot/Modules/FunModule.cs
+++ b/Modix.Bot/Modules/FunModule.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;

--- a/Modix.Bot/Modules/FunModule.cs
+++ b/Modix.Bot/Modules/FunModule.cs
@@ -46,7 +46,8 @@ namespace Modix.Modules
 
                     sb.Append(codepointHex);
 
-                    if (i+1 < emoji.Length) sb.Append("-");
+                    if (i+1 < emoji.Length)
+                        sb.Append("-");
                 }
 
                 sb.Append(".png");


### PR DESCRIPTION
Some emojis are a result of combining several other emojis, e.g. Regional indicators together that represent a countrycode will be interpreted as a flag-emoji.
The `!jumbo` module now takes this into account when parsing the characters that compose the emote.