### PR TITLE
Always refresh promotion comments after adding or editing a comment

### DIFF
--- a/Modix/ClientApp/src/components/Promotions/PromotionCommentEditModal.vue
+++ b/Modix/ClientApp/src/components/Promotions/PromotionCommentEditModal.vue
@@ -53,19 +53,19 @@
 
 
 <script lang="ts">
-import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
-
+import { Component, Prop, Watch } from 'vue-property-decorator';
+import ModixComponent from '@/components/ModixComponent.vue';
 import PromotionComment from '@/models/promotions/PromotionComment';
 import * as _ from 'lodash';
 import PromotionCommentData from '@/models/promotions/PromotionCommentData';
-import { SentimentIcons, PromotionSentiment } from '@/models/promotions/PromotionCampaign';
+import PromotionCampaign, { SentimentIcons, PromotionSentiment } from '@/models/promotions/PromotionCampaign';
 import PromotionService from '@/services/PromotionService';
 
 @Component({})
-export default class PromotionCommentEditModal extends Vue
+export default class PromotionCommentEditModal extends ModixComponent
 {
     @Prop() public comment!: PromotionComment;
-    @Prop({default: false}) public showUpdateModal!: boolean;
+    @Prop({ default: false }) public showUpdateModal!: boolean;
 
     loadingCommentUpdate: boolean = false;
     newComment: PromotionCommentData = { body: "", sentiment: PromotionSentiment.Abstain };

--- a/Modix/ClientApp/src/components/Promotions/PromotionCommentView.vue
+++ b/Modix/ClientApp/src/components/Promotions/PromotionCommentView.vue
@@ -12,15 +12,17 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
-
-import {formatDate} from '@/app/Util';
+import { Component, Prop } from 'vue-property-decorator';
+import ModixComponent from '@/components/ModixComponent.vue';
+import { formatDate } from '@/app/Util';
 import PromotionComment from '@/models/promotions/PromotionComment';
 import { SentimentIcons, PromotionSentiment } from '@/models/promotions/PromotionCampaign';
 import PromotionCommentData from '@/models/promotions/PromotionCommentData';
 
-@Component({})
-export default class PromotionCommentView extends Vue
+@Component({
+    methods: { formatDate }
+})
+export default class PromotionCommentView extends ModixComponent
 {
     loadingUpdate: boolean = false;
     showModal: boolean = false;
@@ -33,30 +35,6 @@ export default class PromotionCommentView extends Vue
     sentimentIcon(sentiment: PromotionSentiment)
     {
         return SentimentIcons[sentiment];
-    }
-
-    formatDate(date: Date): string
-    {
-        return formatDate(date);
-    }
-
-    openModal()
-    {
-        this.showModal = true;
-    }
-
-    cancelModal()
-    {
-        this.showModal = false;
-    }
-
-    async saveComment()
-    {
-        this.loadingUpdate = true;
-
-        this.loadingUpdate = false;
-
-        this.cancelModal();
     }
 }
 </script>

--- a/Modix/ClientApp/src/views/Promotions.vue
+++ b/Modix/ClientApp/src/views/Promotions.vue
@@ -226,6 +226,7 @@ export default class Promotions extends ModixComponent
 
     commentToEdit: PromotionComment | null = null;
     showCommentEditModal: boolean = false;
+    commentUpdatedCallback: (() => Promise<void>) | null = null;
 
     get campaigns(): PromotionCampaign[]
     {
@@ -362,15 +363,21 @@ export default class Promotions extends ModixComponent
         }
     }
 
-    onCommentEditModalOpened(comment: PromotionComment)
+    onCommentEditModalOpened(comment: PromotionComment, callback: () => Promise<void>)
     {
         this.commentToEdit = comment;
+        this.commentUpdatedCallback = callback;
         this.showCommentEditModal = true;
     }
 
-    onCommentEditModalClosing() : void
+    async onCommentEditModalClosing() : Promise<void>
     {
         this.showCommentEditModal = false;
+
+        if (this.commentUpdatedCallback)
+        {
+            await this.commentUpdatedCallback();
+        }
     }
 
     mounted()


### PR DESCRIPTION
Fixes #437.

I don't have the slightest clue what's supposed to be idiomatic in TypeScript, so very open to criticism here.