### PR TITLE
Fix quote embed :x: footer

### DIFF
--- a/Modix.Bot/Modules/IlModule.cs
+++ b/Modix.Bot/Modules/IlModule.cs
@@ -91,12 +91,14 @@ namespace Modix.Modules
 
             var embed = await BuildEmbedAsync(guildUser, code, parsedResult);
 
-            await _autoRemoveMessageService.RegisterRemovableMessageAsync(message, Context.User, embed);
-
-            await message.ModifyAsync(a =>
+            await _autoRemoveMessageService.RegisterRemovableMessageAsync(Context.User, embed, async (e) =>
             {
-                a.Content = string.Empty;
-                a.Embed = embed.Build();
+                await message.ModifyAsync(a =>
+                {
+                    a.Content = string.Empty;
+                    a.Embed = e.Build();
+                });
+                return message;
             });
 
             await Context.Message.DeleteAsync();

--- a/Modix.Bot/Modules/QuoteModule.cs
+++ b/Modix.Bot/Modules/QuoteModule.cs
@@ -75,7 +75,7 @@ namespace Modix.Modules
             if (message != null)
             {
                 await _quoteService.BuildRemovableEmbed(message, Context.User,
-                    async (embed) => await ReplyAsync(embed: embed?.Build()));
+                    async (embed) => await ReplyAsync(embed: embed.Build()));
             }
             else
             {

--- a/Modix.Bot/Modules/ReplModule.cs
+++ b/Modix.Bot/Modules/ReplModule.cs
@@ -127,12 +127,14 @@ namespace Modix.Modules
 
             var embed = await BuildEmbedAsync(guildUser, parsedResult);
 
-            await _autoRemoveMessageService.RegisterRemovableMessageAsync(message, Context.User, embed);
-
-            await message.ModifyAsync(a =>
+            await _autoRemoveMessageService.RegisterRemovableMessageAsync(Context.User, embed, async (e) =>
             {
-                a.Content = string.Empty;
-                a.Embed = embed.Build();
+                await message.ModifyAsync(a =>
+                {
+                    a.Content = string.Empty;
+                    a.Embed = e.Build();
+                });
+                return message;
             });
 
             await Context.Message.DeleteAsync();

--- a/Modix.Bot/Modules/TagModule.cs
+++ b/Modix.Bot/Modules/TagModule.cs
@@ -105,7 +105,7 @@ namespace Modix.Bot.Modules
 
             var user = await UserService.GetUserInformationAsync(Context.Guild.Id, userId);
 
-            var embed = await BuildEmbedAsync(tags, ownerUser: user);
+            var embed = BuildEmbed(tags, ownerUser: user);
 
             await ReplyAsync(embed: embed);
         }
@@ -118,7 +118,7 @@ namespace Modix.Bot.Modules
         {
             var tags = await TagService.GetTagsOwnedByRoleAsync(Context.Guild.Id, role.Id);
 
-            var embed = await BuildEmbedAsync(tags, ownerRole: role);
+            var embed = BuildEmbed(tags, ownerRole: role);
 
             await ReplyAsync(embed: embed);
         }
@@ -133,7 +133,7 @@ namespace Modix.Bot.Modules
                 GuildId = Context.Guild.Id
             });
 
-            var embed = await BuildEmbedAsync(tags, ownerGuild: Context.Guild);
+            var embed = BuildEmbed(tags, ownerGuild: Context.Guild);
 
             await ReplyAsync(embed: embed);
         }
@@ -178,7 +178,7 @@ namespace Modix.Bot.Modules
             await ReplyAsync(embed: embed.Build());
         }
 
