### PR TITLE
Add User Lookup page

### DIFF
--- a/Modix.Services/Core/UserService.cs
+++ b/Modix.Services/Core/UserService.cs
@@ -145,7 +145,7 @@ namespace Modix.Services.Core
         /// <inheritdoc />
         public async Task<EphemeralUser> GetUserInformationAsync(ulong guildId, ulong userId)
         {
-            if (userId <= 0)
+            if (userId == 0)
                 return null;
 
             var guild = await DiscordClient.GetGuildAsync(guildId);

--- a/Modix.Services/Core/UserService.cs
+++ b/Modix.Services/Core/UserService.cs
@@ -145,6 +145,9 @@ namespace Modix.Services.Core
         /// <inheritdoc />
         public async Task<EphemeralUser> GetUserInformationAsync(ulong guildId, ulong userId)
         {
+            if (userId <= 0)
+                return null;
+
             var guild = await DiscordClient.GetGuildAsync(guildId);
             var guildUser = await guild.GetUserAsync(userId);
 

--- a/Modix/ClientApp/package-lock.json
+++ b/Modix/ClientApp/package-lock.json
@@ -901,7 +901,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1160,7 +1160,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1197,7 +1197,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1242,7 +1242,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -1389,7 +1389,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -1488,7 +1488,7 @@
       "dependencies": {
         "color-convert": {
           "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
         }
       }
@@ -1661,7 +1661,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -2196,7 +2196,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -2209,7 +2209,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -2722,7 +2722,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -2847,7 +2847,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -4536,7 +4536,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -4598,7 +4598,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -5028,7 +5028,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -8169,7 +8169,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -10053,7 +10053,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },

--- a/Modix/ClientApp/src/app/Util.ts
+++ b/Modix/ClientApp/src/app/Util.ts
@@ -1,8 +1,6 @@
 import * as dateformat from "dateformat";
 import * as _ from 'lodash';
-import DesignatedChannelMapping from '@/models/moderation/DesignatedChannelMapping';
 import ModixState from '@/models/ModixState';
-import Role from '@/models/Role';
 
 export const formatDate = (date: Date): string =>
 {
@@ -12,6 +10,34 @@ export const formatDate = (date: Date): string =>
 export const toTitleCase = (str: string): string =>
 {
     return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+}
+
+export const ordinalize = (value: number): string =>
+{
+    let rounded = Math.round(value);
+    let asString = rounded.toString();
+
+    if ((Math.floor(rounded / 10) % 10) == 1)
+    {
+        return asString + "th";
+    }
+
+    switch (rounded % 10)
+    {
+        case 1: return asString + "st";
+        case 2: return asString + "nd";
+        case 3: return asString + "rd";
+        default: return asString + "th";
+    }
+}
+
+export const toQuantity = (quantity: number, singular: string, plural: string): string =>
+{
+    let quantityString = quantity.toString();
+
+    return quantity == 1
+        ? quantityString + " " + singular
+        : quantityString + " " + plural;
 }
 
 export const getCookie = (name: string) =>

--- a/Modix/ClientApp/src/components/UserLookup/UserProfile.vue
+++ b/Modix/ClientApp/src/components/UserLookup/UserProfile.vue
@@ -1,0 +1,82 @@
+<template>
+    <div class="message-narrow" v-if="user">
+        <div class="message">
+            <div class="message-header">
+                <h1 class="message-title">
+                    {{user.username}}#{{user.discriminator}}
+                </h1>
+            </div>
+            <div class="message-body">
+                <img v-if="user.avatarUrl" :src="user.avatarUrl" style="float: right; padding-top: 1em; padding-right: 1em;" />
+
+                <div class="box">
+                    <UserProfileSectionTitle :title="'User Information'" />
+                    <UserProfileField :fieldName="'ID'" :fieldValue="user.id" />
+                    <UserProfileField :fieldName="'Status'" :fieldValue="user.status" />
+                    <UserProfileField :fieldName="'First seen'" :fieldValue="formatDate(user.firstSeen)" />
+                    <UserProfileField :fieldName="'Last seen'" :fieldValue="formatDate(user.lastSeen)" />
+                </div>
+
+                <div class="box">
+                    <UserProfileSectionTitle :title="'Guild Participation'" />
+                    <UserProfileField :fieldName="'Rank'" :fieldValue="ordinalize(user.rank)" />
+                    <UserProfileField :fieldName="'Last 7 days'" :fieldValue="toQuantity(user.last7DaysMessages, 'message', 'messages')" />
+                    <UserProfileField :fieldName="'Last 30 days'" :fieldValue="toQuantity(user.last30DaysMessages, ' message', ' messages')" />
+                    <UserProfileField :fieldName="'Average per day'" :fieldValue="toQuantity(Math.round(user.averageMessagesPerDay), ' message', ' messages')" />
+                    <UserProfileField :fieldName="'Percentile'" :fieldValue="ordinalize(user.percentile)" />
+                </div>
+
+                <div class="box">
+                    <UserProfileSectionTitle :title="'Member Information'" />
+                    <UserProfileField :fieldName="'Nickname'" :fieldValue="user.nickname" v-if="user.nickname && user.nickname.length > 0" />
+                    <UserProfileField :fieldName="'Created'" :fieldValue="formatDate(user.createdAt)" />
+                    <UserProfileField :fieldName="'Joined'" :fieldValue="formatDate(user.joinedAt)" />
+                    <UserProfileField :fieldName="'Roles'" :fieldValue="roles" />
+                </div>
+
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop } from 'vue-property-decorator';
+import ModixComponent from '@/components/ModixComponent.vue';
+import * as _ from 'lodash';
+import UserProfileSectionTitle from '@/components/UserLookup/UserProfileSectionTitle.vue';
+import UserProfileField from '@/components/UserLookup/UserProfileField.vue';
+import EphemeralUser from '@/models/EphemeralUser';
+import { formatDate, ordinalize, toQuantity } from '@/app/Util'
+import Role from '@/models/Role';
+import store from "@/app/Store";
+
+@Component({
+    components:
+    {
+        UserProfileSectionTitle,
+        UserProfileField,
+    },
+    methods:
+    {
+        formatDate,
+        ordinalize,
+        toQuantity,
+    },
+})
+export default class UserProfile extends ModixComponent
+{
+    @Prop()
+    user!: EphemeralUser | null;
+
+    get roles(): string
+    {
+        return _.map(this.user!.roles, (role: Role): string => this.parseDiscordContent(`<@&${role.id}>`))
+                .join(", ");
+    }
+
+    async mounted()
+    {
+        await store.retrieveRoles();
+    }
+}
+</script>

--- a/Modix/ClientApp/src/components/UserLookup/UserProfileField.vue
+++ b/Modix/ClientApp/src/components/UserLookup/UserProfileField.vue
@@ -1,0 +1,22 @@
+<template>
+    <div class="field is-horizontal" style="margin-top: 0em; margin-bottom: -0.25em;">
+        <label class="label">{{fieldName}}</label>
+        &nbsp;&nbsp;
+        <div v-html="fieldValue" />
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop } from 'vue-property-decorator';
+import ModixComponent from '@/components/ModixComponent.vue';
+
+@Component({})
+export default class UserProfile extends ModixComponent
+{
+    @Prop()
+    fieldName!: string;
+
+    @Prop()
+    fieldValue!: string;
+}
+</script>

