### PR TITLE
Fix exception when searching claims for an ID that doesn't refer to an actual user in the guild

### DIFF
--- a/Modix.Bot/Modules/AuthorizationModule.cs
+++ b/Modix.Bot/Modules/AuthorizationModule.cs
@@ -32,6 +32,13 @@ namespace Modix.Modules
                 [Remainder] DiscordUserEntity user = null)
         {
             var guildUser = await Context.Guild.GetUserAsync(user?.Id ?? Context.User.Id);
+
+            if (guildUser is null)
+            {
+                await ReplyAsync("Unable to find a user with that ID.");
+                return;
+            }
+
             var claims = await _authorizationService.GetGuildUserClaimsAsync(guildUser);
 
             await ReplyWithClaimsAsync(claims);

--- a/Modix.Bot/Modules/AuthorizationModule.cs
+++ b/Modix.Bot/Modules/AuthorizationModule.cs
@@ -26,27 +26,24 @@ namespace Modix.Modules
         }
 
         [Command("claims")]
+        [RequireContext(ContextType.Guild)]
         [Summary("Lists the currently assigned claims for the calling user, or given user")]
         public async Task ClaimsAsync(
+            [Remainder] 
             [Summary("User whom to list the claims for, if any")]
-                [Remainder] DiscordUserEntity user = null)
+                IGuildUser user = null)
         {
-            var guildUser = await Context.Guild.GetUserAsync(user?.Id ?? Context.User.Id);
-
-            if (guildUser is null)
-            {
-                await ReplyAsync("Unable to find a user with that ID.");
-                return;
-            }
-
+            var guildUser = user ?? (IGuildUser)Context.User;
             var claims = await _authorizationService.GetGuildUserClaimsAsync(guildUser);
 
             await ReplyWithClaimsAsync(claims);
         }
 
         [Command("claims")]
+        [RequireContext(ContextType.Guild)]
         [Summary("Lists the currently assigned claims for the given role.")]
         public async Task ClaimsAsync(
+            [Remainder]
             [Summary("Role for which to list claims of.")]
                 IRole role)
         {
@@ -55,12 +52,14 @@ namespace Modix.Modules
         }
 
         [Command("claims add")]
+        [RequireContext(ContextType.Guild)]
         [Summary("Adds a claim to the given role")]
         public Task AddClaimAsync(
             [Summary("Claim to be added")]
                 AuthorizationClaim claim,
             [Summary("Access of a claim, whether granted or denied")]
                 ClaimMappingType type,
+            [Remainder]
             [Summary("Role which to add the claim to")]
                 IRole role)
         {
@@ -68,12 +67,14 @@ namespace Modix.Modules
         }
 
         [Command("claims add")]
+        [RequireContext(ContextType.Guild)]
         [Summary("Adds a claim to the given user")]
         public Task AddClaimAsync(
             [Summary("Claim to be added")]
                 AuthorizationClaim claim,
             [Summary("Access of a claim, whether granted or denied")]
                 ClaimMappingType type,
+            [Remainder]
             [Summary("User to add the claim to")]
                 IGuildUser user)
         {
@@ -81,12 +82,14 @@ namespace Modix.Modules
         }
 
         [Command("claims remove")]
+        [RequireContext(ContextType.Guild)]
         [Summary("Removes a claim from the given role")]
         public Task RemoveClaimAsync(
             [Summary("Claim to be removed")]
                 AuthorizationClaim claim,
             [Summary("Access of the claim, whether granted or denied")]
                 ClaimMappingType type,
+            [Remainder]
             [Summary("Role from which the claim is to be removed")]
                 IRole role)
         {
@@ -94,12 +97,14 @@ namespace Modix.Modules
         }
 
         [Command("claims remove")]
+        [RequireContext(ContextType.Guild)]
         [Summary("Removes a claim from the given user")]
         public Task RemoveClaimAsync(
             [Summary("Claim to be added")]
                 AuthorizationClaim claim,
             [Summary("Access of a claim, whether granted or denied")]
                 ClaimMappingType type,
+            [Remainder]
             [Summary("User to add the claim to")]
                 IGuildUser user)
         {


### PR DESCRIPTION
Fixes #439.