### PR TITLE
IReadySyncrhonizationProvider and ISelfUserProvider

### DIFF
--- a/Modix.Services.Test/Core/Messages/ReadyNotificationTests.cs
+++ b/Modix.Services.Test/Core/Messages/ReadyNotificationTests.cs
@@ -1,0 +1,21 @@
+﻿using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+
+namespace Modix.Services.Test.Core.Messages
+{
+    [TestFixture]
+    public class ReadyNotificationTests
+    {
+        #region Default Tests
+
+        [Test]
+        public void Default_Always_IsNotNull()
+        {
+            ReadyNotification.Default.ShouldNotBeNull();
+        }
+
+        #endregion Default Tests
+    }
+}

--- a/Modix.Services.Test/Core/ReadySynchronizationProviderTests.cs
+++ b/Modix.Services.Test/Core/ReadySynchronizationProviderTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Threading.Tasks;
+
+using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+
+using Modix.Services.Core;
+
+namespace Modix.Services.Test.Core
+{
+    [TestFixture]
+    public class ReadySynchronizationProviderTests
+    {
+        #region WhenReady Tests
+
+        [Test]
+        public void WhenReady_ReadyNotificationHasNotOccurred_IsNotCompleted()
+        {
+            var uut = new ReadySynchronizationProvider();
+
+            uut.WhenReady.IsCompleted.ShouldBeFalse();
+        }
+
+        [Test]
+        public async Task WhenReady_ReadyNotificationHasOccurred_IsCompleted()
+        {
+            var uut = new ReadySynchronizationProvider();
+
+            await uut.HandleNotificationAsync(ReadyNotification.Default);
+
+            var result = uut.WhenReady;
+
+            await result;
+
+            result.IsCompleted.ShouldBeTrue();
+        }
+
+        #endregion WhenReady Tests
+
+        #region HandleNotificationAsync() Tests
+
+        [Test]
+        public void HandleNotificationAsync_Always_CompletesImmediately()
+        {
+            var uut = new ReadySynchronizationProvider();
+
+            uut.HandleNotificationAsync(ReadyNotification.Default)
+                .IsCompleted.ShouldBeTrue();
+        }
+
+        [Test]
+        public async Task HandleNotificationAsync_HasBeenInvoked_DoesNotThrowException()
+        {
+            var uut = new ReadySynchronizationProvider();
+
+            await uut.HandleNotificationAsync(ReadyNotification.Default);
+
+            await uut.HandleNotificationAsync(ReadyNotification.Default);
+        }
+
+        #endregion HandleNotificationAsync() Tests
+    }
+}

--- a/Modix.Services.Test/Core/SelfUserProviderTests.cs
+++ b/Modix.Services.Test/Core/SelfUserProviderTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Moq.AutoMock;
+using NUnit.Framework;
+using Shouldly;
+
+using Discord.WebSocket;
+
+using Modix.Services.Core;
+
+namespace Modix.Services.Test.Core
+{
+    [TestFixture]
+    public class SelfUserProviderTests
+    {
+        #region GetSelfUserAsnyc() Tests
+
+        [Test]
+        public async Task GetSelfUserAsync_WhenReadyIsNotComplete_WaitsForWhenReady()
+        {
+            var autoMocker = new AutoMocker();
+
+            var whenReadySource = new TaskCompletionSource<object>();
+            autoMocker.GetMock<IReadySynchronizationProvider>()
+                .Setup(x => x.WhenReady)
+                .Returns(() => whenReadySource.Task);
+
+            var selfUser = autoMocker.Get<ISocketSelfUser>();
+            autoMocker.GetMock<IDiscordSocketClient>()
+                .Setup(x => x.CurrentUser)
+                .Returns(() => autoMocker.Get<ISocketSelfUser>());
+
+            var uut = autoMocker.CreateInstance<SelfUserProvider>();
+
+            var result = uut.GetSelfUserAsync();
+            result.IsCompleted.ShouldBeFalse();
+
+            whenReadySource.SetResult(null);
+            await result;
+
+            result.IsCompleted.ShouldBeTrue();
+            result.Result.ShouldBeSameAs(selfUser);
+        }
+
+        [Test]
+        public void GetSelfUserAsync_WhenReadyIsComplete_CompletesImmediately()
+        {
+            var autoMocker = new AutoMocker();
+
+            autoMocker.GetMock<IReadySynchronizationProvider>()
+                .Setup(x => x.WhenReady)
+                .Returns(() => Task.CompletedTask);
+
+            var selfUser = autoMocker.Get<ISocketSelfUser>();
+            autoMocker.GetMock<IDiscordSocketClient>()
+                .Setup(x => x.CurrentUser)
+                .Returns(() => autoMocker.Get<ISocketSelfUser>());
+
+            var uut = autoMocker.CreateInstance<SelfUserProvider>();
+
+            var result = uut.GetSelfUserAsync();
+            result.IsCompleted.ShouldBeTrue();
+
+            result.Result.ShouldBeSameAs(selfUser);
+        }
+
+        [Test]
+        public void GetSelfUserAsync_CancellationTokenIsCancelled_ThrowsCancellation()
+        {
+            var autoMocker = new AutoMocker();
+
+            autoMocker.GetMock<IReadySynchronizationProvider>()
+                .Setup(x => x.WhenReady)
+                .Returns(() => Task.Delay(-1));
+
+            var uut = autoMocker.CreateInstance<SelfUserProvider>();
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                var result = uut.GetSelfUserAsync(cancellationTokenSource.Token);
+
+                cancellationTokenSource.Cancel();
+
+                Should.Throw<TaskCanceledException>(result);
+            }
+        }
+
+        #endregion GetSelfUserAsnyc() Tests
+    }
+}