--- a/Modix/ClientApp/src/components/UserLookup/UserProfileSectionTitle.vue
+++ b/Modix/ClientApp/src/components/UserLookup/UserProfileSectionTitle.vue
@@ -1,0 +1,15 @@
+<template>
+    <div class="section-title">&#x276f {{title}}</div>
+</template>
+
+<script lang="ts">
+import { Component, Prop } from 'vue-property-decorator';
+import ModixComponent from '@/components/ModixComponent.vue';
+
+@Component({})
+export default class UserProfile extends ModixComponent
+{
+    @Prop()
+    title!: string;
+}
+</script>

--- a/Modix/ClientApp/src/components/UserLookup/UserSearch.vue
+++ b/Modix/ClientApp/src/components/UserLookup/UserSearch.vue
@@ -1,0 +1,50 @@
+<template>
+    <section class="section">
+        <div class="message-narrow">
+            <div class="field">
+                <label class="label">User ID</label>
+                <div class="control">
+                    <input :class="inputClass" type="text" placeholder="Enter a User ID..." v-model="userId" />
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+<script lang="ts">
+import { Component, Watch } from 'vue-property-decorator';
+import ModixComponent from '@/components/ModixComponent.vue';
+import UserService from '@/services/UserService';
+
+@Component({})
+export default class UserSearch extends ModixComponent
+{
+    userId: string | null = null;
+
+    inputClass: any = 'input';
+
+    @Watch('userId')
+    async computeInputClass(): Promise<void>
+    {
+        if (this.userId == null || this.userId.length == 0)
+        {
+            this.inputClass = 'input';
+            return;
+        }
+
+        let user = await UserService.getUserInformation(this.userId);
+
+        if (!user || user.id <= 0)
+        {
+            this.inputClass = 'input is-danger';
+        }
+        else
+        {
+            this.inputClass = 'input is-success';
+        }
+
+
+        this.$emit('userSelected', user);
+    }
+}
+</script>

