### PR TITLE
ChannelTrackingBehavior Refactoring/Testing

### DIFF
--- a/Modix.Data/Repositories/GuildChannelRepository.cs
+++ b/Modix.Data/Repositories/GuildChannelRepository.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.EntityFrameworkCore;
@@ -17,31 +18,34 @@ namespace Modix.Data.Repositories
         /// <summary>
         /// Begins a new transaction to create channels within the repository.
         /// </summary>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> which may be used to cancel the returned <see cref="Task"/> before it completes.</param>
         /// <returns>
         /// A <see cref="Task"/> that will complete, with the requested transaction object,
         /// when no other transactions are active upon the repository.
         /// </returns>
-        Task<IRepositoryTransaction> BeginCreateTransactionAsync();
+        Task<IRepositoryTransaction> BeginCreateTransactionAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a new set of channel data within the repository.
         /// </summary>
         /// <param name="data">The initial set of channel data to be created.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> which may be used to cancel the returned <see cref="Task"/> before it completes.</param>
         /// <exception cref="ArgumentNullException">Throws for <paramref name="data"/>.</exception>
         /// <returns>A <see cref="Task"/> which will complete when the operation is complete.</returns>
-        Task CreateAsync(GuildChannelCreationData data);
+        Task CreateAsync(GuildChannelCreationData data, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Attempts to update information about a channel, based on its ID value.
         /// </summary>
         /// <param name="channelId">The <see cref="GuildChannelEntity.ChannelId"/> value of the user guild data to be updated.</param>
         /// <param name="updateAction">An action to be invoked to perform the requested update.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> which may be used to cancel the returned <see cref="Task"/> before it completes.</param>
         /// <exception cref="ArgumentNullException">Throws for <paramref name="updateAction"/>.</exception>
         /// <returns>
         /// A <see cref="Task"/> that will complete when the operation has completed,
         /// containing a flag indicating whether the requested update succeeded (I.E. whether the specified data record exists).
         /// </returns>
-        Task<bool> TryUpdateAsync(ulong channelId, Action<GuildChannelMutationData> updateAction);
+        Task<bool> TryUpdateAsync(ulong channelId, Action<GuildChannelMutationData> updateAction, CancellationToken cancellationToken = default);
     }
 
     /// <inheritdoc />
@@ -55,30 +59,30 @@ namespace Modix.Data.Repositories
             : base(modixContext) { }
 
         /// <inheritdoc />
-        public Task<IRepositoryTransaction> BeginCreateTransactionAsync()
-            => _createTransactionFactory.BeginTransactionAsync(ModixContext.Database);
+        public Task<IRepositoryTransaction> BeginCreateTransactionAsync(CancellationToken cancellationToken = default)
+            => _createTransactionFactory.BeginTransactionAsync(ModixContext.Database, cancellationToken);
 
         /// <inheritdoc />
-        public async Task CreateAsync(GuildChannelCreationData data)
+        public async Task CreateAsync(GuildChannelCreationData data, CancellationToken cancellationToken = default)
         {
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
 
             var entity = data.ToEntity();
 
-            await ModixContext.GuildChannels.AddAsync(entity);
-            await ModixContext.SaveChangesAsync();
+            await ModixContext.GuildChannels.AddAsync(entity, cancellationToken);
+            await ModixContext.SaveChangesAsync(cancellationToken);
         }
 
         /// <inheritdoc />
-        public async Task<bool> TryUpdateAsync(ulong channelId, Action<GuildChannelMutationData> updateAction)
+        public async Task<bool> TryUpdateAsync(ulong channelId, Action<GuildChannelMutationData> updateAction, CancellationToken cancellationToken = default)
         {
             if (updateAction == null)
                 throw new ArgumentNullException(nameof(updateAction));
 
             var entity = await ModixContext.GuildChannels
                 .Where(x => x.ChannelId == channelId)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync(cancellationToken);
 
             if (entity == null)
                 return false;
@@ -89,7 +93,7 @@ namespace Modix.Data.Repositories
 
             ModixContext.UpdateProperty(entity, x => x.Name);
 
-            await ModixContext.SaveChangesAsync();
+            await ModixContext.SaveChangesAsync(cancellationToken);
 
             return true;
         }

