### PR TITLE
AuthorizationAutoConfigBehavior Refactoring and Tests

### DIFF
--- a/Modix.Common.Test/Assertions/MoqAssertions.cs
+++ b/Modix.Common.Test/Assertions/MoqAssertions.cs
@@ -7,11 +7,11 @@ namespace Shouldly
 {
     public static class MoqAssertions
     {
-        public static void ShouldHaveReceived<T>(this Mock<T> mock, Expression<Action<T>> expression) where T : class
-            => mock.Verify(expression);
+        public static void ShouldHaveReceived<T>(this Mock<T> mock, Expression<Action<T>> expression, Times? times = null) where T : class
+            => mock.Verify(expression, times ?? Times.AtLeastOnce());
 
-        public static void ShouldHaveReceived<T, TResult>(this Mock<T> mock, Expression<Func<T, TResult>> expression) where T : class
-            => mock.Verify(expression);
+        public static void ShouldHaveReceived<T, TResult>(this Mock<T> mock, Expression<Func<T, TResult>> expression, Times? times = null) where T : class
+            => mock.Verify(expression, times ?? Times.AtLeastOnce());
 
         public static void ShouldNotHaveReceived<T>(this Mock<T> mock, Expression<Action<T>> expression) where T : class
             => mock.Verify(expression, Times.Never);

--- a/Modix.Services.Test/Core/AuthorizationAutoConfigBehaviorTests.cs
+++ b/Modix.Services.Test/Core/AuthorizationAutoConfigBehaviorTests.cs
@@ -1,0 +1,94 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+using Moq;
+using Moq.AutoMock;
+using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+using Discord.WebSocket;
+
+using Modix.Services.Core;
+
+namespace Modix.Services.Test.Core
+{
+    [TestFixture]
+    public class AuthorizationAutoConfigBehaviorTests
+    {
+        #region HandleNotificationAsync(GuildAvailableNotification) Tests
+
+        [Test]
+        public async Task HandleNotificationAsync_GuildAvailableNotification_Always_InvokesAutoConfigureGuildAsync()
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<AuthorizationAutoConfigBehavior>();
+
+            var guild = autoMocker.Get<ISocketGuild>();
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                var notification = new GuildAvailableNotification(guild);
+
+                await uut.HandleNotificationAsync(notification, cancellationTokenSource.Token);
+
+                autoMocker.GetMock<IAuthorizationService>()
+                    .ShouldHaveReceived(x => x.AutoConfigureGuildAsync(guild, cancellationTokenSource.Token));
+            }
+        }
+
+        #endregion HandleNotificationAsync(GuildAvailableNotification) Tests
+
+        #region HandleNotificationAsync(JoinedGuildNotification) Tests
+
+        [Test]
+        public void HandleNotificationAsync_JoinedGuildNotification_GuildIsNotAvailable_CompletesImmediately()
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<AuthorizationAutoConfigBehavior>();
+
+            var mockGuild = autoMocker.GetMock<ISocketGuild>();
+            mockGuild
+                .Setup(x => x.Available)
+                .Returns(false);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                var notification = new JoinedGuildNotification(mockGuild.Object);
+
+                uut.HandleNotificationAsync(notification, cancellationTokenSource.Token)
+                    .IsCompleted.ShouldBeTrue();
+
+                autoMocker.GetMock<IAuthorizationService>()
+                    .ShouldNotHaveReceived(x => x.AutoConfigureGuildAsync(It.IsAny<IGuild>(), It.IsAny<CancellationToken>()));
+            }
+        }
+
+        [Test]
+        public async Task HandleNotificationAsync_JoinedGuildNotification_GuildIsAvailable_InvokesAutoConfigureGuildAsync()
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<AuthorizationAutoConfigBehavior>();
+
+            var mockGuild = autoMocker.GetMock<ISocketGuild>();
+            mockGuild
+                .Setup(x => x.Available)
+                .Returns(true);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                var notification = new JoinedGuildNotification(mockGuild.Object);
+
+                await uut.HandleNotificationAsync(notification, cancellationTokenSource.Token);
+
+                autoMocker.GetMock<IAuthorizationService>()
+                    .ShouldHaveReceived(x => x.AutoConfigureGuildAsync(mockGuild.Object, cancellationTokenSource.Token));
+            }
+        }
+
+        #endregion HandleNotificationAsync(JoinedGuildNotification) Tests
+    }
+}

