### PR TITLE
Changed formatting for datetime on footer

### DIFF
--- a/Modix.Bot/Modules/EmojiStatsModule.cs
+++ b/Modix.Bot/Modules/EmojiStatsModule.cs
@@ -170,7 +170,7 @@ namespace Modix.Modules
                 .WithAuthor(Context.Guild.Name, Context.Guild.IconUrl)
                 .WithColor(Color.Blue)
                 .WithDescription(sb.ToString())
-                .WithFooter($"{"unique emoji".ToQuantity(guildStats.UniqueEmojis)} used {"time".ToQuantity(guildStats.TotalUses)} ({totalEmojiUsesPerDay.ToString("0.0")}/day) since {guildStats.OldestTimestamp.ToString("d")}");
+                .WithFooter($"{"unique emoji".ToQuantity(guildStats.UniqueEmojis)} used {"time".ToQuantity(guildStats.TotalUses)} ({totalEmojiUsesPerDay.ToString("0.0")}/day) since {guildStats.OldestTimestamp.ToString("yyyy-MM-dd")}");
         }
     }
 }


### PR DESCRIPTION
Makes the timestamp on the footer for emojistats more readable.

### This: 
![bild](https://user-images.githubusercontent.com/22471295/55518730-68beae00-5675-11e9-8a14-9ec46b9aa970.png)


### Becomes this:
![bild](https://user-images.githubusercontent.com/22471295/55518707-55abde00-5675-11e9-8529-b5b6b996abc7.png)