--- a/Modix.Services.Test/Core/ChannelServiceTests.cs
+++ b/Modix.Services.Test/Core/ChannelServiceTests.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Moq;
+using Moq.AutoMock;
+using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+
+using Modix.Data.Models.Core;
+using Modix.Data.Repositories;
+using Modix.Services.Core;
+
+namespace Modix.Services.Test.Core
+{
+    [TestFixture]
+    public class ChannelServiceTests
+    {
+        #region TrackChannelAsync() Tests
+
+        [TestCase(1UL, "ExistingChannelName")]
+        public async Task TrackChannelAsync_TryUpdateSucceeds_DoesNotCreateChannel(ulong channelId, string channelName)
+        {
+            var autoMocker = new AutoMocker();
+
+            var mockCreateTransaction = new Mock<IRepositoryTransaction>();
+            var mockGuildChannelRepository = autoMocker.GetMock<IGuildChannelRepository>();
+
+            var sequence = new MockSequence();
+
+            mockGuildChannelRepository
+                .InSequence(sequence)
+                .Setup(x => x.BeginCreateTransactionAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockCreateTransaction.Object);
+
+            mockGuildChannelRepository
+                .InSequence(sequence)
+                .Setup(x => x.TryUpdateAsync(It.IsAny<ulong>(), It.IsAny<Action<GuildChannelMutationData>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            mockCreateTransaction
+                .InSequence(sequence)
+                .Setup(x => x.Commit());
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                var uut = autoMocker.CreateInstance<ChannelService>();
+
+                var mockChannel = new Mock<IGuildChannel>();
+                mockChannel
+                    .Setup(x => x.Id)
+                    .Returns(channelId);
+                mockChannel
+                    .Setup(x => x.Name)
+                    .Returns(channelName);
+
+                await uut.TrackChannelAsync(mockChannel.Object, cancellationTokenSource.Token);
+
+                mockGuildChannelRepository
+                    .ShouldHaveReceived(x => x.BeginCreateTransactionAsync(cancellationTokenSource.Token), Times.Once());
+
+                mockGuildChannelRepository
+                    .ShouldHaveReceived(x => x.TryUpdateAsync(channelId, It.IsNotNull<Action<GuildChannelMutationData>>(), cancellationTokenSource.Token), Times.Once());
+
+                mockGuildChannelRepository
+                    .ShouldNotHaveReceived(x => x.CreateAsync(It.IsAny<GuildChannelCreationData>(), cancellationTokenSource.Token));
+
+                mockCreateTransaction
+                    .ShouldHaveReceived(x => x.Commit(), Times.Once());
+
+                var updateAction = mockGuildChannelRepository
+                    .Invocations
+                    .First(x => x.Method.Name == nameof(IGuildChannelRepository.TryUpdateAsync))
+                    .Arguments[1] as Action<GuildChannelMutationData>;
+
+                var mutationData = new GuildChannelMutationData();
+                updateAction.Invoke(mutationData);
+
+                mutationData.Name.ShouldBe(channelName);
+            }
+        }
+
+        [TestCase(1UL, 2UL, "NewChannelName")]
+        public async Task TrackChannelAsync_TryUpdateFails_CreatesChannel(ulong channelId, ulong guildId, string channelName)
+        {
+            var autoMocker = new AutoMocker();
+
+            var mockCreateTransaction = new Mock<IRepositoryTransaction>();
+            var mockGuildChannelRepository = autoMocker.GetMock<IGuildChannelRepository>();
+
+            var sequence = new MockSequence();
+
+            mockGuildChannelRepository
+                .InSequence(sequence)
+                .Setup(x => x.BeginCreateTransactionAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mockCreateTransaction.Object);
+
+            mockGuildChannelRepository
+                .InSequence(sequence)
+                .Setup(x => x.TryUpdateAsync(It.IsAny<ulong>(), It.IsAny<Action<GuildChannelMutationData>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+
+            mockGuildChannelRepository
+                .InSequence(sequence)
+                .Setup(x => x.CreateAsync(It.IsAny<GuildChannelCreationData>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            mockCreateTransaction
+                .InSequence(sequence)
+                .Setup(x => x.Commit());
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                var uut = autoMocker.CreateInstance<ChannelService>();
+
+                var mockChannel = new Mock<IGuildChannel>();
+                mockChannel
+                    .Setup(x => x.Id)
+                    .Returns(channelId);
+                mockChannel
+                    .Setup(x => x.GuildId)
+                    .Returns(guildId);
+                mockChannel
+                    .Setup(x => x.Name)
+                    .Returns(channelName);
+
+                await uut.TrackChannelAsync(mockChannel.Object, cancellationTokenSource.Token);
+
+                mockGuildChannelRepository
+                    .ShouldHaveReceived(x => x.BeginCreateTransactionAsync(cancellationTokenSource.Token), Times.Once());
+
+                mockGuildChannelRepository
+                    .ShouldHaveReceived(x => x.TryUpdateAsync(channelId, It.IsNotNull<Action<GuildChannelMutationData>>(), cancellationTokenSource.Token), Times.Once());
+
+                mockGuildChannelRepository
+                    .ShouldHaveReceived(x => x.CreateAsync(It.Is<GuildChannelCreationData>(y =>
+                                (y.ChannelId == channelId)
+                                && (y.GuildId == guildId)
+                                && (y.Name == channelName)),
+                            cancellationTokenSource.Token),
+                        Times.Once());
+
+                mockCreateTransaction
+                    .ShouldHaveReceived(x => x.Commit(), Times.Once());
+            }
+        }
+
+        #endregion TrackChannelAsync() Tests
+    }
+}

--- a/Modix.Services.Test/Core/ChannelTrackingBehaviorTests.cs
+++ b/Modix.Services.Test/Core/ChannelTrackingBehaviorTests.cs
@@ -1,0 +1,346 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Moq;
+using Moq.AutoMock;
+using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+using Discord.WebSocket;
+
+using Modix.Services.Core;
+
+namespace Modix.Services.Test.Core
+{
+    [TestFixture]
+    public class ChannelTrackingBehaviorTests
+    {
+        #region Test Cases
+
+        private static readonly Type[] ChannelIsNotGuildChannelTestCases
+            = {
+                typeof(ISocketChannel),
+                typeof(ISocketDMChannel),
+                typeof(ISocketGroupChannel)
+            };
+
+        private static readonly Type[] GuildChannelIsNotTextChannelTestCases
+            = {
+                typeof(ISocketCategoryChannel),
+                typeof(ISocketGuildChannel),
+                typeof(ISocketVoiceChannel),
+            };
+
+        private static readonly Type[][] GuildChannelsNoneAreTextChannelsTestCases
+            = GuildChannelIsNotTextChannelTestCases
+                .Select(x => new[] { x })
+                .Concat(GuildChannelIsNotTextChannelTestCases
+                    .SelectMany(x => GuildChannelIsNotTextChannelTestCases
+                        .Select(y => new[] { x, y })))
+                .Append(GuildChannelIsNotTextChannelTestCases)
+                .ToArray();
+
+        private static readonly Type[][] GuildChannelsAnyAreTextChannelsTestCases
+            = Enumerable.Empty<Type[]>()
+                .Append(new[] { typeof(ISocketTextChannel) })
+                .Append(new[] { typeof(ISocketTextChannel), typeof(ISocketTextChannel) })
+                .Concat(GuildChannelIsNotTextChannelTestCases
+                    .Select(x => new[] { x, typeof(ISocketTextChannel) }))
+                .Append(GuildChannelIsNotTextChannelTestCases
+                    .Prepend(typeof(ISocketTextChannel))
+                    .Append(typeof(ISocketTextChannel))
+                    .ToArray())
+                .ToArray();
+
+        #endregion Test Cases
+
+        #region HandleNotificationAsync(ChannelCreatedNotification)
+
+        [TestCaseSource(nameof(ChannelIsNotGuildChannelTestCases))]
+        [TestCaseSource(nameof(GuildChannelIsNotTextChannelTestCases))]
+        public void HandleNotificationAsync_ChannelCreatedNotification_ChannelIsNotTextChannel_CompletesImmediately(Type channelType)
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<ChannelTrackingBehavior>();
+
+            var mockChannel = typeof(Mock<>).MakeGenericType(channelType).GetConstructor(Array.Empty<Type>()).Invoke(Array.Empty<object>()) as Mock;
+
+            var notification = new ChannelCreatedNotification(mockChannel.Object as ISocketChannel);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                uut.HandleNotificationAsync(notification, cancellationTokenSource.Token)
+                    .IsCompletedSuccessfully.ShouldBeTrue();
+
+                autoMocker.GetMock<IChannelService>()
+                    .Invocations.ShouldBeEmpty();
+            }
+        }
+
+        [Test]
+        public async Task HandleNotificationAsync_ChannelCreatedNotification_ChannelIsTextChannel_TracksChannel()
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<ChannelTrackingBehavior>();
+
+            var mockChannel = new Mock<ISocketTextChannel>();
+
+            var notification = new ChannelCreatedNotification(mockChannel.Object);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                await uut.HandleNotificationAsync(notification, cancellationTokenSource.Token);
+
+                autoMocker.GetMock<IChannelService>()
+                    .ShouldHaveReceived(x => x.TrackChannelAsync(mockChannel.Object, cancellationTokenSource.Token));
+            }
+        }
+
+        #endregion HandleNotificationAsync(ChannelCreatedNotification)
+
+        #region HandleNotificationAsync(ChannelUpdatedNotification)
+
+        [TestCaseSource(nameof(ChannelIsNotGuildChannelTestCases))]
+        [TestCaseSource(nameof(GuildChannelIsNotTextChannelTestCases))]
+        public void HandleNotificationAsync_ChannelUpdatedNotification_ChannelIsNotTextChannel_CompletesImmediately(Type channelType)
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<ChannelTrackingBehavior>();
+
+            var mockOldChannel = typeof(Mock<>).MakeGenericType(channelType).GetConstructor(Array.Empty<Type>()).Invoke(Array.Empty<object>()) as Mock;
+            var mockNewChannel = typeof(Mock<>).MakeGenericType(channelType).GetConstructor(Array.Empty<Type>()).Invoke(Array.Empty<object>()) as Mock;
+
+            var notification = new ChannelUpdatedNotification(mockOldChannel.Object as ISocketChannel, mockNewChannel.Object as ISocketChannel);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                uut.HandleNotificationAsync(notification, cancellationTokenSource.Token)
+                    .IsCompletedSuccessfully.ShouldBeTrue();
+
+                autoMocker.GetMock<IChannelService>()
+                    .Invocations.ShouldBeEmpty();
+            }
+        }
+
+        [Test]
+        public async Task HandleNotificationAsync_ChannelUpdatedNotification_ChannelIsTextChannel_TracksChannel()
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<ChannelTrackingBehavior>();
+
+            var mockOldChannel = new Mock<ISocketTextChannel>();
+            var mockNewChannel = new Mock<ISocketTextChannel>();
+
+            var notification = new ChannelUpdatedNotification(mockOldChannel.Object, mockNewChannel.Object);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                await uut.HandleNotificationAsync(notification, cancellationTokenSource.Token);
+
+                autoMocker.GetMock<IChannelService>()
+                    .ShouldHaveReceived(x => x.TrackChannelAsync(mockNewChannel.Object, cancellationTokenSource.Token));
+            }
+        }
+
+        #endregion HandleNotificationAsync(ChannelUpdatedNotification)
+
+        #region HandleNotificationAsync(GuildAvailableNotification)
+
+        [TestCaseSource(nameof(GuildChannelsNoneAreTextChannelsTestCases))]
+        public void HandleNotificationAsync_GuildAvailableNotification_NoChannelsAreTextChannel_CompletesImmediately(params Type[] channelTypes)
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<ChannelTrackingBehavior>();
+
+            var mockChannels = channelTypes
+                .Select(x => typeof(Mock<>).MakeGenericType(x).GetConstructor(Array.Empty<Type>()).Invoke(Array.Empty<object>()) as Mock)
+                .ToArray();
+
+            var mockGuild = new Mock<ISocketGuild>();
+            mockGuild
+                .Setup(x => x.Channels)
+                .Returns(mockChannels
+                    .Select(x => x.Object as ISocketGuildChannel)
+                    .ToArray());
+
+            var notification = new GuildAvailableNotification(mockGuild.Object);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                uut.HandleNotificationAsync(notification, cancellationTokenSource.Token)
+                    .IsCompletedSuccessfully.ShouldBeTrue();
+
+                autoMocker.GetMock<IChannelService>()
+                    .Invocations.ShouldBeEmpty();
+            }
+        }
+
+        [TestCaseSource(nameof(GuildChannelsAnyAreTextChannelsTestCases))]
+        public async Task HandleNotificationAsync_GuildAvailableNotification_AnyChannelIsTextChannel_TracksTextChannels(params Type[] channelTypes)
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<ChannelTrackingBehavior>();
+
+            var mockChannels = channelTypes
+                .Select(x => typeof(Mock<>).MakeGenericType(x).GetConstructor(Array.Empty<Type>()).Invoke(Array.Empty<object>()) as Mock)
+                .ToArray();
+
+            var mockGuild = new Mock<ISocketGuild>();
+            mockGuild
+                .Setup(x => x.Channels)
+                .Returns(mockChannels
+                    .Select(x => x.Object as ISocketGuildChannel)
+                    .ToArray());
+
+            var notification = new GuildAvailableNotification(mockGuild.Object);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                await uut.HandleNotificationAsync(notification, cancellationTokenSource.Token);
+
+                var mockChannelService = autoMocker.GetMock<IChannelService>();
+
+                var textChannels = mockChannels
+                    .Select(x => x.Object)
+                    .OfType<ISocketTextChannel>()
+                    .ToArray();
+
+                foreach (var textChannel in textChannels)
+                    mockChannelService.ShouldHaveReceived(x => x.TrackChannelAsync(textChannel, cancellationTokenSource.Token));
+
+                mockChannelService
+                    .Invocations
+                    .Where(x => x.Method.Name == nameof(IChannelService.TrackChannelAsync))
+                    .Select(x => x.Arguments[0])
+                    .ShouldBe(textChannels, ignoreOrder: true);
+            }
+        }
+
+        #endregion HandleNotificationAsync(GuildAvailableNotification)
+
+        #region HandleNotificationAsync(JoinedGuildNotification)
+
+        [TestCaseSource(nameof(GuildChannelsNoneAreTextChannelsTestCases))]
+        [TestCaseSource(nameof(GuildChannelsAnyAreTextChannelsTestCases))]
+        public void HandleNotificationAsync_JoinedGuildNotification_GuildIsNotAvailable_CompletesImmediately(params Type[] channelTypes)
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<ChannelTrackingBehavior>();
+
+            var mockChannels = channelTypes
+                .Select(x => typeof(Mock<>).MakeGenericType(x).GetConstructor(Array.Empty<Type>()).Invoke(Array.Empty<object>()) as Mock)
+                .ToArray();
+
+            var mockGuild = new Mock<ISocketGuild>();
+            mockGuild
+                .Setup(x => x.Channels)
+                .Returns(mockChannels
+                    .Select(x => x.Object as ISocketGuildChannel)
+                    .ToArray());
+            mockGuild
+                .Setup(x => x.Available)
+                .Returns(false);
+
+            var notification = new JoinedGuildNotification(mockGuild.Object);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                uut.HandleNotificationAsync(notification, cancellationTokenSource.Token)
+                    .IsCompletedSuccessfully.ShouldBeTrue();
+
+                autoMocker.GetMock<IChannelService>()
+                    .Invocations.ShouldBeEmpty();
+            }
+        }
+
+        [TestCaseSource(nameof(GuildChannelsNoneAreTextChannelsTestCases))]
+        public void HandleNotificationAsync_JoinedGuildNotification_NoChannelsAreTextChannel_CompletesImmediately(params Type[] channelTypes)
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<ChannelTrackingBehavior>();
+
+            var mockChannels = channelTypes
+                .Select(x => typeof(Mock<>).MakeGenericType(x).GetConstructor(Array.Empty<Type>()).Invoke(Array.Empty<object>()) as Mock)
+                .ToArray();
+
+            var mockGuild = new Mock<ISocketGuild>();
+            mockGuild
+                .Setup(x => x.Channels)
+                .Returns(mockChannels
+                    .Select(x => x.Object as ISocketGuildChannel)
+                    .ToArray());
+            mockGuild
+                .Setup(x => x.Available)
+                .Returns(true);
+
+            var notification = new JoinedGuildNotification(mockGuild.Object);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                uut.HandleNotificationAsync(notification, cancellationTokenSource.Token)
+                    .IsCompletedSuccessfully.ShouldBeTrue();
+
+                autoMocker.GetMock<IChannelService>()
+                    .Invocations.ShouldBeEmpty();
+            }
+        }
+
+        [TestCaseSource(nameof(GuildChannelsAnyAreTextChannelsTestCases))]
+        public async Task HandleNotificationAsync_JoinedGuildNotification_AnyChannelIsTextChannel_TracksTextChannels(params Type[] channelTypes)
+        {
+            var autoMocker = new AutoMocker();
+
+            var uut = autoMocker.CreateInstance<ChannelTrackingBehavior>();
+
+            var mockChannels = channelTypes
+                .Select(x => typeof(Mock<>).MakeGenericType(x).GetConstructor(Array.Empty<Type>()).Invoke(Array.Empty<object>()) as Mock)
+                .ToArray();
+
+            var mockGuild = new Mock<ISocketGuild>();
+            mockGuild
+                .Setup(x => x.Channels)
+                .Returns(mockChannels
+                    .Select(x => x.Object as ISocketGuildChannel)
+                    .ToArray());
+            mockGuild
+                .Setup(x => x.Available)
+                .Returns(true);
+
+            var notification = new JoinedGuildNotification(mockGuild.Object);
+
+            using (var cancellationTokenSource = new CancellationTokenSource())
+            {
+                await uut.HandleNotificationAsync(notification, cancellationTokenSource.Token);
+
+                var mockChannelService = autoMocker.GetMock<IChannelService>();
+
+                var textChannels = mockChannels
+                    .Select(x => x.Object)
+                    .OfType<ISocketTextChannel>()
+                    .ToArray();
+
+                foreach (var textChannel in textChannels)
+                    mockChannelService.ShouldHaveReceived(x => x.TrackChannelAsync(textChannel, cancellationTokenSource.Token));
+
+                mockChannelService
+                    .Invocations
+                    .Where(x => x.Method.Name == nameof(IChannelService.TrackChannelAsync))
+                    .Select(x => x.Arguments[0])
+                    .ShouldBe(textChannels, ignoreOrder: true);
+            }
+        }
+
+        #endregion HandleNotificationAsync(JoinedGuildNotification)
+    }
+}