--- a/Modix.Services.Test/Moderation/InvitePurgingBehaviorTests.cs
+++ b/Modix.Services.Test/Moderation/InvitePurgingBehaviorTests.cs
@@ -25,9 +25,14 @@ namespace Modix.Services.Test.Moderation
 
             var uut = autoMocker.CreateInstance<InvitePurgingBehavior>();
 
-            autoMocker.GetMock<ISelfUser>()
+            var mockSelfUser = autoMocker.GetMock<ISocketSelfUser>();
+            mockSelfUser
                 .Setup(x => x.Id)
                 .Returns(1);
+
+            autoMocker.GetMock<ISelfUserProvider>()
+                .Setup(x => x.GetSelfUserAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(mockSelfUser.Object));
 
             return (autoMocker, uut);
         }
@@ -131,7 +136,7 @@ namespace Modix.Services.Test.Moderation
             uut.DesignatedChannelService.ShouldBeSameAs(autoMocker.Get<IDesignatedChannelService>());
             uut.AuthorizationService.ShouldBeSameAs(autoMocker.Get<IAuthorizationService>());
             uut.ModerationService.ShouldBeSameAs(autoMocker.Get<IModerationService>());
-            uut.SelfUser.ShouldBeSameAs(autoMocker.Get<ISelfUser>());
+            uut.SelfUserProvider.ShouldBeSameAs(autoMocker.Get<ISelfUserProvider>());
         }
 
         #endregion Constructor() Tests
@@ -215,7 +220,7 @@ namespace Modix.Services.Test.Moderation
             var notification = new MessageReceivedNotification(
                 message: BuildTestMessage(autoMocker, DefaultInviteLink));
 
-            autoMocker.GetMock<ISelfUser>()
+            autoMocker.GetMock<ISocketSelfUser>()
                 .Setup(x => x.Id)
                 .Returns(autoMocker.Get<IGuildUser>().Id);
 
@@ -304,7 +309,7 @@ namespace Modix.Services.Test.Moderation
                     DeleteMessageAsync(
                         notification.Message,
                         It.Is<string>(y => y.Contains("invite", StringComparison.OrdinalIgnoreCase)),
-                        autoMocker.Get<ISelfUser>().Id));
+                        autoMocker.Get<ISocketSelfUser>().Id));
         }
 
         [Test]
@@ -417,7 +422,7 @@ namespace Modix.Services.Test.Moderation
                 newMessage: BuildTestMessage(autoMocker, DefaultInviteLink),
                 channel: autoMocker.Get<IISocketMessageChannel>());
 
-            autoMocker.GetMock<ISelfUser>()
+            autoMocker.GetMock<ISocketSelfUser>()
                 .Setup(x => x.Id)
                 .Returns(autoMocker.Get<IGuildUser>().Id);
 
@@ -516,7 +521,7 @@ namespace Modix.Services.Test.Moderation
                     DeleteMessageAsync(
                         notification.NewMessage,
                         It.Is<string>(y => y.Contains("invite", StringComparison.OrdinalIgnoreCase)),
-                        autoMocker.Get<ISelfUser>().Id));
+                        autoMocker.Get<ISocketSelfUser>().Id));
         }
 
         [Test]

