### PR TITLE
Change REPL size limit to 5,000 chars.

### DIFF
--- a/Modix.Bot/Modules/ReplModule.cs
+++ b/Modix.Bot/Modules/ReplModule.cs
@@ -32,8 +32,13 @@ namespace Modix.Modules
     [Name("Repl"), Summary("Execute & demonstrate code snippets.")]
     public class ReplModule : ModuleBase
     {
+        // 1024 is the maximum field embed size
+        // minus 3 for the start codeblocks
+        // minus 3 for the end codeblocks
+        // THIS LIMIT IS NOT ARBITRARY
+        private const int MaxReplSize = 1_024 - 3 - 3;
+        
         private const string DefaultReplRemoteUrl = "http://csdiscord-repl-service:31337/Eval";
-        private const int MaxReplSize = 5_000;
         private readonly string _replUrl;
         private readonly CodePasteService _pasteService;
         private readonly IAutoRemoveMessageService _autoRemoveMessageService;

--- a/Modix.Bot/Modules/ReplModule.cs
+++ b/Modix.Bot/Modules/ReplModule.cs
@@ -33,6 +33,7 @@ namespace Modix.Modules
     public class ReplModule : ModuleBase
     {
         private const string DefaultReplRemoteUrl = "http://csdiscord-repl-service:31337/Eval";
+        private const int MaxReplSize = 5_000;
         private readonly string _replUrl;
         private readonly CodePasteService _pasteService;
         private readonly IAutoRemoveMessageService _autoRemoveMessageService;
@@ -63,9 +64,9 @@ namespace Modix.Modules
                 return;
             }
 
-            if (code.Length > 1000)
+            if (code.Length > MaxReplSize)
             {
-                await ModifyOrSendErrorEmbed("Code to execute cannot be longer than 1000 characters.");
+                await ModifyOrSendErrorEmbed($"Code to execute cannot be longer than {MaxReplSize} characters.");
                 return;
             }
 


### PR DESCRIPTION
Why 5000?
- 1000 is too small
- 2000 is enforced by discord
- removing the limit entirely could have bad side effects if being used in a non-controlled environment, eg. another piece of the code uses the eval service for some reason
- 5000 is a large enough ceiling imo