--- a/Modix.Services.Test/Core/AuthorizationServiceTests.cs
+++ b/Modix.Services.Test/Core/AuthorizationServiceTests.cs
@@ -1,0 +1,256 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Moq;
+using Moq.AutoMock;
+using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+using Discord.WebSocket;
+
+using Modix.Services.Core;
+using Modix.Data.Repositories;
+using Modix.Data.Models.Core;
+
+namespace Modix.Services.Test.Core
+{
+    [TestFixture]
+    public class AuthorizationServiceTests
+    {
+        #region AutoConfigureGuildAsync() Tests
+
+        private class AutoConfigureGuildAsyncTestContext : AutoMocker, IDisposable
+        {
+            public ulong SelfUserId { get; set; }
+                = 1;
+
+            public ulong GuildId { get; set; }
+                = 2;
+
+            public bool AnyClaimMappings { get; set; }
+                = false;
+
+            public IList<ulong> AdministratorRoleIds { get; }
+                = new List<ulong>() { 3, 4 };
+
+            public IList<ulong> NonAdministratorRoleIds { get; }
+                = new List<ulong>() { 5, 6 };
+
+            public IReadOnlyCollection<Mock<IRole>> MockRoles
+                => _mockRoles;
+            private readonly List<Mock<IRole>> _mockRoles
+                = new List<Mock<IRole>>();
+
+            public Mock<IRepositoryTransaction> MockClaimMappingCreateTransaction { get; }
+                = new Mock<IRepositoryTransaction>();
+
+            public CancellationToken CancellationToken
+                => _cancellationTokenSource.Token;
+            private readonly CancellationTokenSource _cancellationTokenSource
+                = new CancellationTokenSource();
+
+            public void Setup()
+            {
+                GetMock<IServiceProvider>()
+                    .Setup(x => x.GetService(typeof(IUserService)))
+                    .Returns(Get<IUserService>());
+
+                var mockSelfUser = GetMock<ISocketSelfUser>();
+                mockSelfUser
+                    .Setup(x => x.Id)
+                    .Returns(SelfUserId);
+
+                GetMock<ISelfUserProvider>()
+                    .Setup(x => x.GetSelfUserAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(mockSelfUser.Object);
+
+                GetMock<IGuild>()
+                    .Setup(x => x.Id)
+                    .Returns(GuildId);
+
+                var claimMappingRepository = GetMock<IClaimMappingRepository>();
+                claimMappingRepository
+                    .Setup(x => x.AnyAsync(It.IsAny<ClaimMappingSearchCriteria>()))
+                    .ReturnsAsync(AnyClaimMappings);
+                claimMappingRepository
+                    .Setup(x => x.BeginCreateTransactionAsync())
+                    .ReturnsAsync(MockClaimMappingCreateTransaction.Object);
+
+                var administratorPermission = GuildPermissions.None.Modify(administrator: true);
+                var nonAdministratorPermission = GuildPermissions.All.Modify(administrator: false);
+
+                _mockRoles.AddRange(
+                    AdministratorRoleIds
+                        .Select(x =>
+                        {
+                            var mockRole = new Mock<IRole>();
+                            mockRole
+                                .Setup(y => y.Id)
+                                .Returns(x);
+                            mockRole
+                                .Setup(y => y.Permissions)
+                                .Returns(administratorPermission);
+                            return mockRole;
+                        })
+                        .Concat(NonAdministratorRoleIds
+                            .Select(x =>
+                            {
+                                var mockRole = new Mock<IRole>();
+                                mockRole
+                                    .Setup(y => y.Id)
+                                    .Returns(x);
+                                mockRole
+                                    .Setup(y => y.Permissions)
+                                    .Returns(nonAdministratorPermission);
+                                return mockRole;
+                            })));
+
+                GetMock<IGuild>()
+                    .Setup(x => x.Roles)
+                    .Returns(_mockRoles
+                        .Select(x => x.Object)
+                        .ToArray());
+            }
+
+            public void ClaimMappingRepositoryShouldHaveReceivedAnyAsync()
+                => GetMock<IClaimMappingRepository>()
+                    .ShouldHaveReceived(x => x.AnyAsync(It.Is<ClaimMappingSearchCriteria>(y =>
+                            (y.Claims == null)
+                            && (y.CreatedById == null)
+                            && (y.CreatedRange == null)
+                            && (y.GuildId == GuildId)
+                            && (y.IsDeleted == false)
+                            && (y.RoleIds == null))),
+                        Times.Once());
+
+            public void Dispose()
+                => _cancellationTokenSource.Dispose();
+        }
+
+        [Test]
+        public async Task AutoConfigureGuildAsync_GuildContainsAnyClaimMappings_DoesNotCreateClaimMappings()
+        {
+            var testContext = new AutoConfigureGuildAsyncTestContext()
+            {
+                AnyClaimMappings = true
+            };
+
+            using (testContext)
+            {
+                testContext.Setup();
+
+                var uut = testContext.CreateInstance<AuthorizationService>();
+
+                await uut.AutoConfigureGuildAsync(testContext.Get<IGuild>(), testContext.CancellationToken);
+
+                testContext.ClaimMappingRepositoryShouldHaveReceivedAnyAsync();
+
+                testContext.GetMock<ISelfUserProvider>()
+                    .Invocations.ShouldBeEmpty();
+
+                testContext.GetMock<IUserService>()
+                    .Invocations.ShouldBeEmpty();
+
+                testContext.GetMock<IClaimMappingRepository>()
+                    .ShouldNotHaveReceived(x => x.BeginCreateTransactionAsync());
+
+                testContext.GetMock<IClaimMappingRepository>()
+                    .ShouldNotHaveReceived(x => x.CreateAsync(It.IsAny<ClaimMappingCreationData>()));
+            }
+        }
+
+        [Test]
+        public async Task AutoConfigureGuildAsync_GuildContainsNoClaimMappings_TracksSelfUser()
+        {
+            var testContext = new AutoConfigureGuildAsyncTestContext();
+
+            using (testContext)
+            {
+                testContext.Setup();
+
+                var uut = testContext.CreateInstance<AuthorizationService>();
+
+                await uut.AutoConfigureGuildAsync(testContext.Get<IGuild>(), testContext.CancellationToken);
+
+                testContext.ClaimMappingRepositoryShouldHaveReceivedAnyAsync();
+
+                testContext.GetMock<ISelfUserProvider>()
+                    .ShouldHaveReceived(x => x.GetSelfUserAsync(testContext.CancellationToken), Times.Once());
+
+                testContext.GetMock<IUserService>()
+                    .ShouldHaveReceived(x => x.TrackUserAsync(testContext.Get<IGuild>(), testContext.SelfUserId), Times.Once());
+            }
+        }
+
+        [Test]
+        public async Task AutoConfigureGuildAsync_GuildContainsNoClaimMappings_CreatesClaimMappingsForAdministratorRoles()
+        {
+            var testContext = new AutoConfigureGuildAsyncTestContext();
+
+            using (testContext)
+            {
+                testContext.Setup();
+
+                var sequence = new MockSequence();
+
+                var mockClaimMappingRepository = testContext.GetMock<IClaimMappingRepository>();
+
+                mockClaimMappingRepository
+                    .InSequence(sequence)
+                    .Setup(x => x.BeginCreateTransactionAsync())
+                    .ReturnsAsync(testContext.MockClaimMappingCreateTransaction.Object);
+
+                mockClaimMappingRepository
+                    .InSequence(sequence)
+                    .Setup(x => x.CreateAsync(It.IsAny<ClaimMappingCreationData>()))
+                    .ReturnsAsync(0);
+
+                testContext.MockClaimMappingCreateTransaction
+                    .InSequence(sequence)
+                    .Setup(x => x.Commit());
+
+                var uut = testContext.CreateInstance<AuthorizationService>();
+
+                await uut.AutoConfigureGuildAsync(testContext.Get<IGuild>(), testContext.CancellationToken);
+
+                testContext.ClaimMappingRepositoryShouldHaveReceivedAnyAsync();
+
+                testContext.GetMock<IClaimMappingRepository>()
+                    .ShouldHaveReceived(x => x.BeginCreateTransactionAsync(), Times.Once());
+
+                var actualClaimMappings = testContext.GetMock<IClaimMappingRepository>()
+                    .Invocations
+                    .Where(x => x.Method.Name == nameof(IClaimMappingRepository.CreateAsync))
+                    .Select(x => x.Arguments[0] as ClaimMappingCreationData)
+                    .ToArray();
+
+                foreach (var actualClaimMapping in actualClaimMappings)
+                {
+                    actualClaimMapping.CreatedById.ShouldBe(testContext.SelfUserId);
+                    actualClaimMapping.GuildId.ShouldBe(testContext.GuildId);
+                    actualClaimMapping.RoleId.ShouldNotBeNull();
+                    actualClaimMapping.Type.ShouldBe(ClaimMappingType.Granted);
+                    actualClaimMapping.UserId.ShouldBeNull();
+                }
+
+                var expectedClaimMappings = Enum.GetValues(typeof(AuthorizationClaim)).Cast<AuthorizationClaim>()
+                    .SelectMany(x => testContext.AdministratorRoleIds
+                        .Select(y => (claim: x, roleId: y)))
+                    .ToArray();
+
+                actualClaimMappings
+                    .Select(x => (claim: x.Claim, roleId: x.RoleId.Value))
+                    .ShouldBe(expectedClaimMappings);
+
+                testContext.MockClaimMappingCreateTransaction
+                    .ShouldHaveReceived(x => x.Commit(), Times.Once());
+            }
+        }
+
+        #endregion AutoConfigureGuildAsync() Tests
+    }
+}

--- a/Modix.Services.Test/Core/Messages/GuildAvailableNotificationTests.cs
+++ b/Modix.Services.Test/Core/Messages/GuildAvailableNotificationTests.cs
@@ -1,0 +1,27 @@
+﻿using Moq;
+using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+using Discord.WebSocket;
+
+namespace Modix.Services.Test.Core.Messages
+{
+    [TestFixture]
+    public class GuildAvailableNotificationTests
+    {
+        #region Constructor Tests
+
+        [Test]
+        public void Constructor_Always_PropertiesAreGiven()
+        {
+            var mockGuild = new Mock<ISocketGuild>();
+
+            var uut = new GuildAvailableNotification(mockGuild.Object);
+
+            uut.Guild.ShouldBeSameAs(mockGuild.Object);
+        }
+
+        #endregion Constructor Tests
+    }
+}

--- a/Modix.Services.Test/Core/Messages/JoinedGuildNotificationTests.cs
+++ b/Modix.Services.Test/Core/Messages/JoinedGuildNotificationTests.cs
@@ -1,0 +1,27 @@
+﻿using Moq;
+using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+using Discord.WebSocket;
+
+namespace Modix.Services.Test.Core.Messages
+{
+    [TestFixture]
+    public class JoinedGuildNotificationTests
+    {
+        #region Constructor Tests
+
+        [Test]
+        public void Constructor_Always_PropertiesAreGiven()
+        {
+            var mockGuild = new Mock<ISocketGuild>();
+
+            var uut = new JoinedGuildNotification(mockGuild.Object);
+
+            uut.Guild.ShouldBeSameAs(mockGuild.Object);
+        }
+
+        #endregion Constructor Tests
+    }
+}

--- a/Modix.Services/Core/CoreSetup.cs
+++ b/Modix.Services/Core/CoreSetup.cs
@@ -19,7 +19,6 @@ namespace Modix.Services.Core
         /// <returns><paramref name="services"/></returns>
         public static IServiceCollection AddModixCore(this IServiceCollection services)
             => services
-                .AddSingleton<IBehavior, AuthorizationAutoConfigBehavior>()
                 .AddSingleton<IBehavior, ChannelTrackingBehavior>()
                 .AddSingleton<IBehavior, RoleTrackingBehavior>()
                 .AddSingleton<IBehavior, UserTrackingBehavior>()
@@ -30,6 +29,9 @@ namespace Modix.Services.Core
                 .AddSingleton<INotificationHandler<ReadyNotification>>(x => x.GetService<ReadySynchronizationProvider>())
                 .AddSingleton<ISelfUserProvider, SelfUserProvider>()
                 .AddScoped<IAuthorizationService, AuthorizationService>()
+                .AddScoped<AuthorizationAutoConfigBehavior>()
+                .AddScoped<INotificationHandler<GuildAvailableNotification>>(x => x.GetService<AuthorizationAutoConfigBehavior>())
+                .AddScoped<INotificationHandler<JoinedGuildNotification>>(x => x.GetService<AuthorizationAutoConfigBehavior>())
                 .AddScoped<IChannelService, ChannelService>()
                 .AddScoped<IRoleService, RoleService>()
                 .AddScoped<IUserService, UserService>()

--- a/Modix.Services/Core/Messages/GuildAvailableNotification.cs
+++ b/Modix.Services/Core/Messages/GuildAvailableNotification.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+using Discord.WebSocket;
+
+using Modix.Common.Messaging;
+
+namespace Discord
+{
+    /// <summary>
+    /// Describes an application-wide notification that occurs when <see cref="IBaseSocketClient.GuildAvailable"/> is raised.
+    /// </summary>
+    public class GuildAvailableNotification : INotification
+    {
+        /// <summary>
+        /// Constructs a new <see cref="GuildAvailableNotification"/> from the given values.
+        /// </summary>
+        /// <param name="guild">The value to use for <see cref="Guild"/>.</param>
+        /// <exception cref="ArgumentNullException">Throws for <paramref name="guild"/>.</exception>
+        public GuildAvailableNotification(ISocketGuild guild)
+        {
+            Guild = guild ?? throw new ArgumentNullException(nameof(guild));
+        }
+
+        /// <summary>
+        /// The guild whose data is now available.
+        /// </summary>
+        public ISocketGuild Guild { get; }
+    }
+}

--- a/Modix.Services/Core/Messages/JoinedGuildNotification.cs
+++ b/Modix.Services/Core/Messages/JoinedGuildNotification.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+using Discord.WebSocket;
+
+using Modix.Common.Messaging;
+
+namespace Discord
+{
+    /// <summary>
+    /// Describes an application-wide notification that occurs when <see cref="IBaseSocketClient.JoinedGuild"/> is raised.
+    /// </summary>
+    public class JoinedGuildNotification : INotification
+    {
+        /// <summary>
+        /// Constructs a new <see cref="JoinedGuildNotification"/> from the given values.
+        /// </summary>
+        /// <param name="guild">The value to use for <see cref="Guild"/>.</param>
+        /// <exception cref="ArgumentNullException">Throws for <paramref name="guild"/>.</exception>
+        public JoinedGuildNotification(ISocketGuild guild)
+        {
+            Guild = guild ?? throw new ArgumentNullException(nameof(guild));
+        }
+
+        /// <summary>
+        /// The guild that the bot has joined.
+        /// </summary>
+        public ISocketGuild Guild { get; }
+    }
+}

--- a/Modix.Services/Core/UserService.cs
+++ b/Modix.Services/Core/UserService.cs
@@ -55,6 +55,14 @@ namespace Modix.Services.Core
         /// <param name="user">The user whose info is to be tracked.</param>
         /// <returns>A <see cref="Task"/> that will complete when the operation has completed.</returns>
         Task TrackUserAsync(IGuildUser user);
+
+        /// <summary>
+        /// Updates information about the given user within the user tracking system of a guild.
+        /// </summary>
+        /// <param name="guild">The guild for which user info is to be tracked.</param>
+        /// <param name="userId">The <see cref="IEntity{ulong}.Id"/> value of the user whose info is to be tracked.</param>
+        /// <returns>A <see cref="Task"/> that will complete when the operation has completed.</returns>
+        Task TrackUserAsync(IGuild guild, ulong userId);
     }
 
     /// <inheritdoc />
@@ -175,6 +183,11 @@ namespace Modix.Services.Core
                 transaction.Commit();
             }
         }
+
+        /// <inheritdoc />
+        public async Task TrackUserAsync(IGuild guild, ulong userId)
+            => await TrackUserAsync(
+                    await guild.GetUserAsync(userId));
 
         /// <summary>
         /// A <see cref="IDiscordClient"/> to be used to interact with the Discord API.


### PR DESCRIPTION
Refactored to utilize the abstractions and messaging systems.

After investigating the Discord API docs, I verified that `GuildAvailable` does not necessarily occur when the bot joins a guild during runtime, so we the behavior now listens to `JoinedGuild` as well.

Also, removed the behavior for listening to `LeftGuild` and wiping all claims config when that occurs, since it's really an artificial restriction that we added, and since we've had to kick MODiX out of the guild and re-invite it in the past, to fix Discord issues.