### PR TITLE
Refactor IMessageRepository

### DIFF
--- a/Modix.Data/Models/Core/MessageBrief.cs
+++ b/Modix.Data/Models/Core/MessageBrief.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Linq.Expressions;
+using Modix.Data.Models.Core;
+
+namespace Modix.Data.Repositories
+{
+    public class MessageBrief
+    {
+        /// <summary>
+        /// The unique Discord snowflake ID of the guild in which the message was sent.
+        /// </summary>
+        public ulong GuildId { get; set; }
+
+        /// <summary>
+        /// The unique Discord snowflake ID of the channel in which the message was sent.
+        /// </summary>
+        public ulong ChannelId { get; set; }
+
+        /// <summary>
+        /// The Discord ID of the message.
+        /// </summary>
+        public ulong Id { get; set; }
+
+        /// <summary>
+        /// The unique Discord snowflake ID of the user who sent the message.
+        /// </summary>
+        public ulong AuthorId { get; set; }
+
+        /// <summary>
+        /// A timestamp indicating when the message was sent.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; set; }
+
+        /// <summary>
+        /// The unique Discord snowflake ID for the starboard-message associated with this message.
+        /// </summary>
+        public ulong? StarboardEntryId { get; internal set; }
+
+        internal static readonly Expression<Func<MessageEntity, MessageBrief>> FromEntityProjection
+            = entity => new MessageBrief()
+            {
+                Id = entity.Id,
+                GuildId = entity.GuildId,
+                ChannelId = entity.ChannelId,
+                AuthorId = entity.AuthorId,
+                Timestamp = entity.Timestamp,
+                StarboardEntryId = entity.StarboardEntryId,
+            };
+    }
+}

--- a/Modix.Data/Models/Core/MessageCreationData.cs
+++ b/Modix.Data/Models/Core/MessageCreationData.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Modix.Data.Models.Core;
+
+namespace Modix.Data.Repositories
+{
+    public class MessageCreationData
+    {
+        /// <summary>
+        /// The unique Discord snowflake ID of the guild in which the message was sent.
+        /// </summary>
+        public ulong GuildId { get; set; }
+
+        /// <summary>
+        /// The unique Discord snowflake ID of the channel in which the message was sent.
+        /// </summary>
+        public ulong ChannelId { get; set; }
+
+        /// <summary>
+        /// The Discord ID of the message.
+        /// </summary>
+        public ulong Id { get; set; }
+
+        /// <summary>
+        /// The unique Discord snowflake ID of the user who sent the message.
+        /// </summary>
+        public ulong AuthorId { get; set; }
+
+        /// <summary>
+        /// A timestamp indicating when the message was sent.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; set; }
+
+        internal MessageEntity ToEntity()
+            => new MessageEntity()
+            {
+                GuildId = GuildId,
+                ChannelId = ChannelId,
+                Id = Id,
+                AuthorId = AuthorId,
+                Timestamp = Timestamp,
+            };
+    }
+}

