### PR TITLE
Config/Build cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM microsoft/dotnet:2.2-sdk-stretch as dotnet-test
 WORKDIR /src
 COPY . .
-RUN dotnet test Modix.Data.Test
+RUN dotnet test Modix.sln
 
 FROM microsoft/dotnet:2.2-sdk-stretch as dotnet-build
 WORKDIR /src

--- a/Modix.sln
+++ b/Modix.sln
@@ -18,7 +18,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Dockerfile = Dockerfile
-		NuGet.config = NuGet.config
 		readme.md = readme.md
 	EndProjectSection
 EndProject

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="Discord.Net Nightlies" value="https://www.myget.org/F/discord-net/api/v3/index.json" />
-    </packageSources>
-</configuration>


### PR DESCRIPTION
Removed deprecated package source reference, since we no longer run on Discord.NET Betas.

Removed the NuGet.config file entirely, as it's now empty, and any settings that go in it should now be doable in Directory.Build.props.

Adjusted dockerfile to include all Test projects in the build, not just Modix.Data.Test.