### PR TITLE
Remove hardcoded enums in the documentation service

### DIFF
--- a/Modix.Services/Csharp/DocumentationApiResponse.cs
+++ b/Modix.Services/Csharp/DocumentationApiResponse.cs
@@ -4,40 +4,21 @@ namespace Modix.Services.Csharp
 {
     public class DocumentationApiResponse
     {
-        public List<DocumentationMember> Results { get; set; }= new List<DocumentationMember>();
+        public List<DocumentationMember> Results { get; set; } = new List<DocumentationMember>();
+
         public int Count { get; set; }
     }
 
     public class DocumentationMember
     {
         public string DisplayName { get; set; }
+
         public string Url { get; set; }
-        public Type ItemType { get; set; }
-        public Kind ItemKind { get; set; }
+
+        public string ItemType { get; set; }
+
+        public string ItemKind { get; set; }
+
         public string Description { get; set; }
-    }
-
-    public enum Type
-    {
-        Type,
-        Namespace,
-        Member,
-    }
-
-    public enum Kind
-    {
-        Namespace,
-        Class,
-        Enumeration,
-        Method,
-        Structure,
-        Property,
-        Constructor,
-        Field,
-        Event,
-        Interface,
-        Delegate,
-        Enum,
-        Struct
     }
 }


### PR DESCRIPTION
Fixes the exception returned when invoking `!docs Span<T>`, for example.