### PR TITLE
Fix mentioning, add announcements

### DIFF
--- a/Modix.Bot/Modules/AnnounceModule.cs
+++ b/Modix.Bot/Modules/AnnounceModule.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using Modix.Services.CommandHelp;
+using Modix.Services.Mentions;
+
+namespace Modix.Bot.Modules
+{
+    [Name("announce")]
+    [Summary("Makes an announcement")]
+    [HelpTags("announce", "$")]
+    public class AnnounceModule : ModuleBase
+    {
+        private IMentionService _mentionService { get; }
+
+        public AnnounceModule(IMentionService mentionService)
+        {
+            _mentionService = mentionService;
+        }
+
+        [Command]
+        [Alias("$")]
+        [Summary("Makes an announcement in the currnet channel")]
+        public async Task MakeAnnouncementAsync([Summary("The role to mention")] IRole role,
+            [Remainder, Summary("The message to send as part of the announcement.")]
+            string message)
+        {
+            // Send message
+            await _mentionService.MentionRoleAsync(role, Context.Channel, message);
+
+            // Clean up
+            await Context.Message.DeleteAsync();
+        }
+    }
+}

--- a/Modix.Bot/Modules/AnnounceModule.cs
+++ b/Modix.Bot/Modules/AnnounceModule.cs
@@ -6,7 +6,7 @@ using Modix.Services.Mentions;
 
 namespace Modix.Bot.Modules
 {
-    [Name("announce")]
+    [Name("Announcements")]
     [Summary("Makes an announcement")]
     [HelpTags("announce", "$")]
     public class AnnounceModule : ModuleBase
@@ -18,9 +18,9 @@ namespace Modix.Bot.Modules
             _mentionService = mentionService;
         }
 
-        [Command]
+        [Command("announce")]
         [Alias("$")]
-        [Summary("Makes an announcement in the currnet channel")]
+        [Summary("Makes an announcement in the current channel")]
         public async Task MakeAnnouncementAsync([Summary("The role to mention")] IRole role,
             [Remainder, Summary("The message to send as part of the announcement.")]
             string message)

--- a/Modix.Bot/Modules/AnnounceModule.cs
+++ b/Modix.Bot/Modules/AnnounceModule.cs
@@ -22,7 +22,8 @@ namespace Modix.Bot.Modules
         [Alias("$")]
         [Summary("Makes an announcement in the current channel")]
         public async Task MakeAnnouncementAsync([Summary("The role to mention")] IRole role,
-            [Remainder, Summary("The message to send as part of the announcement.")]
+            [Summary("The message to send as part of the announcement.")]
+            [Remainder]
             string message)
         {
             // Send message

--- a/Modix.Bot/Modules/AnnounceModule.cs
+++ b/Modix.Bot/Modules/AnnounceModule.cs
@@ -26,10 +26,11 @@ namespace Modix.Bot.Modules
             string message)
         {
             // Send message
-            await _mentionService.MentionRoleAsync(role, Context.Channel, message);
-
-            // Clean up
-            await Context.Message.DeleteAsync();
+            if (await _mentionService.MentionRoleAsync(role, Context.Channel, message))
+            {
+                // Clean up
+                await Context.Message.DeleteAsync();
+            }
         }
     }
 }

--- a/Modix.Bot/Modules/MentionModule.cs
+++ b/Modix.Bot/Modules/MentionModule.cs
@@ -31,9 +31,9 @@ namespace Modix.Bot.Modules
         public async Task MentionAsync(
             [Summary("The role that the user is attempting to mention.")]
             IRole role,
-            [Summary("The message that is being sent with the mention.")] [Remainder]
+            [Remainder, Summary("The message that is being sent with the mention. Note, this is ignored by the command.")]
             string message)
-            => await MentionService.MentionRoleAsync(role, Context.Channel, message);
+            => await MentionService.MentionRoleAsync(role, Context.Channel);
 
         internal protected IMentionService MentionService { get; }
     }

--- a/Modix.Bot/Modules/MentionModule.cs
+++ b/Modix.Bot/Modules/MentionModule.cs
@@ -22,18 +22,10 @@ namespace Modix.Bot.Modules
         [Summary("Mentions the supplied role.")]
         public async Task MentionAsync(
             [Summary("The role that the user is attempting to mention.")]
-                IRole role)
-            => await MentionService.MentionRoleAsync(role, Context.Channel);
-
-        [Command("mention")]
-        [Alias("@")]
-        [Summary("Mentions the supplied role.")]
-        public async Task MentionAsync(
-            [Summary("The role that the user is attempting to mention.")]
             IRole role,
             [Summary("Message to provide to mentionees. The 'message' argument is ignored by the command.")]
             [Remainder]
-            string message)
+            string message = null)
             => await MentionService.MentionRoleAsync(role, Context.Channel);
 
         internal protected IMentionService MentionService { get; }

--- a/Modix.Bot/Modules/MentionModule.cs
+++ b/Modix.Bot/Modules/MentionModule.cs
@@ -31,7 +31,8 @@ namespace Modix.Bot.Modules
         public async Task MentionAsync(
             [Summary("The role that the user is attempting to mention.")]
             IRole role,
-            [Remainder, Summary("The message that is being sent with the mention. Note, this is ignored by the command.")]
+            [Summary("Message to provide to mentionees. The 'message' argument is ignored by the command.")]
+            [Remainder]
             string message)
             => await MentionService.MentionRoleAsync(role, Context.Channel);
 

