### PR TITLE
Ordering roles by position instead of hoist-status

### DIFF
--- a/Modix.Bot/Modules/GuildInfoModule.cs
+++ b/Modix.Bot/Modules/GuildInfoModule.cs
@@ -178,8 +178,8 @@ namespace Modix.Modules
         {
             var roles = guild.Roles
                 .Where(x => x.Id != guild.EveryoneRole.Id)
-                .OrderByDescending(x => x.IsHoisted)
-                .ThenByDescending(x => x.Position)
+                .OrderByDescending(x => x.Position)
+                .ThenByDescending(x => x.IsHoisted)
                 .ThenByDescending(x => x.Name);
 
             stringBuilder.AppendLine(Format.Bold("\u276F Guild Roles"))

--- a/Modix.Bot/Modules/GuildInfoModule.cs
+++ b/Modix.Bot/Modules/GuildInfoModule.cs
@@ -179,8 +179,7 @@ namespace Modix.Modules
             var roles = guild.Roles
                 .Where(x => x.Id != guild.EveryoneRole.Id)
                 .OrderByDescending(x => x.Position)
-                .ThenByDescending(x => x.IsHoisted)
-                .ThenByDescending(x => x.Name);
+                .ThenByDescending(x => x.IsHoisted);
 
             stringBuilder.AppendLine(Format.Bold("\u276F Guild Roles"))
                 .AppendLine(roles.Select(x => x.Mention).Humanize())


### PR DESCRIPTION
![picture](https://user-images.githubusercontent.com/22471295/55802882-6b882b80-5ad9-11e9-91b3-dfed3ad61f16.png)

Purely cosmetical PR.
Orders the roles by position first instead of hoist-status (i.e. Role is split to it's own list in the user-sidebar).