--- a/Modix.Services/CommandHelp/CommandErrorHandler.cs
+++ b/Modix.Services/CommandHelp/CommandErrorHandler.cs
@@ -5,8 +5,11 @@ using System.Threading.Tasks;
 
 using Discord;
 using Discord.WebSocket;
+
 using Microsoft.Extensions.Caching.Memory;
+
 using Modix.Common.Messaging;
+using Modix.Services.Core;
 
 namespace Modix.Services.CommandHelp
 {
@@ -27,12 +30,12 @@ namespace Modix.Services.CommandHelp
 
         private const string _emoji = "⚠";
         private readonly IEmote _emote = new Emoji(_emoji);
-        private readonly ISelfUser _botUser;
+        private readonly ISelfUserProvider _selfUserProvider;
         private readonly IMemoryCache _memoryCache;
 
-        public CommandErrorHandler(ISelfUser botUser, IMemoryCache memoryCache)
+        public CommandErrorHandler(ISelfUserProvider selfUserProvider, IMemoryCache memoryCache)
         {
-            _botUser = botUser;
+            _selfUserProvider = selfUserProvider;
             _memoryCache = memoryCache;
         }
 
@@ -135,7 +138,7 @@ namespace Modix.Services.CommandHelp
                     await originalMessage.RemoveReactionAsync(_emote, reaction.User.Value);
                 }
 
-                await originalMessage.RemoveReactionAsync(_emote, _botUser);
+                await originalMessage.RemoveReactionAsync(_emote, await _selfUserProvider.GetSelfUserAsync());
             }
         }
     }

--- a/Modix.Services/Core/CoreSetup.cs
+++ b/Modix.Services/Core/CoreSetup.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Discord;
 
+using Microsoft.Extensions.DependencyInjection;
+
+using Modix.Common.Messaging;
 using Modix.Data.Repositories;
 
 namespace Modix.Services.Core
@@ -22,6 +25,10 @@ namespace Modix.Services.Core
                 .AddSingleton<IBehavior, UserTrackingBehavior>()
                 .AddSingleton<IBehavior, MessageLogBehavior>()
                 .AddSingleton<IBehavior, DiscordSocketListeningBehavior>()
+                .AddSingleton<ReadySynchronizationProvider>()
+                .AddSingleton<IReadySynchronizationProvider>(x => x.GetService<ReadySynchronizationProvider>())
+                .AddSingleton<INotificationHandler<ReadyNotification>>(x => x.GetService<ReadySynchronizationProvider>())
+                .AddSingleton<ISelfUserProvider, SelfUserProvider>()
                 .AddScoped<IAuthorizationService, AuthorizationService>()
                 .AddScoped<IChannelService, ChannelService>()
                 .AddScoped<IRoleService, RoleService>()

--- a/Modix.Services/Core/DiscordSocketListeningBehavior.cs
+++ b/Modix.Services/Core/DiscordSocketListeningBehavior.cs
@@ -30,6 +30,7 @@ namespace Modix.Services.Core
             DiscordSocketClient.MessageUpdated += OnMessageUpdatedAsync;
             DiscordSocketClient.ReactionAdded += OnReactionAddedAsync;
             DiscordSocketClient.ReactionRemoved += OnReactionRemovedAsync;
+            DiscordSocketClient.Ready += OnReadyAsync;
             DiscordSocketClient.UserBanned += OnUserBannedAsync;
             DiscordSocketClient.UserJoined += OnUserJoinedAsync;
             DiscordSocketClient.UserLeft += OnUserLeftAsync;
@@ -45,6 +46,7 @@ namespace Modix.Services.Core
             DiscordSocketClient.MessageUpdated -= OnMessageUpdatedAsync;
             DiscordSocketClient.ReactionAdded -= OnReactionAddedAsync;
             DiscordSocketClient.ReactionRemoved -= OnReactionRemovedAsync;
+            DiscordSocketClient.Ready -= OnReadyAsync;
             DiscordSocketClient.UserBanned -= OnUserBannedAsync;
             DiscordSocketClient.UserJoined -= OnUserJoinedAsync;
             DiscordSocketClient.UserLeft -= OnUserLeftAsync;
