### PR TITLE
Make promotions edit button not overlap text

### DIFF
--- a/Modix/ClientApp/src/components/Promotions/PromotionCommentView.vue
+++ b/Modix/ClientApp/src/components/Promotions/PromotionCommentView.vue
@@ -5,7 +5,7 @@
         <span class="commentBody">
             {{comment.content}} <span class="date">{{formatDate(comment.createAction.created)}}</span>
         </span>
-        <span class="button is-link edit" :style="{'margin-left': '0.33em'}" v-if="comment.isFromCurrentUser && !hidden" v-on:click="$emit('comment-edit-modal-opened', comment)">Edit</span>
+        <span class="button is-link edit" v-if="comment.isFromCurrentUser && !hidden" v-on:click="$emit('comment-edit-modal-opened', comment)">Edit</span>
 
     </div>
 

--- a/Modix/ClientApp/src/styles/components/promotionCommentView.scss
+++ b/Modix/ClientApp/src/styles/components/promotionCommentView.scss
@@ -81,8 +81,7 @@
 
 .edit
 {
-    position: absolute;
-    right: 0px;
-
+    float: right;
+    margin-left: 0.33em;
     padding: 2em;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2829282/54787864-7c90fb80-4c03-11e9-8711-635170c5516b.png)