--- a/Modix.Services.Test/Core/Messages/ChannelCreatedNotificationTests.cs
+++ b/Modix.Services.Test/Core/Messages/ChannelCreatedNotificationTests.cs
@@ -1,0 +1,27 @@
+﻿using Moq;
+using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+using Discord.WebSocket;
+
+namespace Modix.Services.Test.Core.Messages
+{
+    [TestFixture]
+    public class ChannelCreatedNotificationTests
+    {
+        #region Constructor Tests
+
+        [Test]
+        public void Constructor_Always_PropertiesAreGiven()
+        {
+            var mockChannel = new Mock<ISocketChannel>();
+
+            var uut = new ChannelCreatedNotification(mockChannel.Object);
+
+            uut.Channel.ShouldBeSameAs(mockChannel.Object);
+        }
+
+        #endregion Constructor Tests
+    }
+}

--- a/Modix.Services.Test/Core/Messages/ChannelUpdatedNotificationTests.cs
+++ b/Modix.Services.Test/Core/Messages/ChannelUpdatedNotificationTests.cs
@@ -1,0 +1,29 @@
+﻿using Moq;
+using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+using Discord.WebSocket;
+
+namespace Modix.Services.Test.Core.Messages
+{
+    [TestFixture]
+    public class ChannelUpdatedNotificationTests
+    {
+        #region Constructor Tests
+
+        [Test]
+        public void Constructor_Always_PropertiesAreGiven()
+        {
+            var mockOldChannel = new Mock<ISocketChannel>();
+            var mockNewChannel = new Mock<ISocketChannel>();
+
+            var uut = new ChannelUpdatedNotification(mockOldChannel.Object, mockNewChannel.Object);
+
+            uut.OldChannel.ShouldBeSameAs(mockOldChannel.Object);
+            uut.NewChannel.ShouldBeSameAs(mockNewChannel.Object);
+        }
+
+        #endregion Constructor Tests
+    }
+}

