### PR TITLE
Add attribute to increase success rate of help queries

### DIFF
--- a/Modix.Bot/Modules/AuthorizationModule.cs
+++ b/Modix.Bot/Modules/AuthorizationModule.cs
@@ -6,6 +6,7 @@ using Discord;
 using Discord.Commands;
 
 using Modix.Data.Models.Core;
+using Modix.Services.CommandHelp;
 using Modix.Services.Core;
 
 namespace Modix.Modules
@@ -13,6 +14,7 @@ namespace Modix.Modules
     [Name("Authorization")]
     [Group("auth")]
     [Summary("Commands for configuring the authorization system.")]
+    [HelpTags("claims")]
     public class AuthorizationModule : ModuleBase
     {
         public AuthorizationModule(IAuthorizationService authorizationService)

--- a/Modix.Bot/Modules/DocumentationModule.cs
+++ b/Modix.Bot/Modules/DocumentationModule.cs
@@ -2,11 +2,14 @@
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
+using Modix.Services.CommandHelp;
 using Modix.Services.Csharp;
 
 namespace Modix.Modules
 {
-    [Name("Documentation"), Summary("Search for information within the .NET docs.")]
+    [Name("Documentation")]
+    [Summary("Search for information within the .NET docs.")]
+    [HelpTags("docs")]
     public class DocumentationModule : ModuleBase
     {
         public DocumentationModule(DocumentationService documentationService)

--- a/Modix.Bot/Modules/EmojiStatsModule.cs
+++ b/Modix.Bot/Modules/EmojiStatsModule.cs
@@ -13,6 +13,7 @@ using Modix.Services.Utilities;
 
 namespace Modix.Modules
 {
+    [Name("EmojiStats")]
     [Group("emojistats")]
     [Summary("Commands related to generating statistics on emojis.")]
     public class EmojiStatsModule : ModuleBase

--- a/Modix.Bot/Modules/FunModule.cs
+++ b/Modix.Bot/Modules/FunModule.cs
@@ -2,12 +2,15 @@
 using System.Net.Http;
 using System.Threading.Tasks;
 using Discord.Commands;
+using Modix.Services.CommandHelp;
 using Modix.Services.Utilities;
 using Serilog;
 
 namespace Modix.Modules
 {
-    [Name("Fun"), Summary("A bunch of miscellaneous, fun commands.")]
+    [Name("Fun")]
+    [Summary("A bunch of miscellaneous, fun commands.")]
+    [HelpTags("jumbo")]
     public class FunModule : ModuleBase
     {
         public FunModule(IHttpClientFactory httpClientFactory)

--- a/Modix.Bot/Modules/GuildInfoModule.cs
+++ b/Modix.Bot/Modules/GuildInfoModule.cs
@@ -5,18 +5,21 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using Humanizer;
 using Modix.Data.Models;
 using Modix.Data.Repositories;
+using Modix.Services.CommandHelp;
 using Modix.Services.Core;
 using Modix.Services.Utilities;
 
 namespace Modix.Modules
 {
+    [Name("Guild Information")]
+    [Summary("Retrieves information and statistics about the supplied guild.")]
+    [HelpTags("guildinfo")]
     public sealed class GuildInfoModule : ModuleBase
     {
         //optimization: UtcNow is slow and the module is created per-request

--- a/Modix.Bot/Modules/HelpModule.cs
+++ b/Modix.Bot/Modules/HelpModule.cs
@@ -71,21 +71,24 @@ namespace Modix.Modules
         }
 
         [Command("help")]
-        [Summary("Prints a neat list of all commands in the supplied module.")]
+        [Summary("Prints a neat list of all commands based on the supplied query.")]
         [Priority(-10)]
-        public async Task HelpAsync([Remainder]string moduleName)
+        public async Task HelpAsync(
+            [Remainder]
+            [Summary("The module name or related query to use to search for the help module.")]
+                string query)
         {
-            var foundModule = _commandHelpService.GetModuleHelpData().FirstOrDefault(d => d.Name.IndexOf(moduleName, StringComparison.OrdinalIgnoreCase) >= 0);
+            var foundModule = _commandHelpService.GetModuleHelpData(query);
 
             if (foundModule is null)
             {
-                await ReplyAsync($"Sorry, I couldn't find the \"{moduleName}\" module.");
+                await ReplyAsync($"Sorry, I couldn't find help related to \"{query}\".");
                 return;
             }
 
             var embed = GetEmbedForModule(foundModule);
 
-            await ReplyAsync($"Results for \"{moduleName}\":", embed: embed.Build());
+            await ReplyAsync($"Results for \"{query}\":", embed: embed.Build());
 
         }
 

--- a/Modix.Bot/Modules/IlModule.cs
+++ b/Modix.Bot/Modules/IlModule.cs
@@ -9,13 +9,16 @@ using Discord.WebSocket;
 using Microsoft.Extensions.Options;
 using Modix.Data.Models.Core;
 using Modix.Services.AutoRemoveMessage;
+using Modix.Services.CommandHelp;
 using Modix.Services.CodePaste;
 using Modix.Services.Utilities;
 using Serilog;
 
 namespace Modix.Modules
 {
-    [Name("Decompiler"), Summary("Compile code & view the IL.")]
+    [Name("Decompiler")]
+    [Summary("Compile code & view the IL.")]
+    [HelpTags("il")]
     public class IlModule : ModuleBase
     {
         private const string DefaultIlRemoteUrl = "http://csdiscord-repl-service:31337/Il";

--- a/Modix.Bot/Modules/MentionModule.cs
+++ b/Modix.Bot/Modules/MentionModule.cs
@@ -2,13 +2,14 @@
 
 using Discord;
 using Discord.Commands;
-
+using Modix.Services.CommandHelp;
 using Modix.Services.Mentions;
 
 namespace Modix.Bot.Modules
 {
     [Name("Mentioning")]
     [Summary("Commands related to mentioning roles.")]
+    [HelpTags("mentions", "@")]
     public class MentionModule : ModuleBase
     {
         public MentionModule(IMentionService mentionService)

--- a/Modix.Bot/Modules/ModerationModule.cs
+++ b/Modix.Bot/Modules/ModerationModule.cs
@@ -8,6 +8,7 @@ using Discord.Commands;
 
 using Modix.Bot.Extensions;
 using Modix.Data.Models.Moderation;
+using Modix.Services.CommandHelp;
 using Modix.Services.Moderation;
 using Modix.Services.Utilities;
 
@@ -15,6 +16,7 @@ namespace Modix.Modules
 {
     [Name("Moderation")]
     [Summary("Guild moderation commands.")]
+    [HelpTags("note", "warn", "mute", "tempmute", "unmute", "ban", "forceban", "unban", "clean")]
     public class ModerationModule : ModuleBase
     {
         public ModerationModule(IModerationService moderationService)

--- a/Modix.Bot/Modules/PromotionsModule.cs
+++ b/Modix.Bot/Modules/PromotionsModule.cs
@@ -8,6 +8,7 @@ using Discord.Commands;
 using Modix.Bot.Extensions;
 using Modix.Data.Models.Promotions;
 using Modix.Data.Utilities;
+using Modix.Services.CommandHelp;
 using Modix.Services.Promotions;
 using Modix.Services.Utilities;
 
@@ -17,6 +18,7 @@ namespace Modix.Modules
     [Summary("Manage promotion campaigns.")]
     [Group("promotions")]
     [Alias("promotion", "campaign", "campaigns")]
+    [HelpTags("campaigns", "nominate", "nomination", "nominating")]
     public class PromotionsModule : ModuleBase
     {
         private const string DefaultApprovalMessage = "I approve of this nomination.";

--- a/Modix.Bot/Modules/QuoteModule.cs
+++ b/Modix.Bot/Modules/QuoteModule.cs
@@ -4,10 +4,13 @@ using System.Threading.Tasks;
 using Discord;
 using Modix.Services.Quote;
 using Serilog;
+using Modix.Services.CommandHelp;
 
 namespace Modix.Modules
 {
-    [Name("Quoting"), Summary("Quote a message from the guild with its ID.")]
+    [Name("Quoting")]
+    [Summary("Quote a message from the guild with its ID.")]
+    [HelpTags("quotes")]
     public class QuoteModule : ModuleBase
     {
         private readonly IQuoteService _quoteService;

--- a/Modix.Bot/Modules/ReplModule.cs
+++ b/Modix.Bot/Modules/ReplModule.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Options;
 using Modix.Data.Models.Core;
 using Modix.Services.AutoRemoveMessage;
 using Modix.Services.CodePaste;
+using Modix.Services.CommandHelp;
 using Modix.Services.Utilities;
 using Newtonsoft.Json;
 
@@ -29,7 +30,9 @@ namespace Modix.Modules
         public string ReturnTypeName { get; set; }
     }
 
-    [Name("Repl"), Summary("Execute & demonstrate code snippets.")]
+    [Name("Repl")]
+    [Summary("Execute & demonstrate code snippets.")]
+    [HelpTags("eval", "exec")]
     public class ReplModule : ModuleBase
     {
         // 1000 is the maximum field embed size

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -5,18 +5,17 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
 using Humanizer;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
 using Modix.Bot.Extensions;
 using Modix.Data.Models;
 using Modix.Data.Models.Core;
 using Modix.Data.Repositories;
+using Modix.Services.CommandHelp;
 using Modix.Services.Core;
 using Modix.Services.Moderation;
 using Modix.Services.Promotions;
@@ -24,6 +23,9 @@ using Modix.Services.Utilities;
 
 namespace Modix.Modules
 {
+    [Name("User Information")]
+    [Summary("Retrieves information and statistics about the supplied user.")]
+    [HelpTags("userinfo", "info")]
     public class UserInfoModule : ModuleBase
     {
         //optimization: UtcNow is slow and the module is created per-request

--- a/Modix.Services/CommandHelp/CommandHelpService.cs
+++ b/Modix.Services/CommandHelp/CommandHelpService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Discord.Commands;
@@ -17,6 +18,15 @@ namespace Modix.Services.CommandHelp
         /// A readonly collection of data about all available modules.
         /// </returns>
         IReadOnlyCollection<ModuleHelpData> GetModuleHelpData();
+
+        /// <summary>
+        /// Retrieves help data for the supplied query.
+        /// </summary>
+        /// <param name="query">A query to use to search for an applicable help module.</param>
+        /// <returns>
+        /// Help information for the supplied query, or <see langword="null"/> if no information could be found for the supplied query.
+        /// </returns>
+        ModuleHelpData GetModuleHelpData(string query);
     }
 
     /// <inheritdoc />
@@ -37,5 +47,29 @@ namespace Modix.Services.CommandHelp
                     .Where(x => !x.Attributes.Any(attr => attr is HiddenFromHelpAttribute))
                     .Select(x => ModuleHelpData.FromModuleInfo(x))
                     .ToArray());
+
+        /// <inheritdoc />
+        public ModuleHelpData GetModuleHelpData(string query)
+        {
+            var allHelpData = GetModuleHelpData();
+
+            var byNameExact = allHelpData.FirstOrDefault(x => x.Name.Equals(query, StringComparison.OrdinalIgnoreCase));
+            if (byNameExact != null)
+                return byNameExact;
+
+            var byTagsExact = allHelpData.FirstOrDefault(x => x.HelpTags.Any(y => y.Equals(query, StringComparison.OrdinalIgnoreCase)));
+            if (byTagsExact != null)
+                return byTagsExact;
+
+            var byNameContains = allHelpData.FirstOrDefault(x => x.Name.Contains(query, StringComparison.OrdinalIgnoreCase));
+            if (byNameContains != null)
+                return byNameContains;
+
+            var byTagsContains = allHelpData.FirstOrDefault(x => x.HelpTags.Any(y => y.Contains(query, StringComparison.OrdinalIgnoreCase)));
+            if (byTagsContains != null)
+                return byTagsContains;
+
+            return null;
+        }
     }
 }

--- a/Modix.Services/CommandHelp/HelpTagsAttribute.cs
+++ b/Modix.Services/CommandHelp/HelpTagsAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Modix.Services.CommandHelp
+{
+    /// <summary>
+    /// Indicates tags to use during help searches to increase the hit rate of the module.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class HelpTagsAttribute : Attribute
+    {
+        public HelpTagsAttribute(params string[] tags)
+        {
+            Tags = tags;
+        }
+
+        public string[] Tags { get; }
+    }
+}

--- a/Modix.Services/CommandHelp/ModuleHelpData.cs
+++ b/Modix.Services/CommandHelp/ModuleHelpData.cs
@@ -14,6 +14,8 @@ namespace Modix.Services.CommandHelp
 
         public IReadOnlyCollection<CommandHelpData> Commands { get; set; }
 
+        public IReadOnlyCollection<string> HelpTags { get; set; }
+
         public static ModuleHelpData FromModuleInfo(ModuleInfo module)
         {
             var moduleName = module.Name;
@@ -34,6 +36,11 @@ namespace Modix.Services.CommandHelp
                     .Where(x => !ShouldBeHidden(x))
                     .Select(x => CommandHelpData.FromCommandInfo(x))
                     .ToArray(),
+                HelpTags = module.Attributes
+                    .OfType<HelpTagsAttribute>()
+                    .SingleOrDefault()
+                    ?.Tags
+                    ?? Array.Empty<string>(),
             };
 
             return ret;


### PR DESCRIPTION
I noticed that some `!help` queries don't return the information that the user was hoping for.

For example, this PR makes `!help eval` return help for the expected module.

I considered just taking the approach of making searches for a command name return information for the related command or module, but I noticed we have some very similar commands in different modules that would make that behave a little oddly. (For example, the designations commands.) Additionally, I like the flexibility of being able to define help tags that are neither part of the module name or a command name (e.g. "nominating").