@@ -93,6 +95,13 @@ namespace Modix.Services.Core
         private Task OnReactionRemovedAsync(ICacheable<IUserMessage, ulong> message, IISocketMessageChannel channel, ISocketReaction reaction)
         {
             MessageDispatcher.Dispatch(new ReactionRemovedNotification(message, channel, reaction));
+
+            return Task.CompletedTask;
+        }
+
+        private Task OnReadyAsync()
+        {
+            MessageDispatcher.Dispatch(ReadyNotification.Default);
 
             return Task.CompletedTask;
         }

--- a/Modix.Services/Core/Messages/ReadyNotification.cs
+++ b/Modix.Services/Core/Messages/ReadyNotification.cs
@@ -1,0 +1,20 @@
+﻿using Discord.WebSocket;
+
+using Modix.Common.Messaging;
+
+namespace Discord
+{
+    /// <summary>
+    /// Describes an application-wide notification that occurs when <see cref="IDiscordSocketClient.Ready"/> is raised.
+    /// </summary>
+    public class ReadyNotification : INotification
+    {
+        /// <summary>
+        /// A default, reusable instance of the <see cref="ReadyNotification"/> class.
+        /// </summary>
+        public static readonly ReadyNotification Default
+            = new ReadyNotification();
+
+        private ReadyNotification() { }
+    }
+}

--- a/Modix.Services/Core/ReadySynchronizationProvider.cs
+++ b/Modix.Services/Core/ReadySynchronizationProvider.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Discord;
+using Discord.WebSocket;
+
+using Modix.Common.Messaging;
+
+namespace Modix.Services.Core
+{
+    /// <summary>
+    /// Provides application-wide synchronization for asynchronous operations,
+    /// based on the <see cref="IDiscordSocketClient.Ready"/>.
+    /// </summary>
+    public interface IReadySynchronizationProvider
+    {
+        /// <summary>
+        /// A <see cref="Task"/> that will complete the first time <see cref="IDiscordSocketClient.Ready"/> is raised.
+        /// </summary>
+        Task WhenReady { get; }
+    }
+
+    /// <inheritdoc />
+    public class ReadySynchronizationProvider
+        : IReadySynchronizationProvider,
+            INotificationHandler<ReadyNotification>
+    {
+        public ReadySynchronizationProvider()
+        {
+            _whenReadySource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public Task WhenReady
+            => _whenReadySource.Task;
+
+        public Task HandleNotificationAsync(ReadyNotification notification, CancellationToken cancellationToken = default)
+        {
+            _whenReadySource.TrySetResult(null);
+
+            return Task.CompletedTask;
+        }
+
+        private readonly TaskCompletionSource<object> _whenReadySource;
+    }
+}

--- a/Modix.Services/Core/SelfUserProvider.cs
+++ b/Modix.Services/Core/SelfUserProvider.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+using Discord.WebSocket;
+
+using Nito.AsyncEx;
+
+namespace Modix.Services.Core
+{
+    /// <summary>
+    /// Provides application-wide synchronization for access to <see cref="IBaseSocketClient.CurrentUser"/>,
+    /// which is only available after <see cref="IDiscordSocketClient.Ready"/> has occurred.
+    /// </summary>
+    public interface ISelfUserProvider
+    {
+        Task<ISocketSelfUser> GetSelfUserAsync(CancellationToken cancellationToken = default);
+    }
+
+    /// <inheritdoc />
+    public class SelfUserProvider
+        : ISelfUserProvider
+    {
+        public SelfUserProvider(
+            IDiscordSocketClient discordSocketClient,
+            IReadySynchronizationProvider readySynchronizationProvider)
+        {
+            _discordSocketClient = discordSocketClient;
+            _readySynchronizationProvider = readySynchronizationProvider;
+        }
+
+        /// <inheritdoc />
+        public async Task<ISocketSelfUser> GetSelfUserAsync(CancellationToken cancellationToken = default)
+        {
+            await _readySynchronizationProvider.WhenReady.WaitAsync(cancellationToken);
+
+            return _discordSocketClient.CurrentUser;
+        }
+
+        private readonly IDiscordSocketClient _discordSocketClient;
+
+        private readonly IReadySynchronizationProvider _readySynchronizationProvider;
+    }
+}

--- a/Modix.Services/Moderation/MutePersistingHandler.cs
+++ b/Modix.Services/Moderation/MutePersistingHandler.cs
@@ -6,6 +6,7 @@ using Discord.WebSocket;
 
 using Modix.Common.Messaging;
 using Modix.Data.Models.Moderation;
+using Modix.Services.Core;
 
 using Serilog;
 
@@ -18,19 +19,19 @@ namespace Modix.Services.Moderation
         INotificationHandler<UserJoinedNotification>
     {
         private readonly IModerationService _moderationService;
-        private readonly ISelfUser _botUser;
+        private readonly ISelfUserProvider _selfUserProvider;
 
         /// <summary>
         /// Constructs a new <see cref="MutePersistingHandler"/> object with the given injected dependencies.
         /// </summary>
         /// <param name="moderationService">A moderation service to interact with the infractions system.</param>
-        /// <param name="botUser">The Discord user that the bot is running as.</param>
+        /// <param name="selfUserProvider">The Discord user that the bot is running as.</param>
         public MutePersistingHandler(
             IModerationService moderationService,
-            ISelfUser botUser)
+            ISelfUserProvider selfUserProvider)
         {
             _moderationService = moderationService;
-            _botUser = botUser;
+            _selfUserProvider = selfUserProvider;
         }
 
         public Task HandleNotificationAsync(UserJoinedNotification notification, CancellationToken cancellationToken)
@@ -61,7 +62,7 @@ namespace Modix.Services.Moderation
                 return;
             }
 