--- a/Modix.Data/Models/Core/MessageEntity.cs
+++ b/Modix.Data/Models/Core/MessageEntity.cs
@@ -5,7 +5,7 @@ using Modix.Data.Utilities;
 
 namespace Modix.Data.Models.Core
 {
-    public class MessageEntity
+    internal class MessageEntity
     {
         [Required]
         public ulong Id { get; set; }

--- a/Modix.Data/ModixContext.cs
+++ b/Modix.Data/ModixContext.cs
@@ -43,7 +43,7 @@ namespace Modix.Data
 
         public DbSet<DesignatedRoleMappingEntity> DesignatedRoleMappings { get; set; }
 
-        public DbSet<MessageEntity> Messages { get; set; }
+        internal DbSet<MessageEntity> Messages { get; set; }
 
         public DbSet<ModerationActionEntity> ModerationActions { get; set; }
 

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -297,9 +297,8 @@ namespace Modix.Data.Repositories
         {
             return await ModixContext.Messages
                 .AsNoTracking()
-                .AsQueryable()
-                .Select(MessageBrief.FromEntityProjection)
                 .Where(x => x.Id == messageId)
+                .Select(MessageBrief.FromEntityProjection)
                 .FirstOrDefaultAsync();
         }
 

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -9,28 +9,122 @@ using NpgsqlTypes;
 
 namespace Modix.Data.Repositories
 {
+    /// <summary>
+    /// Describes a repository for managing message entities within an underlying data storage provider.
+    /// </summary>
     public interface IMessageRepository
     {
+        /// <summary>
+        /// Begins a new transaction to maintain message entities within the repository.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> that will complete, with the requested transaction object,
+        /// when no other transactions are active upon the repository.
+        /// </returns>
         Task<IRepositoryTransaction> BeginMaintainTransactionAsync();
 
-        Task<IReadOnlyDictionary<DateTime, int>> GetGuildUserMessageCountByDate(ulong guildId, ulong userId, TimeSpan timespan);
+        /// <summary>
+        /// Creates a new message log within the repository.
+        /// </summary>
+        /// <param name="data">The data for the message log to be created.</param>
+        /// <returns>
+        /// A <see cref="Task"/> which will complete when the operation is complete.
+        /// </returns>
+        Task CreateAsync(MessageCreationData data);
 
-        Task<IReadOnlyDictionary<ulong, int>> GetGuildUserMessageCountByChannel(ulong guildId, ulong userId, TimeSpan timespan);
-
-        Task<IReadOnlyCollection<PerUserMessageCount>> GetPerUserMessageCounts(ulong guildId, ulong userId, TimeSpan timespan, int userCount = 10);
-
-        Task<GuildUserParticipationStatistics> GetGuildUserParticipationStatistics(ulong guildId, ulong userId);
-
-        Task CreateAsync(MessageCreationData message);
-
+        /// <summary>
+        /// Deletes emoji logs within the repository.
+        /// </summary>
+        /// <param name="messageId">The unique Discord snowflake ID of the message to delete.</param>
+        /// <returns>
+        /// A <see cref="Task"/> which will complete when the operation is complete.
+        /// </returns>
         Task DeleteAsync(ulong messageId);
 
+        /// <summary>
+        /// Searches the message logs for message records matching the supplied ID.
+        /// </summary>
+        /// <param name="messageId">The unique Discord snowflake ID of the message to look for.</param>
+        /// <returns>
+        /// A <see cref="Task"/> which will complete when the operation is complete,
+        /// containing a <see cref="MessageBrief"/> containing information for the message or a default value if no match is found.
+        /// </returns>
         Task<MessageBrief> GetMessage(ulong messageId);
 
+        /// <summary>
+        /// Searches the message logs for message records matching the supplied guild ID and user ID within a given timeframe.
+        /// </summary>
+        /// <param name="guildId">The unique Discord snowflake ID of the guild to search in.</param>
+        /// <param name="userId">The unique Discord snowflake ID of the user to get a message count for.</param>
+        /// <param name="timespan">The timeframe the query should be based on.</param>
+        /// <returns>
+        /// A <see cref="Task"/> which will complete when the operation is complete,
+        /// containing a dictionary which contains a separate message count for each day within the given timeframe.
+        /// </returns>
+        Task<IReadOnlyDictionary<DateTime, int>> GetGuildUserMessageCountByDate(ulong guildId, ulong userId, TimeSpan timespan);
+
+        /// <summary>
+        /// Searches the message logs for message records matching the supplied guild ID and user ID within a given timeframe.
+        /// </summary>
+        /// <param name="guildId">The unique Discord snowflake ID of the guild to search in.</param>
+        /// <param name="userId">The unique Discord snowflake ID of the user to get a message count for.</param>
+        /// <param name="timespan">The timeframe the query should be based on.</param>
+        /// <returns>
+        /// A <see cref="Task"/> which will complete when the operation is complete,
+        /// containing a dictionary which contains the number of messages the given user has sent in each channel within the given timeframe.
+        /// </returns>
+        Task<IReadOnlyDictionary<ulong, int>> GetGuildUserMessageCountByChannel(ulong guildId, ulong userId, TimeSpan timespan);
+
+        /// <summary>
+        /// Calculates a given number of users contributions (through messages) in a given guild in a specific timeframe.
+        /// </summary>
+        /// <param name="guildId">The guild to count messages for.</param>
+        /// <param name="userId">The Discord snowflake ID of the user who is querying for message counts.</param>
+        /// <param name="timespan">The timeframe the query should be based on.</param>
+        /// <returns>
+        /// A <see cref="Task"/> which will complete when the operation is complete,
+        /// containing a collection of the given size <paramref name="userCount"/> within the given timeframe including the user who requested the information.
+        /// </returns>
+        Task<IReadOnlyCollection<PerUserMessageCount>> GetPerUserMessageCounts(ulong guildId, ulong userId, TimeSpan timespan, int userCount = 10);
+
+        /// <summary>
+        /// Gets participation information about a given user in a given guild.
+        /// </summary>
+        /// <param name="guildId">The guild to count messages for.</param>
+        /// <param name="userId">The Discord snowflake ID of the user who is querying for message counts.</param>
+        /// <returns>
+        /// A <see cref="Task"/> which will complete when the operation is complete,
+        /// containing <see cref="GuildUserParticipationStatistics"/> which contains information about the given user's participation in the given guild.
+        /// </returns>
+        Task<GuildUserParticipationStatistics> GetGuildUserParticipationStatistics(ulong guildId, ulong userId);
+
+        /// <summary>
+        /// Updates the starboard-entry column for a given message ID.
+        /// </summary>
+        /// <param name="messageId">The unique Discord snowflake ID of the message to update the starboard-entry column for.</param>
+        /// <param name="starboardEntryId">The ID of the starboard-entry message. Optionally null if the record no longer should exist.</param>
+        /// <returns>A <see cref="Task"/> which will complete when the operation is complete.</returns>
         Task UpdateStarboardColumn(ulong messageId, ulong? starboardEntryId);
 
+        /// <summary>
+        /// Gets the total amount of messages logged for a given guild in a certain timeframe.
+        /// </summary>
+        /// <param name="guildId"></param>
+        /// <param name="timespan"></param>
+        /// <returns>
+        /// A <see cref="Task"/> which will complete when the operation is complete,
+        /// containing the number of messages sent in the given guild during the given time period.</returns>
         Task<int> GetTotalMessageCountAsync(ulong guildId, TimeSpan timespan);
 
+        /// <summary>
+        /// Gets the total amount of messages sent in each channel of a given guild during a specific timeframe.
+        /// </summary>
+        /// <param name="guildId">The unique Discord snowflake ID of the guild to search in.</param>
+        /// <param name="timespan">The timeframe the query should be based on.</param>
+        /// <returns>
+        /// A <see cref="Task"/> which will complete when the operation is complete,
+        /// containing a dictionary which contains a separate message count for each channel within the given timeframe.
+        /// </returns>
         Task<IReadOnlyDictionary<ulong, int>> GetTotalMessageCountByChannelAsync(ulong guildId, TimeSpan timespan);
     }
 
@@ -42,16 +136,19 @@ namespace Modix.Data.Repositories
         private static readonly RepositoryTransactionFactory _maintainTransactionFactory
             = new RepositoryTransactionFactory();
 
+        /// <inheritdoc />
         public Task<IRepositoryTransaction> BeginMaintainTransactionAsync()
             => _maintainTransactionFactory.BeginTransactionAsync(ModixContext.Database);
 
-        public async Task CreateAsync(MessageCreationData message)
+        /// <inheritdoc />
+        public async Task CreateAsync(MessageCreationData data)
         {
-            var entity = message.ToEntity();
+            var entity = data.ToEntity();
             await ModixContext.Messages.AddAsync(entity);
             await ModixContext.SaveChangesAsync();
         }
 
+        /// <inheritdoc />
         public async Task DeleteAsync(ulong messageId)
         {
             var entity = await ModixContext.Messages
@@ -65,6 +162,7 @@ namespace Modix.Data.Repositories
             }
         }
 
+        /// <inheritdoc />
         public async Task<int> GetGuildUserMessageCount(ulong guildId, ulong userId, TimeSpan timespan)
         {
             var earliestDateTime = DateTimeOffset.UtcNow - timespan;
@@ -75,6 +173,7 @@ namespace Modix.Data.Repositories
                 .CountAsync();
         }
 
+        /// <inheritdoc />
         public async Task<IReadOnlyDictionary<DateTime, int>> GetGuildUserMessageCountByDate(ulong guildId, ulong userId, TimeSpan timespan)
         {
             return await GetGuildUserMessages(guildId, userId, timespan)
@@ -82,6 +181,7 @@ namespace Modix.Data.Repositories
                 .ToDictionaryAsync(x => x.Key, x => x.Count());
         }
 
+        /// <inheritdoc />
         public async Task<IReadOnlyDictionary<ulong, int>> GetGuildUserMessageCountByChannel(ulong guildId, ulong userId, TimeSpan timespan)
         {
             return await GetGuildUserMessages(guildId, userId, timespan)
@@ -89,6 +189,7 @@ namespace Modix.Data.Repositories
                 .ToDictionaryAsync(x => x.Key, x => x.Count());
         }
 
+        /// <inheritdoc />
         public async Task<IReadOnlyCollection<PerUserMessageCount>> GetPerUserMessageCounts(ulong guildId, ulong userId, TimeSpan timespan, int userCount = 10)
         {
             var earliestDateTime = DateTimeOffset.UtcNow - timespan;
@@ -143,6 +244,7 @@ namespace Modix.Data.Repositories
                     order by ""Rank"" asc";
         }
 
+        /// <inheritdoc />
         public async Task<GuildUserParticipationStatistics> GetGuildUserParticipationStatistics(ulong guildId, ulong userId)
         {
             var stats = await ModixContext.Query<GuildUserParticipationStatistics>()
@@ -190,6 +292,7 @@ namespace Modix.Data.Repositories
             return stats;
         }
 
+        /// <inheritdoc />
         public async Task<MessageBrief> GetMessage(ulong messageId)
         {
             return await ModixContext.Messages
@@ -200,6 +303,7 @@ namespace Modix.Data.Repositories
                 .FirstOrDefaultAsync();
         }
 
+        /// <inheritdoc />
         public async Task UpdateStarboardColumn(ulong messageId, ulong? starboardEntryId)
         {
             var entity = await ModixContext.Messages
@@ -212,6 +316,7 @@ namespace Modix.Data.Repositories
             await ModixContext.SaveChangesAsync();
         }
 
+        /// <inheritdoc />
         public async Task<int> GetTotalMessageCountAsync(ulong guildId, TimeSpan timespan)
         {
             var earliestDateTime = DateTimeOffset.UtcNow - timespan;
@@ -222,6 +327,7 @@ namespace Modix.Data.Repositories
                 .CountAsync();
         }
 
+        /// <inheritdoc />
         public async Task<IReadOnlyDictionary<ulong, int>> GetTotalMessageCountByChannelAsync(ulong guildId, TimeSpan timespan)
         {
             var earliestDateTime = DateTimeOffset.UtcNow - timespan;


### PR DESCRIPTION
It's been long enough, figured I'd actually do what @Scott-Caldwell told me to do before the starboard PR was merged.

Refactored the `IMessageRepository` and relevant data-models as to not expose `MessageEntity` outside of our data-layer.

This PR also solved the race-condition we saw once in a blue moon when people **_SMASHED_** that like button.

I have a lingering feeling that I've overlooked something here, so please take extra care when reviewing it.