### PR TITLE
Add promotion history to !info

### DIFF
--- a/Modix.Data/Repositories/PromotionCampaignRepository.cs
+++ b/Modix.Data/Repositories/PromotionCampaignRepository.cs
@@ -81,6 +81,17 @@ namespace Modix.Data.Repositories
         /// containing the action representing the closure of the campaign.
         /// </returns>
         Task<PromotionActionSummary> TryCloseAsync(long campaignId, ulong closedById, PromotionCampaignOutcome outcome);
+
+        /// <summary>
+        /// Retireves the promotion progression for the supplied user.
+        /// </summary>
+        /// <param name="guildId">The unique Discord snowflake ID of the guild in which the desired promotions took place.</param>
+        /// <param name="userId">The unique Discord snowflake ID of the user for whom to retrieve promotions.</param>
+        /// <returns>
+        /// A <see cref="Task"/> which will complete when the operation is complete,
+        /// containing a collection representing the promotion progression for the supplied user.
+        /// </returns>
+        Task<IReadOnlyCollection<PromotionCampaignSummary>> GetPromotionsForUserAsync(ulong guildId, ulong userId);
     }
 
     /// <inheritdoc />
@@ -174,6 +185,16 @@ namespace Modix.Data.Repositories
 
             return action;
         }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<PromotionCampaignSummary>> GetPromotionsForUserAsync(ulong guildId, ulong userId)
+            => await ModixContext.PromotionCampaigns.AsNoTracking()
+                .Where(x => x.GuildId == guildId
+                    && x.SubjectId == userId
+                    && x.Outcome == PromotionCampaignOutcome.Accepted)
+                .AsExpandable()
+                .Select(PromotionCampaignSummary.FromEntityProjection)
+                .ToArrayAsync();
 
         private static readonly RepositoryTransactionFactory _createTransactionFactory
             = new RepositoryTransactionFactory();

--- a/Modix.Services/Promotions/PromotionsService.cs
+++ b/Modix.Services/Promotions/PromotionsService.cs
@@ -101,6 +101,17 @@ namespace Modix.Services.Promotions
         /// containing the requested action information.
         /// </returns>
         Task<PromotionActionSummary> GetPromotionActionSummaryAsync(long promotionActionId);
+
+        /// <summary>
+        /// Retrieves the promotion progression for the supplied user.
+        /// </summary>
+        /// <param name="guildId">The unique Discord snowflake ID of the guild in which the desired promotions took place.</param>
+        /// <param name="userId">The unique Discord snowflake ID of the user for whom to retrieve promotions.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that will complete when the operation is complete,
+        /// containing a collection representing the promotion progression for the supplied user.
+        /// </returns>
+        Task<IReadOnlyCollection<PromotionCampaignSummary>> GetPromotionsForUserAsync(ulong guildId, ulong userId);
     }
 
     /// <inheritdoc />
@@ -368,6 +379,10 @@ namespace Modix.Services.Promotions
 
             return await PromotionActionRepository.ReadSummaryAsync(promotionActionId);
         }
+
+        /// <inheritdoc />
+        public async Task<IReadOnlyCollection<PromotionCampaignSummary>> GetPromotionsForUserAsync(ulong guildId, ulong userId)
+            => await PromotionCampaignRepository.GetPromotionsForUserAsync(guildId, userId);
 
         /// <summary>
         /// An <see cref="IDiscordClient"/> for interacting with the Discord API.


### PR DESCRIPTION
When trying to decide if a member should be put up for promotion, people are often interested in knowing how recently the member was last promoted. This PR adds a promotion history of up to five (5) of the most recent promotions applied to a user to the `!info` command.

![image](https://user-images.githubusercontent.com/2829282/55676231-9a668d80-589e-11e9-8162-15ea53cfce7f.png)