-            var muteRole = await _moderationService.GetOrCreateDesignatedMuteRoleAsync(guildUser.Guild, _botUser.Id);
+            var muteRole = await _moderationService.GetOrCreateDesignatedMuteRoleAsync(guildUser.Guild, (await _selfUserProvider.GetSelfUserAsync()).Id);
 
             Log.Debug("User {0} was muted, because they have an active mute infraction.", guildUser.Id);
 

--- a/Modix.Services/Promotions/PromotionLoggingHandler.cs
+++ b/Modix.Services/Promotions/PromotionLoggingHandler.cs
@@ -27,21 +27,21 @@ namespace Modix.Services.Promotions
             IDesignatedChannelService designatedChannelService,
             IUserService userService,
             IPromotionsService promotionsService,
-            ISelfUser selfUser)
+            ISelfUserProvider selfUserProvider)
         {
             AuthorizationService = authorizationService;
             DiscordClient = discordClient;
             DesignatedChannelService = designatedChannelService;
             UserService = userService;
             PromotionsService = promotionsService;
-            SelfUser = selfUser;
+            SelfUserProvider = selfUserProvider;
         }
         
         public async Task HandleNotificationAsync(PromotionActionCreatedNotification notification, CancellationToken cancellationToken)
         {
             // TODO: Temporary workaround, remove as part of auth rework.
             if (AuthorizationService.CurrentUserId is null)
-                await AuthorizationService.OnAuthenticatedAsync(SelfUser);
+                await AuthorizationService.OnAuthenticatedAsync(await SelfUserProvider.GetSelfUserAsync());
 
             if (await DesignatedChannelService.AnyDesignatedChannelAsync(notification.Data.GuildId, DesignatedChannelType.PromotionLog))
             {
@@ -139,9 +139,9 @@ namespace Modix.Services.Promotions
         internal protected IPromotionsService PromotionsService { get; }
 
         /// <summary>
-        /// The <see cref="ISelfUser"/> representing the bot, within the Discord API.
+        /// An <see cref="ISelfUserProvider"/> for interacting with the current bot user.
         /// </summary>
-        internal protected ISelfUser SelfUser { get; }
+        internal protected ISelfUserProvider SelfUserProvider { get; }
 
         private static readonly Dictionary<(PromotionActionType, PromotionSentiment?, PromotionCampaignOutcome?), string> _logRenderTemplates
             = new Dictionary<(PromotionActionType, PromotionSentiment?, PromotionCampaignOutcome?), string>()

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddSingleton<IDiscordSocketClient>(provider => provider.GetRequiredService<DiscordSocketClient>().Abstract());
             services.AddSingleton<IDiscordClient>(provider => provider.GetRequiredService<DiscordSocketClient>());
-            services.AddScoped<ISelfUser>(p => p.GetRequiredService<DiscordSocketClient>().CurrentUser);
 
             services.AddSingleton(
                 provider => new DiscordRestClient(config: new DiscordRestConfig


### PR DESCRIPTION
Implemented `ISelfUserProvider`, which provides a `.GetSelfUserAsync()` method that completes only after the `IDiscordSocketClient.Ready` event has been raised, and `IReadySynchronizationProvider` to support it.

This should help with the recurring issue we've had with having `ISelfUser` injected through DI, but as a scoped service, rather than a singleton, which necessitates other services that pull it be scoped, when they could otherwise be singletons.