--- a/Modix.Services/Core/ChannelTrackingBehavior.cs
+++ b/Modix.Services/Core/ChannelTrackingBehavior.cs
@@ -1,90 +1,60 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Discord;
 using Discord.WebSocket;
 
+using Modix.Common.Messaging;
+
 namespace Modix.Services.Core
 {
     /// <summary>
-    /// Implements a behavior for keeping the channel data within the local datastore synchronized with the Discord API.
+    /// Ensures that Discord channel data within the local datastore remains synchronized with the Discord API.
     /// </summary>
-    public class ChannelTrackingBehavior : BehaviorBase
+    public class ChannelTrackingBehavior
+        : INotificationHandler<ChannelCreatedNotification>,
+            INotificationHandler<ChannelUpdatedNotification>,
+            INotificationHandler<GuildAvailableNotification>,
+            INotificationHandler<JoinedGuildNotification>
     {
-        // TODO: Abstract DiscordSocketClient to IDiscordSocketClient, or something, to make this testable
         /// <summary>
         /// Constructs a new <see cref="ChannelTrackingBehavior"/> object, with the given injected dependencies.
-        /// See <see cref="BehaviorBase"/> for more details.
         /// </summary>
-        public ChannelTrackingBehavior(DiscordSocketClient discordClient, IServiceProvider serviceProvider)
-            : base(serviceProvider)
+        public ChannelTrackingBehavior(
+            IChannelService channelService)
         {
-            DiscordClient = discordClient;
+            _channelService = channelService;
         }
 
         /// <inheritdoc />
-        internal protected override Task OnStartingAsync()
-        {
-            DiscordClient.Ready += OnReady;
-            DiscordClient.JoinedGuild += OnJoinedGuild;
-            DiscordClient.ChannelCreated += OnChannelCreated;
-            DiscordClient.ChannelUpdated += OnChannelUpdated;
-
-            return Task.CompletedTask;
-        }
-
-        /// <inheritdoc />
-        internal protected override Task OnStoppedAsync()
-        {
-            DiscordClient.Ready -= OnReady;
-            DiscordClient.JoinedGuild -= OnJoinedGuild;
-            DiscordClient.ChannelCreated -= OnChannelCreated;
-            DiscordClient.ChannelUpdated -= OnChannelUpdated;
-
-            return Task.CompletedTask;
-        }
-
-        /// <inheritdoc />
-        internal protected override void Dispose(bool disposeManaged)
-        {
-            if (disposeManaged && IsRunning)
-                OnStoppedAsync();
-
-            base.Dispose(disposeManaged);
-        }
-
-        /// <summary>
-        /// A <see cref="DiscordSocketClient"/> to be used for interacting with the Discord API.
-        /// </summary>
-        // TODO: Abstract DiscordSocketClient to IDiscordSocketClient, or something, to make this testable
-        internal protected DiscordSocketClient DiscordClient { get; }
-
-        private Task OnReady()
-            => SelfExecuteRequest<IChannelService>(async channelService =>
-            {
-                foreach(var channel in DiscordClient.Guilds
-                        .SelectMany(x => x.Channels)
-                        .Where(x => x is IMessageChannel))
-                    await channelService.TrackChannelAsync(channel);
-            });
-
-        private Task OnJoinedGuild(IGuild guild)
-            => SelfExecuteRequest<IChannelService>(async channelService =>
-            {
-                foreach (var channel in (await guild.GetChannelsAsync())
-                        .Where(x => x is IMessageChannel))
-                    await channelService.TrackChannelAsync(channel);
-            });
-
-        private Task OnChannelCreated(IChannel channel)
-            => (channel is IMessageChannel) && (channel is IGuildChannel guildChannel) && !(guildChannel.Guild is null)
-                ? SelfExecuteRequest<IChannelService>(channelService => channelService.TrackChannelAsync(guildChannel))
+        public Task HandleNotificationAsync(ChannelCreatedNotification notification, CancellationToken cancellationToken = default)
+            => notification.Channel is ITextChannel textChannel
+                ? _channelService.TrackChannelAsync(textChannel, cancellationToken)
                 : Task.CompletedTask;
 
-        private Task OnChannelUpdated(IChannel oldChannel, IChannel newChannel)
-            => (newChannel is IMessageChannel) && (newChannel is IGuildChannel guildChannel) && !(guildChannel.Guild is null)
-                ? SelfExecuteRequest<IChannelService>(channelService => channelService.TrackChannelAsync(guildChannel))
+        /// <inheritdoc />
+        public Task HandleNotificationAsync(ChannelUpdatedNotification notification, CancellationToken cancellationToken = default)
+            => notification.NewChannel is ITextChannel textChannel
+                ? _channelService.TrackChannelAsync(textChannel, cancellationToken)
                 : Task.CompletedTask;
+
+        /// <inheritdoc />
+        public async Task HandleNotificationAsync(GuildAvailableNotification notification, CancellationToken cancellationToken = default)
+        {
+            foreach (var channel in notification.Guild.Channels.Where(x => x is ITextChannel))
+                await _channelService.TrackChannelAsync(channel, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public async Task HandleNotificationAsync(JoinedGuildNotification notification, CancellationToken cancellationToken = default)
+        {
+            if(notification.Guild.Available)
+                foreach (var channel in notification.Guild.Channels.Where(x => x is ITextChannel))
+                    await _channelService.TrackChannelAsync(channel, cancellationToken);
+        }
+
+        private readonly IChannelService _channelService;
     }
 }

--- a/Modix.Services/Core/CoreSetup.cs
+++ b/Modix.Services/Core/CoreSetup.cs
@@ -19,7 +19,6 @@ namespace Modix.Services.Core
         /// <returns><paramref name="services"/></returns>
         public static IServiceCollection AddModixCore(this IServiceCollection services)
             => services
-                .AddSingleton<IBehavior, ChannelTrackingBehavior>()
                 .AddSingleton<IBehavior, RoleTrackingBehavior>()
                 .AddSingleton<IBehavior, UserTrackingBehavior>()
                 .AddSingleton<IBehavior, MessageLogBehavior>()
@@ -33,6 +32,11 @@ namespace Modix.Services.Core
                 .AddScoped<INotificationHandler<GuildAvailableNotification>>(x => x.GetService<AuthorizationAutoConfigBehavior>())
                 .AddScoped<INotificationHandler<JoinedGuildNotification>>(x => x.GetService<AuthorizationAutoConfigBehavior>())
                 .AddScoped<IChannelService, ChannelService>()
+                .AddScoped<ChannelTrackingBehavior>()
+                .AddScoped<INotificationHandler<ChannelCreatedNotification>>(x => x.GetService<ChannelTrackingBehavior>())
+                .AddScoped<INotificationHandler<ChannelUpdatedNotification>>(x => x.GetService<ChannelTrackingBehavior>())
+                .AddScoped<INotificationHandler<GuildAvailableNotification>>(x => x.GetService<ChannelTrackingBehavior>())
+                .AddScoped<INotificationHandler<JoinedGuildNotification>>(x => x.GetService<ChannelTrackingBehavior>())
                 .AddScoped<IRoleService, RoleService>()
                 .AddScoped<IUserService, UserService>()
                 .AddScoped<IGuildChannelRepository, GuildChannelRepository>()

--- a/Modix.Services/Core/DiscordSocketListeningBehavior.cs
+++ b/Modix.Services/Core/DiscordSocketListeningBehavior.cs
@@ -27,6 +27,8 @@ namespace Modix.Services.Core
         /// <inheritdoc />
         public Task StartAsync()
         {
+            DiscordSocketClient.ChannelCreated += OnChannelCreatedAsync;
+            DiscordSocketClient.ChannelUpdated += OnChannelUpdatedAsync;
             DiscordSocketClient.GuildAvailable += OnGuildAvailableAsync;
             DiscordSocketClient.JoinedGuild += OnJoinedGuildAsync;
             DiscordSocketClient.MessageDeleted += OnMessageDeletedAsync;
@@ -45,6 +47,8 @@ namespace Modix.Services.Core
         /// <inheritdoc />
         public Task StopAsync()
         {
+            DiscordSocketClient.ChannelCreated -= OnChannelCreatedAsync;
+            DiscordSocketClient.ChannelUpdated -= OnChannelUpdatedAsync;
             DiscordSocketClient.GuildAvailable -= OnGuildAvailableAsync;
             DiscordSocketClient.JoinedGuild -= OnJoinedGuildAsync;
             DiscordSocketClient.MessageDeleted -= OnMessageDeletedAsync;
@@ -69,6 +73,20 @@ namespace Modix.Services.Core
         /// A <see cref="IMessageDispatcher"/> used to dispatch discord notifications to the rest of the application.
         /// </summary>
         internal protected IMessageDispatcher MessageDispatcher { get; }
+
+        private Task OnChannelCreatedAsync(ISocketChannel channel)
+        {
+            MessageDispatcher.Dispatch(new ChannelCreatedNotification(channel));
+
+            return Task.CompletedTask;
+        }
+
+        private Task OnChannelUpdatedAsync(ISocketChannel oldChannel, ISocketChannel newChannel)
+        {
+            MessageDispatcher.Dispatch(new ChannelUpdatedNotification(oldChannel, newChannel));
+
+            return Task.CompletedTask;
+        }
 
         private Task OnGuildAvailableAsync(ISocketGuild guild)
         {

--- a/Modix.Services/Core/Messages/ChannelCreatedNotification.cs
+++ b/Modix.Services/Core/Messages/ChannelCreatedNotification.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+using Discord.WebSocket;
+
+using Modix.Common.Messaging;
+
+namespace Discord
+{
+    /// <summary>
+    /// Describes an application-wide notification that occurs when <see cref="IBaseSocketClient.ChannelCreated"/> is raised.
+    /// </summary>
+    public class ChannelCreatedNotification : INotification
+    {
+        /// <summary>
+        /// Constructs a new <see cref="ChannelCreatedNotification"/> from the given values.
+        /// </summary>
+        /// <param name="channel">The value to use for <see cref="Channel"/>.</param>
+        /// <exception cref="ArgumentNullException">Throws for <paramref name="channel"/>.</exception>
+        public ChannelCreatedNotification(ISocketChannel channel)
+        {
+            Channel = channel ?? throw new ArgumentNullException(nameof(channel));
+        }
+
+        /// <summary>
+        /// The channel that was created.
+        /// </summary>
+        public ISocketChannel Channel { get; }
+    }
+}

--- a/Modix.Services/Core/Messages/ChannelUpdatedNotification.cs
+++ b/Modix.Services/Core/Messages/ChannelUpdatedNotification.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+using Discord.WebSocket;
+
+using Modix.Common.Messaging;
+
+namespace Discord
+{
+    /// <summary>
+    /// Describes an application-wide notification that occurs when <see cref="IBaseSocketClient.ChannelUpdated"/> is raised.
+    /// </summary>
+    public class ChannelUpdatedNotification : INotification
+    {
+        /// <summary>
+        /// Constructs a new <see cref="ChannelUpdatedNotification"/> from the given values.
+        /// </summary>
+        /// <param name="oldChannel">The value to use for <see cref="OldChannel"/>.</param>
+        /// <param name="newChannel">The value to use for <see cref="NewChannel"/>.</param>
+        /// <exception cref="ArgumentNullException">Throws for <paramref name="oldChannel"/> and <paramref name="newChannel"/>.</exception>
+        public ChannelUpdatedNotification(ISocketChannel oldChannel, ISocketChannel newChannel)
+        {
+            OldChannel = oldChannel ?? throw new ArgumentNullException(nameof(oldChannel));
+            NewChannel = newChannel ?? throw new ArgumentNullException(nameof(newChannel));
+        }
+
+        /// <summary>
+        /// The state of the channel that was updated, prior to the update.
+        /// </summary>
+        public ISocketChannel OldChannel { get; }
+
+        /// <summary>
+        /// The state of the channel that was updated, after the update.
+        /// </summary>
+        public ISocketChannel NewChannel { get; }
+    }
+}


### PR DESCRIPTION
Refactored `ChannelTrackingBehavior` to utilize the Modix Messaging system, and to listen to `GuildAvailable` rather than `Ready` (since guild data is not actually fully available on `Ready`).

Implemented tests for the behavior, and everything it uses, all the way down to the bottom of the call stack.

Added `CancellationToken` support in a similar fashion.