### PR TITLE
Quoting if a message is edited with a link

### DIFF
--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -11,7 +11,7 @@ namespace Modix.Services.Quote
     public class MessageLinkBehavior : BehaviorBase
     {
         private static readonly Regex Pattern = new Regex(
-            @"(?<Prelink>\S+\s+)?https?://(?:(?:ptb|canary)\.)?discordapp\.com/channels/(?<GuildId>\d+)/(?<ChannelId>\d+)/(?<MessageId>\d+)/?(?<Postlink>\s+\S+)?",
+            @"(?<Prelink>\S+\s+\S*)?https?://(?:(?:ptb|canary)\.)?discordapp\.com/channels/(?<GuildId>\d+)/(?<ChannelId>\d+)/(?<MessageId>\d+)/?(?<Postlink>\S*\s+\S+)?",
             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         public MessageLinkBehavior(DiscordSocketClient discordClient, IServiceProvider serviceProvider)
@@ -28,6 +28,7 @@ namespace Modix.Services.Quote
         protected internal override Task OnStartingAsync()
         {
             DiscordClient.MessageReceived += OnMessageReceivedAsync;
+            DiscordClient.MessageUpdated += OnMessageUpdatedAsync;
 
             return Task.CompletedTask;
         }
@@ -35,8 +36,14 @@ namespace Modix.Services.Quote
         protected internal override Task OnStoppedAsync()
         {
             DiscordClient.MessageReceived -= OnMessageReceivedAsync;
+            DiscordClient.MessageUpdated -= OnMessageUpdatedAsync;
 
             return Task.CompletedTask;
+        }
+
+        private async Task OnMessageUpdatedAsync(Cacheable<IMessage, ulong> cached, SocketMessage message, ISocketMessageChannel channel)
+        {
+            await OnMessageReceivedAsync(message);
         }
 
         private async Task OnMessageReceivedAsync(SocketMessage message)

--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -43,6 +43,11 @@ namespace Modix.Services.Quote
 
         private async Task OnMessageUpdatedAsync(Cacheable<IMessage, ulong> cached, SocketMessage message, ISocketMessageChannel channel)
         {
+            var cachedMessage = await cached.GetOrDownloadAsync();
+
+            if (Pattern.IsMatch(cachedMessage.Content))
+                return;
+
             await OnMessageReceivedAsync(message);
         }
 


### PR DESCRIPTION
This is probably overkill since it'll basically almost never happen. Regardless, if you happen to send a message that refers to another message but for whatever reason don't put the link in there and then decide to edit it with the aforementioned link, it will now quote appropriately.