-        private async Task<Embed> BuildEmbedAsync(IReadOnlyCollection<TagSummary> tags, IUser ownerUser = null, IGuild ownerGuild = null, IRole ownerRole = null)
+        private Embed BuildEmbed(IReadOnlyCollection<TagSummary> tags, IUser ownerUser = null, IGuild ownerGuild = null, IRole ownerRole = null)
         {
             var orderedTags = tags
                 .OrderByDescending(x => x.Uses)

--- a/Modix.Services/AutoRemoveMessage/AutoRemoveMessageService.cs
+++ b/Modix.Services/AutoRemoveMessage/AutoRemoveMessageService.cs
@@ -12,10 +12,13 @@ namespace Modix.Services.AutoRemoveMessage
     public interface IAutoRemoveMessageService
     {
         /// <summary>
-        /// Registers a removable message with the service.
+        /// Registers a removable message with the service and adds an indicator for this to the provided embed.
         /// </summary>
-        /// <param name="message">The removable message.</param>
         /// <param name="user">The user who can remove the message.</param>
+        /// <param name="embed">The embed to operate on</param>
+        /// <param name="callback">A callback that returns the <see cref="IUserMessage"/> to register as removable. The modified embed is provided with this callback.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// If the provided <paramref name="callback"/> is null.
         /// <returns>
         /// A <see cref="Task"/> that will complete when the operation completes.
         /// </returns>
@@ -45,7 +48,7 @@ namespace Modix.Services.AutoRemoveMessage
         public async Task RegisterRemovableMessageAsync(IUser user, EmbedBuilder embed, Func<EmbedBuilder, Task<IUserMessage>> callback)
         {
             if (callback == null)
-                return;
+                throw new ArgumentNullException(nameof(callback));
 
             if (embed.Footer == null)
             {
@@ -57,7 +60,6 @@ namespace Modix.Services.AutoRemoveMessage
             }
 
             var msg = await callback.Invoke(embed);
-
             await NotificationDispatchService.PublishScopedAsync(new RemovableMessageSent()
             {
                 Message = msg,

--- a/Modix.Services/AutoRemoveMessage/AutoRemoveMessageService.cs
+++ b/Modix.Services/AutoRemoveMessage/AutoRemoveMessageService.cs
@@ -44,17 +44,17 @@ namespace Modix.Services.AutoRemoveMessage
         /// <inheritdoc />
         public async Task RegisterRemovableMessageAsync(IUser user, EmbedBuilder embed, Func<EmbedBuilder, Task<IUserMessage>> callback)
         {
-            if (embed.Footer != null)
-            {
-                embed.Footer.Text += $" | {_footerReactMessage}";
-            }
-            else
+            if (callback == null)
+                return;
+
+            if (embed.Footer == null)
             {
                 embed.WithFooter(_footerReactMessage);
             }
-
-            if (callback == null)
-                return;
+            else if (!embed.Footer.Text.Contains(_footerReactMessage))
+            {
+                embed.Footer.Text += $" | {_footerReactMessage}";
+            }
 
             var msg = await callback.Invoke(embed);
 

--- a/Modix.Services/Quote/QuoteService.cs
+++ b/Modix.Services/Quote/QuoteService.cs
@@ -64,8 +64,8 @@ namespace Modix.Services.Quote
                 return;
             }
 
-            var msg = await callback.Invoke(embed);
-            await _autoRemoveMessageService.RegisterRemovableMessageAsync(msg, executingUser, embed);
+            await _autoRemoveMessageService.RegisterRemovableMessageAsync(executingUser, embed,
+                async (e) => await callback.Invoke(e));
         }
 
         private bool TryAddImageAttachment(IMessage message, ref EmbedBuilder embed)


### PR DESCRIPTION
Honestly I'm surprised nobody noticed this (including me)
Could this mean nobody really cares about removing quote embeds?

Oh, and I changed a function in the tagmodule that didn't need to be async anymore, I believe @jmazouri might have missed this in his recent changes to it. The error bothered me too much to just ignore it :)

We're now also checking if the :x: footer content exists anywhere in the existing footer we are registering as removable before adding our own (i.e. the sourcemessage was of removable type), if it does exist we'll just piggyback on that particular footer.

_Please look at the following changes with a fucking electron microscope_