### PR TITLE
Make REPL and IL endpoints configurable with environment variables

### DIFF
--- a/Modix.Data/Models/Core/ModixConfig.cs
+++ b/Modix.Data/Models/Core/ModixConfig.cs
@@ -17,5 +17,9 @@
         public string DiscordClientSecret { get; set; }
 
         public int MessageCacheSize { get; set; } = 10;
+
+        public string ReplUrl { get; set; }
+
+        public string IlUrl { get; set; }
     }
 }

--- a/Modix/developmentSettings.default.json
+++ b/Modix/developmentSettings.default.json
@@ -6,5 +6,7 @@
   "LogWebhookToken": "",
   "DiscordToken": "",
   "StackoverflowToken": "",
-  "MessageCacheSize": ""
+  "MessageCacheSize": "",
+  "ReplUrl": "",
+  "IlUrl":  ""
 }


### PR DESCRIPTION
Inspired by recent changes to REPL, I decided to PR this since it's always annoyed me.

Shouldn't break CI - if the variables aren't set, it should fall back to the hardcoded URL.