### PR TITLE
Inline tag list fields.

### DIFF
--- a/Modix.Bot/Modules/TagModule.cs
+++ b/Modix.Bot/Modules/TagModule.cs
@@ -202,7 +202,8 @@ namespace Modix.Bot.Modules
             foreach (var tag in orderedTags.Take(tagsToDisplay))
             {
                 builder.AddField(x => x.WithName(tag.Name)
-                                       .WithValue($"{tag.Uses} uses"));
+                                       .WithValue($"{tag.Uses} uses")
+                                       .WithIsInline(true));
             }
 
             if (tags.Count > tagsToDisplay)


### PR DESCRIPTION
This will inline the fields for each tag listed in the `!tag list` command, along with all its subcommands.
The field for more more than 5 tags "and x more" is kept not inlined.
![preview](https://chito.ge/3uz7eD2.png)