### PR TITLE
Add campaign(s) as aliases for promotions commands

### DIFF
--- a/Modix.Bot/Modules/PromotionsModule.cs
+++ b/Modix.Bot/Modules/PromotionsModule.cs
@@ -16,7 +16,7 @@ namespace Modix.Modules
     [Name("Promotions")]
     [Summary("Manage promotion campaigns.")]
     [Group("promotions")]
-    [Alias("promotion")]
+    [Alias("promotion", "campaign", "campaigns")]
     public class PromotionsModule : ModuleBase
     {
         private const string DefaultApprovalMessage = "I approve of this nomination.";


### PR DESCRIPTION
Because people often try those while looking for the right command.