### PR TITLE
Small refactor of MessageLogBehavior

### DIFF
--- a/Modix.Services/Core/MessageLogBehavior.cs
+++ b/Modix.Services/Core/MessageLogBehavior.cs
@@ -62,8 +62,7 @@ namespace Modix.Services.Core
                     return;
                 }
 
-                await designatedChannelService
-                .SendToDesignatedChannelsAsync(guild, DesignatedChannelType.MessageLog, content, embed);
+                await designatedChannelService.SendToDesignatedChannelsAsync(guild, DesignatedChannelType.MessageLog, content, embed);
             });
         }
 


### PR DESCRIPTION
* Extracted logging to separate method.
* Checking if MessageLog channel exists in the guild before logging.

This is a pretty pointless PR goes as far as the main C#-server is concerned, however for testing purposes where you have no interest in logging message-related actions (edit/delete) it'll certainly clean things up a bit because it no longer spits out an exception everytime it tries to log to a non-existent channel designation.