### PR TITLE
Fix error when retrieving designated channels/roles

### DIFF
--- a/Modix/Controllers/ChannelController.cs
+++ b/Modix/Controllers/ChannelController.cs
@@ -27,7 +27,7 @@ namespace Modix.Controllers
                 Id = d.Id,
                 ChannelId = d.Channel.Id,
                 ChannelDesignation = d.Type,
-                Name = UserGuild?.GetChannel(d.Channel.Id).Name ?? d.Id.ToString()
+                Name = UserGuild?.GetChannel(d.Channel.Id)?.Name ?? d.Channel.Id.ToString()
             });
 
             return Ok(mapped);

--- a/Modix/Controllers/RoleController.cs
+++ b/Modix/Controllers/RoleController.cs
@@ -27,7 +27,7 @@ namespace Modix.Controllers
                 Id = d.Id,
                 RoleId = d.Role.Id,
                 RoleDesignation = d.Type,
-                Name = UserGuild?.GetRole(d.Role.Id).Name ?? d.Id.ToString()
+                Name = UserGuild?.GetRole(d.Role.Id)?.Name ?? d.Role.Id.ToString()
             });
 
             return Ok(mapped);


### PR DESCRIPTION
If the role/channel doesn't exist in the guild, just return the display id.