### PR TITLE
Abstraction fixes: null checks

### DIFF
--- a/Discord.Net.Abstractions/Rest/IBaseDiscordClient.cs
+++ b/Discord.Net.Abstractions/Rest/IBaseDiscordClient.cs
@@ -98,7 +98,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IChannel> GetChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (BaseDiscordClient as IDiscordClient).GetChannelAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public Task<IReadOnlyCollection<IConnection>> GetConnectionsAsync(RequestOptions options = null)
@@ -119,7 +119,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IGuild> GetGuildAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (BaseDiscordClient as IDiscordClient).GetGuildAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IGuild>> GetGuildsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
@@ -130,7 +130,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IInvite> GetInviteAsync(string inviteId, RequestOptions options = null)
             => (await (BaseDiscordClient as IDiscordClient).GetInviteAsync(inviteId, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IPrivateChannel>> GetPrivateChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
@@ -145,17 +145,17 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (BaseDiscordClient as IDiscordClient).GetUserAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IUser> GetUserAsync(string username, string discriminator, RequestOptions options = null)
             => (await (BaseDiscordClient as IDiscordClient).GetUserAsync(username, discriminator, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IVoiceRegion> GetVoiceRegionAsync(string id, RequestOptions options = null)
             => (await (BaseDiscordClient as IDiscordClient).GetVoiceRegionAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IVoiceRegion>> GetVoiceRegionsAsync(RequestOptions options = null)
@@ -166,7 +166,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
             => (await (BaseDiscordClient as IDiscordClient).GetWebhookAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public Task LoginAsync(TokenType tokenType, string token, bool validateToken = true)

--- a/Discord.Net.Abstractions/Rest/IDiscordRestClient.cs
+++ b/Discord.Net.Abstractions/Rest/IDiscordRestClient.cs
@@ -100,7 +100,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestChannel> GetChannelAsync(ulong id, RequestOptions options = null)
             => (await DiscordRestClient.GetChannelAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IRestDMChannel>> GetDMChannelsAsync(RequestOptions options = null)
@@ -117,7 +117,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestGuild> GetGuildAsync(ulong id, RequestOptions options = null)
             => (await DiscordRestClient.GetGuildAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IRestGuildEmbed> GetGuildEmbedAsync(ulong id, RequestOptions options = null)
@@ -147,12 +147,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestGuildUser> GetGuildUserAsync(ulong guildId, ulong id, RequestOptions options = null)
             => (await DiscordRestClient.GetGuildUserAsync(guildId, id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         new public async Task<IRestInviteMetadata> GetInviteAsync(string inviteId, RequestOptions options)
             => (await DiscordRestClient.GetInviteAsync(inviteId, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IIRestPrivateChannel>> GetPrivateChannelsAsync(RequestOptions options = null)
@@ -163,12 +163,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestUser> GetUserAsync(ulong id, RequestOptions options = null)
             => (await DiscordRestClient.GetUserAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         new public async Task<IRestVoiceRegion> GetVoiceRegionAsync(string id, RequestOptions options)
             => (await DiscordRestClient.GetVoiceRegionAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         new public async Task<IReadOnlyCollection<IRestVoiceRegion>> GetVoiceRegionsAsync(RequestOptions options)
@@ -179,7 +179,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         new public async Task<IRestWebhook> GetWebhookAsync(ulong id, RequestOptions options)
             => (await DiscordRestClient.GetWebhookAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <summary>
         /// The existing <see cref="Rest.DiscordRestClient"/> being abstracted.

--- a/Discord.Net.Abstractions/Rest/IRestChannel.cs
+++ b/Discord.Net.Abstractions/Rest/IRestChannel.cs
@@ -38,7 +38,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (RestChannel as IChannel).GetUserAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetUsersAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)

--- a/Discord.Net.Abstractions/Rest/IRestDMChannel.cs
+++ b/Discord.Net.Abstractions/Rest/IRestDMChannel.cs
@@ -113,7 +113,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestMessage> GetMessageAsync(ulong id, RequestOptions options = null)
             => (await RestDMChannel.GetMessageAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IMessage> GetMessageAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
@@ -177,7 +177,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public IRestUser GetUser(ulong id)
             => RestDMChannel.GetUser(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null)

--- a/Discord.Net.Abstractions/Rest/IRestGroupChannel.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGroupChannel.cs
@@ -105,12 +105,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestMessage> GetMessageAsync(ulong id, RequestOptions options = null)
             => (await RestGroupChannel.GetMessageAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IMessage> GetMessageAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (RestGroupChannel as IMessageChannel).GetMessageAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IRestMessage>> GetMessagesAsync(int limit = 100, RequestOptions options = null)
@@ -169,7 +169,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public IRestUser GetUser(ulong id)
             => RestGroupChannel.GetUser(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public Task LeaveAsync(RequestOptions options = null)

--- a/Discord.Net.Abstractions/Rest/IRestGuild.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGuild.cs
@@ -367,12 +367,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestVoiceChannel> GetAFKChannelAsync(RequestOptions options = null)
             => (await RestGuild.GetAFKChannelAsync(options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IVoiceChannel> GetAFKChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (RestGuild as IGuild).GetAFKChannelAsync(mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IRestAuditLogEntry>> GetAuditLogsAsync(int limit, RequestOptions options = null)
@@ -414,12 +414,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestGuildChannel> GetChannelAsync(ulong id, RequestOptions options = null)
             => (await RestGuild.GetChannelAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IGuildChannel> GetChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (RestGuild as IGuild).GetChannelAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IRestGuildChannel>> GetChannelsAsync(RequestOptions options = null)
@@ -446,27 +446,27 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestTextChannel> GetDefaultChannelAsync(RequestOptions options = null)
             => (await RestGuild.GetDefaultChannelAsync(options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<ITextChannel> GetDefaultChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (RestGuild as IGuild).GetDefaultChannelAsync(mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IRestGuildChannel> GetEmbedChannelAsync(RequestOptions options = null)
             => (await RestGuild.GetEmbedChannelAsync(options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IGuildChannel> GetEmbedChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (RestGuild as IGuild).GetEmbedChannelAsync(mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IGuildEmote> GetEmoteAsync(ulong id, RequestOptions options = null)
             => (await RestGuild.GetEmoteAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         Task<GuildEmote> IGuild.GetEmoteAsync(ulong id, RequestOptions options)
@@ -509,12 +509,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public IRestRole GetRole(ulong id)
             => RestGuild.GetRole(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         IRole IGuild.GetRole(ulong id)
             => (RestGuild as IGuild).GetRole(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IRestTextChannel> GetSystemChannelAsync(RequestOptions options = null)
@@ -529,12 +529,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestTextChannel> GetTextChannelAsync(ulong id, RequestOptions options = null)
             => (await RestGuild.GetTextChannelAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<ITextChannel> GetTextChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (RestGuild as IGuild).GetTextChannelAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IRestTextChannel>> GetTextChannelsAsync(RequestOptions options = null)
@@ -549,12 +549,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestGuildUser> GetUserAsync(ulong id, RequestOptions options = null)
             => (await RestGuild.GetUserAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IGuildUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (RestGuild as IGuild).GetUserAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IRestGuildUser>> GetUsersAsync(RequestOptions options = null)
@@ -572,22 +572,22 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestInviteMetadata> GetVanityInviteAsync(RequestOptions options = null)
             => (await RestGuild.GetVanityInviteAsync(options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         async Task<IInviteMetadata> IGuild.GetVanityInviteAsync(RequestOptions options)
             => (await (RestGuild as IGuild).GetVanityInviteAsync(options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IRestVoiceChannel> GetVoiceChannelAsync(ulong id, RequestOptions options = null)
             => (await RestGuild.GetVoiceChannelAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IVoiceChannel> GetVoiceChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (RestGuild as IGuild).GetVoiceChannelAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IRestVoiceChannel>> GetVoiceChannelsAsync(RequestOptions options = null)
@@ -616,12 +616,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
             => (await RestGuild.GetWebhookAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         async Task<IWebhook> IGuild.GetWebhookAsync(ulong id, RequestOptions options)
             => (await (RestGuild as IGuild).GetWebhookAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IRestWebhook>> GetWebhooksAsync(RequestOptions options = null)

--- a/Discord.Net.Abstractions/Rest/IRestGuildChannel.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGuildChannel.cs
@@ -65,7 +65,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         async Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
             => (await (RestGuildChannel as IGuildChannel).GetUserAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)

--- a/Discord.Net.Abstractions/Rest/IRestTextChannel.cs
+++ b/Discord.Net.Abstractions/Rest/IRestTextChannel.cs
@@ -139,12 +139,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestMessage> GetMessageAsync(ulong id, RequestOptions options = null)
             => (await RestTextChannel.GetMessageAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IMessage> GetMessageAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (RestTextChannel as IMessageChannel).GetMessageAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IRestMessage>> GetMessagesAsync(int limit = 100, RequestOptions options = null)
@@ -203,7 +203,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestGuildUser> GetUserAsync(ulong id, RequestOptions options = null)
             => (await RestTextChannel.GetUserAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IRestGuildUser>> GetUsersAsync(RequestOptions options = null)
@@ -215,12 +215,12 @@ namespace Discord.Rest
         /// <inheritdoc />
         public async Task<IRestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
             => (await RestTextChannel.GetWebhookAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         async Task<IWebhook> ITextChannel.GetWebhookAsync(ulong id, RequestOptions options)
             => (await (RestTextChannel as ITextChannel).GetWebhookAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IRestWebhook>> GetWebhooksAsync(RequestOptions options = null)

--- a/Discord.Net.Abstractions/Rest/IRestWebhook.cs
+++ b/Discord.Net.Abstractions/Rest/IRestWebhook.cs
@@ -46,7 +46,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public IGuild Guild
             => (RestWebhook as IWebhook).Guild
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public ulong? GuildId

--- a/Discord.Net.Abstractions/Rest/IRestWebhookUser.cs
+++ b/Discord.Net.Abstractions/Rest/IRestWebhookUser.cs
@@ -25,7 +25,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         IGuild IGuildUser.Guild
             => (RestWebhookUser as IGuildUser).Guild
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public ulong GuildId

--- a/Discord.Net.Abstractions/WebSocket/IBaseSocketClient.cs
+++ b/Discord.Net.Abstractions/WebSocket/IBaseSocketClient.cs
@@ -349,32 +349,42 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketChannel GetChannel(ulong id)
             => BaseSocketClient.GetChannel(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public ISocketGuild GetGuild(ulong id)
             => BaseSocketClient.GetGuild(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         new public async Task<IRestInviteMetadata> GetInviteAsync(string inviteId, RequestOptions options)
-            => RestInviteMetadataAbstractionExtensions.Abstract(
-                await BaseSocketClient.GetInviteAsync(inviteId, options));
+        {
+            var restInviteMetadata = await BaseSocketClient.GetInviteAsync(inviteId, options);
+
+            return (restInviteMetadata is null)
+                ? null
+                : RestInviteMetadataAbstractionExtensions.Abstract(restInviteMetadata);
+        }
 
         /// <inheritdoc />
         public ISocketUser GetUser(ulong id)
             => BaseSocketClient.GetUser(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public ISocketUser GetUser(string username, string discriminator)
             => BaseSocketClient.GetUser(username, discriminator)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IRestVoiceRegion GetVoiceRegion(string id)
-            => RestVoiceRegionAbstractionExtensions.Abstract(
-                BaseSocketClient.GetVoiceRegion(id));
+        {
+            var restVoiceRegion = BaseSocketClient.GetVoiceRegion(id);
+
+            return (restVoiceRegion is null)
+                ? null
+                : RestVoiceRegionAbstractionExtensions.Abstract(restVoiceRegion);
+        }
 
         /// <inheritdoc />
         public Task SetActivityAsync(IActivity activity)

--- a/Discord.Net.Abstractions/WebSocket/IDiscordShardedClient.cs
+++ b/Discord.Net.Abstractions/WebSocket/IDiscordShardedClient.cs
@@ -70,12 +70,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public IDiscordSocketClient GetShard(int id)
             => DiscordShardedClient.GetShard(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IDiscordSocketClient GetShardFor(IGuild guild)
             => DiscordShardedClient.GetShardFor(guild)
-                .Abstract();
+                ?.Abstract();
 
         /// <summary>
         /// The existing <see cref="WebSocket.DiscordShardedClient"/> being abstracted.

--- a/Discord.Net.Abstractions/WebSocket/ISocketChannel.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketChannel.cs
@@ -51,12 +51,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketUser GetUser(ulong id)
             => SocketChannel.GetUser(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketChannel as IChannel).GetUserAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetUsersAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)

--- a/Discord.Net.Abstractions/WebSocket/ISocketDMChannel.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketDMChannel.cs
@@ -120,7 +120,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketMessage GetCachedMessage(ulong id)
             => SocketDMChannel.GetCachedMessage(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IReadOnlyCollection<ISocketMessage> GetCachedMessages(int limit = 100)
@@ -143,12 +143,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public async Task<IMessage> GetMessageAsync(ulong id, RequestOptions options = null)
             => (await SocketDMChannel.GetMessageAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IMessage> GetMessageAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketDMChannel as IMessageChannel).GetMessageAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IMessage>> GetMessagesAsync(int limit = 100, RequestOptions options = null)

--- a/Discord.Net.Abstractions/WebSocket/ISocketGroupChannel.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGroupChannel.cs
@@ -110,7 +110,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketMessage GetCachedMessage(ulong id)
             => SocketGroupChannel.GetCachedMessage(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IReadOnlyCollection<ISocketMessage> GetCachedMessages(int limit = 100)
@@ -138,7 +138,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public async Task<IMessage> GetMessageAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketGroupChannel as IMessageChannel).GetMessageAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IMessage>> GetMessagesAsync(int limit = 100, RequestOptions options = null)
@@ -197,7 +197,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         new public ISocketGroupUser GetUser(ulong id)
             => SocketGroupChannel.GetUser(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public Task LeaveAsync(RequestOptions options = null)

--- a/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
@@ -476,7 +476,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public async Task<IVoiceChannel> GetAFKChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketGuild as IGuild).GetAFKChannelAsync(mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IRestAuditLogEntry>> GetAuditLogsAsync(int limit, RequestOptions options = null)
@@ -512,7 +512,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketGuildChannel GetChannel(ulong id)
             => SocketGuild.GetChannel(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IGuildChannel> GetChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
@@ -533,17 +533,17 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public async Task<ITextChannel> GetDefaultChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketGuild as IGuild).GetDefaultChannelAsync(mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IGuildChannel> GetEmbedChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketGuild as IGuild).GetEmbedChannelAsync(mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IGuildEmote> GetEmoteAsync(ulong id, RequestOptions options = null)
             => (await SocketGuild.GetEmoteAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         Task<GuildEmote> IGuild.GetEmoteAsync(ulong id, RequestOptions options)
@@ -581,12 +581,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketRole GetRole(ulong id)
             => SocketGuild.GetRole(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         IRole IGuild.GetRole(ulong id)
             => (SocketGuild as IGuild).GetRole(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<ITextChannel> GetSystemChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
@@ -596,12 +596,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketTextChannel GetTextChannel(ulong id)
             => SocketGuild.GetTextChannel(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<ITextChannel> GetTextChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketGuild as IGuild).GetTextChannelAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<ITextChannel>> GetTextChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
@@ -612,12 +612,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketGuildUser GetUser(ulong id)
             => SocketGuild.GetUser(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IGuildUser> GetUserAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketGuild as IGuild).GetUserAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IGuildUser>> GetUsersAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
@@ -638,12 +638,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketVoiceChannel GetVoiceChannel(ulong id)
             => SocketGuild.GetVoiceChannel(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IVoiceChannel> GetVoiceChannelAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketGuild as IGuild).GetVoiceChannelAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IVoiceChannel>> GetVoiceChannelsAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
@@ -665,13 +665,18 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public async Task<IRestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
-            => RestWebhookAbstractionExtensions.Abstract(
-                await SocketGuild.GetWebhookAsync(id, options));
+        {
+            var restWebhook = await SocketGuild.GetWebhookAsync(id, options);
+
+            return (restWebhook is null)
+                ? null
+                : RestWebhookAbstractionExtensions.Abstract(restWebhook);
+        }
 
         /// <inheritdoc />
         async Task<IWebhook> IGuild.GetWebhookAsync(ulong id, RequestOptions options)
             => (await (SocketGuild as IGuild).GetWebhookAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IRestWebhook>> GetWebhooksAsync(RequestOptions options = null)

--- a/Discord.Net.Abstractions/WebSocket/ISocketGuildChannel.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGuildChannel.cs
@@ -82,12 +82,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         new public ISocketGuildUser GetUser(ulong id)
             => SocketGuildChannel.GetUser(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         async Task<IGuildUser> IGuildChannel.GetUserAsync(ulong id, CacheMode mode, RequestOptions options)
             => (await (SocketGuildChannel as IGuildChannel).GetUserAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         IAsyncEnumerable<IReadOnlyCollection<IGuildUser>> IGuildChannel.GetUsersAsync(CacheMode mode, RequestOptions options)

--- a/Discord.Net.Abstractions/WebSocket/ISocketTextChannel.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketTextChannel.cs
@@ -118,7 +118,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketMessage GetCachedMessage(ulong id)
             => SocketTextChannel.GetCachedMessage(id)
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IReadOnlyCollection<ISocketMessage> GetCachedMessages(int limit = 100)
@@ -152,12 +152,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public async Task<IMessage> GetMessageAsync(ulong id, RequestOptions options = null)
             => (await SocketTextChannel.GetMessageAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IMessage> GetMessageAsync(ulong id, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketTextChannel as IMessageChannel).GetMessageAsync(id, mode, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public IAsyncEnumerable<IReadOnlyCollection<IMessage>> GetMessagesAsync(int limit = 100, RequestOptions options = null)
@@ -215,13 +215,18 @@ namespace Discord.WebSocket
 
         /// <inheritdoc />
         public async Task<IRestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
-            => RestWebhookAbstractionExtensions.Abstract(
-                await SocketTextChannel.GetWebhookAsync(id, options));
+        {
+            var restWebhook = await SocketTextChannel.GetWebhookAsync(id, options);
+
+            return (restWebhook is null)
+                ? null
+                : RestWebhookAbstractionExtensions.Abstract(restWebhook);
+        }
 
         /// <inheritdoc />
         async Task<IWebhook> ITextChannel.GetWebhookAsync(ulong id, RequestOptions options)
             => (await (SocketTextChannel as ITextChannel).GetWebhookAsync(id, options))
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<IRestWebhook>> GetWebhooksAsync(RequestOptions options = null)

--- a/Discord.Net.Abstractions/WebSocket/ISocketWebhookUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketWebhookUser.cs
@@ -27,12 +27,12 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public ISocketGuild Guild
             => SocketWebhookUser.Guild
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         IGuild IGuildUser.Guild
             => (SocketWebhookUser as IGuildUser).Guild
-                .Abstract();
+                ?.Abstract();
 
         /// <inheritdoc />
         public ulong GuildId


### PR DESCRIPTION
Methods such as `GetXXX(id)` may return null, so `.Abstract()` calls upon them need to be null-checked.

Also, `.Guild` on webhooks.