--- a/Modix/ClientApp/src/components/UserLookup/UserSearch.vue
+++ b/Modix/ClientApp/src/components/UserLookup/UserSearch.vue
@@ -26,7 +26,7 @@ export default class UserSearch extends ModixComponent
     @Watch('userId')
     async computeInputClass(): Promise<void>
     {
-        if (this.userId == null || this.userId.length == 0)
+        if (!this.userId || this.userId.length == 0)
         {
             this.inputClass = 'input';
             return;
@@ -34,7 +34,7 @@ export default class UserSearch extends ModixComponent
 
         let user = await UserService.getUserInformation(this.userId);
 
-        if (!user || user.id <= 0)
+        if (!user)
         {
             this.inputClass = 'input is-danger';
         }
@@ -42,7 +42,6 @@ export default class UserSearch extends ModixComponent
         {
             this.inputClass = 'input is-success';
         }
-
 
         this.$emit('userSelected', user);
     }

--- a/Modix/ClientApp/src/models/EphemeralUser.ts
+++ b/Modix/ClientApp/src/models/EphemeralUser.ts
@@ -2,39 +2,39 @@ import Role from './Role';
 
 export default class EphemeralUser
 {
-    id: number = 0;
+    id!: string;
 
-    username: string = "";
+    username!: string;
 
-    nickname: string = "";
+    nickname!: string;
 
-    discriminator: string = "";
+    discriminator!: string;
 
-    avatarUrl: string = "";
+    avatarUrl!: string;
 
-    status: string = "";
+    status!: string;
 
-    createdAt: Date = new Date();
+    createdAt!: Date;
 
-    joinedAt: Date = new Date();
+    joinedAt!: Date;
 
-    firstSeen: Date = new Date();
+    firstSeen!: Date;
 
-    lastSeen: Date = new Date();
+    lastSeen!: Date;
 
-    rank: number = 0;
+    rank!: number;
 
-    last7DaysMessages: number = 0;
+    last7DaysMessages!: number;
 
-    last30DaysMessages: number = 0;
+    last30DaysMessages!: number;
 
-    averageMessagesPerDay: number = 0;
+    averageMessagesPerDay!: number;
 
-    percentile: number = 0;
+    percentile!: number;
 
-    roles: Role[] = [];
+    roles!: Role[];
 
-    isBanned: boolean = false;
+    isBanned!: boolean;
 
-    banReason: string = "";
+    banReason!: string;
 }

--- a/Modix/ClientApp/src/models/EphemeralUser.ts
+++ b/Modix/ClientApp/src/models/EphemeralUser.ts
@@ -1,0 +1,40 @@
+import Role from './Role';
+
+export default class EphemeralUser
+{
+    id: number = 0;
+
+    username: string = "";
+
+    nickname: string = "";
+
+    discriminator: string = "";
+
+    avatarUrl: string = "";
+
+    status: string = "";
+
+    createdAt: Date = new Date();
+
+    joinedAt: Date = new Date();
+
+    firstSeen: Date = new Date();
+
+    lastSeen: Date = new Date();
+
+    rank: number = 0;
+
+    last7DaysMessages: number = 0;
+
+    last30DaysMessages: number = 0;
+
+    averageMessagesPerDay: number = 0;
+
+    percentile: number = 0;
+
+    roles: Role[] = [];
+
+    isBanned: boolean = false;
+
+    banReason: string = "";
+}

--- a/Modix/ClientApp/src/router.ts
+++ b/Modix/ClientApp/src/router.ts
@@ -19,6 +19,7 @@ const Stats = () => import('./views/Stats.vue').then(m => m.default)
 const Tags = () => import('./views/Tags/Tags.vue').then(m => m.default)
 const Logs = () => import('./views/Logs.vue').then(m => m.default)
 const DeletedMessages = () => import('./components/Logs/DeletedMessages.vue').then(m => m.default)
+const UserLookup = () => import('./views/UserLookup.vue').then(m => m.default)
 
 Vue.use(Router)
 
@@ -45,6 +46,15 @@ let routes: (ModixRouteData | RedirectRouteData)[] =
         component: Commands,
         showInNavbar: true,
         type: RouteType.Normal
+    },
+    {
+        path: '/userlookup',
+        name: 'userlookup',
+        title: 'User Lookup',
+        component: UserLookup,
+        showInNavbar: true,
+        requiresAuth: true,
+        type: RouteType.Normal,
     },
     {
         path: '/tags',

--- a/Modix/ClientApp/src/services/UserService.ts
+++ b/Modix/ClientApp/src/services/UserService.ts
@@ -1,0 +1,11 @@
+import _ from 'lodash';
+import client from './ApiClient';
+import EphemeralUser from '@/models/EphemeralUser';
+
+export default class UserService
+{
+    static async getUserInformation(userId: string): Promise<EphemeralUser | null>
+    {
+        return (await client.get(`userInformation/${userId}`)).data;
+    }
+}

--- a/Modix/ClientApp/src/styles/variables.scss
+++ b/Modix/ClientApp/src/styles/variables.scss
@@ -125,3 +125,22 @@ a.is-disabled
 {
     margin: 0;
 }
+
+.message-title
+{
+    font-size: 1.5em;
+}
+
+.message-narrow
+{
+    max-width: 900px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.section-title
+{
+    margin-bottom: 0.25em;
+    font-size: 1.25em;
+    font-weight: bold;
+}

--- a/Modix/ClientApp/src/views/UserLookup.vue
+++ b/Modix/ClientApp/src/views/UserLookup.vue
@@ -1,0 +1,44 @@
+<template>
+    <div>
+        <div>
+            <UserSearch @userSelected="onUserSelected" />
+        </div>
+        <div>
+            <UserProfile :user="selectedUser" />
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop } from 'vue-property-decorator';
+import ModixComponent from '@/components/ModixComponent.vue';
+import UserSearch from '@/components/UserLookup/UserSearch.vue';
+import UserProfile from '@/components/UserLookup/UserProfile.vue';
+import * as _ from 'lodash';
+import EphemeralUser from '@/models/EphemeralUser';
+import UserService from '@/services/UserService';
+
+@Component(
+{
+    components:
+    {
+        UserSearch,
+        UserProfile,
+    }
+})
+export default class UserLookup extends ModixComponent
+{
+    @Prop()
+    selectedUser!: EphemeralUser | null;
+
+    async mounted()
+    {
+        this.selectedUser = (await UserService.getUserInformation(this.$store.state.modix.user.userId))!;
+    }
+
+    onUserSelected(user: EphemeralUser | null): void
+    {
+        this.selectedUser = user;
+    }
+}
+</script>

--- a/Modix/Controllers/UserInformationController.cs
+++ b/Modix/Controllers/UserInformationController.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord.WebSocket;
+using Microsoft.AspNetCore.Mvc;
+using Modix.Data.Repositories;
+using Modix.Services.Core;
+using Modix.Services.Utilities;
+
+namespace Modix.Controllers
+{
+    [Route("~/api/userInformation")]
+    public class UserInformationController : ModixController
+    {
+        private IUserService UserService { get; }
+
+        private IMessageRepository MessageRepository { get; }
+
+        public UserInformationController(
+            DiscordSocketClient client,
+            IAuthorizationService modixAuth,
+            IUserService userService,
+            IMessageRepository messageRepository)
+            : base(client, modixAuth)
+        {
+            UserService = userService;
+            MessageRepository = messageRepository;
+        }
+
+        [HttpGet("{userIdString}")]
+        public async Task<IActionResult> GetUserInformationAsync(string userIdString)
+        {
+            if (!ulong.TryParse(userIdString, out var userId))
+                return Ok(null);
+
+            var userInformation = await UserService.GetUserInformationAsync(UserGuild.Id, userId);
+
+            if (userInformation is null)
+                return Ok(null);
+
+            var userRank = await MessageRepository.GetGuildUserParticipationStatistics(UserGuild.Id, userId);
+            var messages7 = await MessageRepository.GetGuildUserMessageCountByDate(UserGuild.Id, userId, TimeSpan.FromDays(7));
+            var messages30 = await MessageRepository.GetGuildUserMessageCountByDate(UserGuild.Id, userId, TimeSpan.FromDays(30));
+
+            var roles = userInformation.RoleIds
+                .Select(x => UserGuild.GetRole(x))
+                .OrderByDescending(x => x.IsHoisted)
+                .ThenByDescending(x => x.Position)
+                .ToArray();
+
+            var mapped = new
+            {
+                Id = userInformation.Id,
+                Username = userInformation.Username,
+                Nickname = userInformation.Nickname,
+                Discriminator = userInformation.Discriminator,
+                AvatarUrl = userInformation.GetDefiniteAvatarUrl(),
+                Status = userInformation.Status.ToString(),
+                CreatedAt = userInformation.CreatedAt,
+                JoinedAt = userInformation.JoinedAt,
+                FirstSeen = userInformation.FirstSeen,
+                LastSeen = userInformation.LastSeen,
+                Rank = userRank.Rank,
+                Last7DaysMessages = messages7.Count,
+                Last30DaysMessages = messages30.Count,
+                AverageMessagesPerDay = userRank.AveragePerDay,
+                Percentile = userRank.Percentile,
+                Roles = roles
+                    .Where(x => !x.IsEveryone)
+                    .Select(x => new
+                    {
+                        Id = x.Id,
+                        Name = x.Name,
+                        Color = x.Color.ToString(),
+                    }),
+                IsBanned = userInformation.IsBanned,
+                BanReason = userInformation.BanReason,
+            };
+
+            return Ok(mapped);
+        }
+    }
+}

--- a/Modix/Controllers/UserInformationController.cs
+++ b/Modix/Controllers/UserInformationController.cs
@@ -50,7 +50,7 @@ namespace Modix.Controllers
 
             var mapped = new
             {
-                Id = userInformation.Id,
+                Id = userInformation.Id.ToString(),
                 Username = userInformation.Username,
                 Nickname = userInformation.Nickname,
                 Discriminator = userInformation.Discriminator,


### PR DESCRIPTION
Closes #195. I feel like I've waited long enough without anyone expressing interest in it :p

Web analog to `!info`.

Shows the current user's profile by default, allows searching by ID.

Ideas for future expansion:
* Allow searching by name+discriminator
* Optionally include infractions based on claims
* Additional statistics

![image](https://user-images.githubusercontent.com/2829282/54765479-fb6c4100-4bcf-11e9-803b-242916ff3153.png)
