### PR TITLE
Forbid tags from mentioning users

### DIFF
--- a/Modix.Services/Tags/TagService.cs
+++ b/Modix.Services/Tags/TagService.cs
@@ -226,6 +226,7 @@ namespace Modix.Services.Tags
                     throw new InvalidOperationException($"The channel '{channel.Name}' is not a message channel.");
 
                 var sanitizedContent = FormatUtilities.SanitizeEveryone(tag.Content);
+                sanitizedContent = FormatUtilities.SanitizeUserMentions(sanitizedContent);
 
                 try
                 {

--- a/Modix.Services/Tags/TagService.cs
+++ b/Modix.Services/Tags/TagService.cs
@@ -225,8 +225,7 @@ namespace Modix.Services.Tags
                 if (!(channel is IMessageChannel messageChannel))
                     throw new InvalidOperationException($"The channel '{channel.Name}' is not a message channel.");
 
-                var sanitizedContent = FormatUtilities.SanitizeEveryone(tag.Content);
-                sanitizedContent = FormatUtilities.SanitizeUserMentions(sanitizedContent);
+                var sanitizedContent = FormatUtilities.SanitizeAllMentions(tag.Content);
 
                 try
                 {

--- a/Modix.Services/Utilities/FormatUtilities.cs
+++ b/Modix.Services/Utilities/FormatUtilities.cs
@@ -118,6 +118,15 @@ namespace Modix.Services.Utilities
             return $"This user has {formatted}";
         }
 
+        public static string SanitizeAllMentions(string text)
+        {
+            var everyoneSanitized = SanitizeEveryone(text);
+            var userSanitized = SanitizeUserMentions(everyoneSanitized);
+            var roleSanitized = SanitizeRoleMentions(userSanitized);
+
+            return roleSanitized;
+        }
+
         public static string SanitizeEveryone(string text)
             => text.Replace("@everyone", "@\x200beveryone")
                    .Replace("@here", "@\x200bhere");
@@ -125,7 +134,12 @@ namespace Modix.Services.Utilities
         public static string SanitizeUserMentions(string text)
             => _userMentionRegex.Replace(text, "<@\x200b${Id}>");
 
+        public static string SanitizeRoleMentions(string text)
+            => _roleMentionRegex.Replace(text, "<@&\x200b${Id}>");
+
         private static readonly Regex _userMentionRegex = new Regex("<@!?(?<Id>[0-9]+)>", RegexOptions.Compiled);
+
+        private static readonly Regex _roleMentionRegex = new Regex("<@&(?<Id>[0-9]+)>", RegexOptions.Compiled);
 
         /// <summary>
         /// Identifies a dominant color from the provided image.

--- a/Modix.Services/Utilities/FormatUtilities.cs
+++ b/Modix.Services/Utilities/FormatUtilities.cs
@@ -122,6 +122,11 @@ namespace Modix.Services.Utilities
             => text.Replace("@everyone", "@\x200beveryone")
                    .Replace("@here", "@\x200bhere");
 
+        public static string SanitizeUserMentions(string text)
+            => _userMentionRegex.Replace(text, "<@\x200b${Id}>");
+
+        private static readonly Regex _userMentionRegex = new Regex("<@!?(?<Id>[0-9]+)>", RegexOptions.Compiled);
+
         /// <summary>
         /// Identifies a dominant color from the provided image.
         /// </summary>


### PR DESCRIPTION
It was never a useful feature anyway, and it's been abused. Replaces user mentions with `<@id>`.

![image](https://user-images.githubusercontent.com/2829282/55118508-f40fd080-50c4-11e9-99df-8c8235739e08.png)