--- a/Modix.Bot/Modules/MentionModule.cs
+++ b/Modix.Bot/Modules/MentionModule.cs
@@ -30,11 +30,10 @@ namespace Modix.Bot.Modules
         [Summary("Mentions the supplied role.")]
         public async Task MentionAsync(
             [Summary("The role that the user is attempting to mention.")]
-                IRole role,
-            [Summary("The message that is being sent with the mention.")]
-            [Remainder]
-                string message)
-            => await MentionAsync(role);
+            IRole role,
+            [Summary("The message that is being sent with the mention.")] [Remainder]
+            string message)
+            => await MentionService.MentionRoleAsync(role, Context.Channel, message);
 
         internal protected IMentionService MentionService { get; }
     }

--- a/Modix.Services/Mentions/MentionService.cs
+++ b/Modix.Services/Mentions/MentionService.cs
@@ -16,6 +16,14 @@ namespace Modix.Services.Mentions
         /// <param name="role">The role to mention</param>
         /// <param name="channel">The channel to mention in</param>
         Task MentionRoleAsync(IRole role, IMessageChannel channel);
+
+        /// <summary>
+        /// Mentions the given role in the given channel
+        /// </summary>
+        /// <param name="role">The role to mention</param>
+        /// <param name="channel">The channel to mention in</param>
+        /// <param name="message">The message to send alongside the mention</param>
+        Task MentionRoleAsync(IRole role, IMessageChannel channel, string message);
     }
 
     /// <inheritdoc />
@@ -33,6 +41,10 @@ namespace Modix.Services.Mentions
 
         /// <inheritdoc />
         public async Task MentionRoleAsync(IRole role, IMessageChannel channel)
+            => await MentionRoleAsync(role, channel, string.Empty);
+
+        /// <inheritdoc />
+        public async Task MentionRoleAsync(IRole role, IMessageChannel channel, string message)
         {
             if (role is null)
                 throw new ArgumentNullException(nameof(role));
@@ -40,7 +52,7 @@ namespace Modix.Services.Mentions
             if (channel is null)
                 throw new ArgumentNullException(nameof(channel));
 
-            if (role.IsMentionable)
+            if (role.IsMentionable && string.IsNullOrWhiteSpace(message))
             {
                 await channel.SendMessageAsync($"You can do that yourself - but fine: {role.Mention}");
                 return;
@@ -62,7 +74,7 @@ namespace Modix.Services.Mentions
             //Make sure we set the role to unmentionable again no matter what
             try
             {
-                await channel.SendMessageAsync(role.Mention);
+                await channel.SendMessageAsync($"{role.Mention} {message}");
             }
             finally
             {

--- a/Modix.Services/Mentions/MentionService.cs
+++ b/Modix.Services/Mentions/MentionService.cs
@@ -15,15 +15,8 @@ namespace Modix.Services.Mentions
         /// </summary>
         /// <param name="role">The role to mention</param>
         /// <param name="channel">The channel to mention in</param>
-        Task<bool> MentionRoleAsync(IRole role, IMessageChannel channel);
-
-        /// <summary>
-        /// Mentions the given role in the given channel
-        /// </summary>
-        /// <param name="role">The role to mention</param>
-        /// <param name="channel">The channel to mention in</param>
         /// <param name="message">The message to send alongside the mention</param>
-        Task<bool> MentionRoleAsync(IRole role, IMessageChannel channel, string message);
+        Task<bool> MentionRoleAsync(IRole role, IMessageChannel channel, string message = null);
     }
 
     /// <inheritdoc />
@@ -40,17 +33,16 @@ namespace Modix.Services.Mentions
         }
 
         /// <inheritdoc />
-        public async Task<bool> MentionRoleAsync(IRole role, IMessageChannel channel)
-            => await MentionRoleAsync(role, channel, string.Empty);
-
-        /// <inheritdoc />
-        public async Task<bool> MentionRoleAsync(IRole role, IMessageChannel channel, string message)
+        public async Task<bool> MentionRoleAsync(IRole role, IMessageChannel channel, string message = null)
         {
             if (role is null)
                 throw new ArgumentNullException(nameof(role));
 
             if (channel is null)
                 throw new ArgumentNullException(nameof(channel));
+
+            if (message is null)
+                message = string.Empty;
 
             if (role.IsMentionable)
             {


### PR DESCRIPTION
This PR does two things:

1. Adds `!announce` command with optional `!$` alias. Usage:

```
!announce News I'm mentioning the News Role`
!$ News Same Here
```

2. Fixes the role mentioning feature so the it matches the documentation. Specifically, this refers to the `!mention role message` overload. Before, it would just swallow the message argument.

**NOTE:** The `!mention` and `!announce` commands function nearly identically. The only difference between them is that the `!announce` command will automatically delete the initial message. The `!mention` overload, now fixed, will preserve the original message.

Edit: Added clarification
Edit 2: Fixes #469