### PR TITLE
Move website base url out to bot config.

### DIFF
--- a/Modix.Bot/Behaviors/ModerationLoggingBehavior.cs
+++ b/Modix.Bot/Behaviors/ModerationLoggingBehavior.cs
@@ -99,7 +99,7 @@ namespace Modix.Behaviors
             => _lazyModerationService.Value;
         private readonly Lazy<IModerationService> _lazyModerationService;
 
-        internal static protected ModixConfig Config { get; private set; }
+        internal protected static ModixConfig Config { get; private set; }
 
         // https://modix.gg/logs/deletedMessages?batchId={14}
         private static string _batchDeletedUrl = new UriBuilder(Config.WebsiteBaseUrl)

--- a/Modix.Bot/Behaviors/ModerationLoggingBehavior.cs
+++ b/Modix.Bot/Behaviors/ModerationLoggingBehavior.cs
@@ -102,7 +102,7 @@ namespace Modix.Behaviors
         internal protected static ModixConfig Config { get; private set; }
 
         // https://modix.gg/logs/deletedMessages?batchId={14}
-        private static string _batchDeletedUrl = new UriBuilder(Config.WebsiteBaseUrl)
+        private static readonly string _batchDeletedUrl = new UriBuilder(Config.WebsiteBaseUrl)
         {
             Path = "/logs/deletedMessages",
             Query = "batchId={14}"

--- a/Modix.Bot/Behaviors/ModerationLoggingBehavior.cs
+++ b/Modix.Bot/Behaviors/ModerationLoggingBehavior.cs
@@ -106,9 +106,9 @@ namespace Modix.Behaviors
         {
             Path = "/logs/deletedMessages",
             Query = "batchId={14}"
-        }.ToString(true);
+        }.RemoveDefaultPort().ToString();
 
-        private static readonly Dictionary<(ModerationActionType, InfractionType?), string> _renderTemplates
+        private readonly Dictionary<(ModerationActionType, InfractionType?), string> _renderTemplates
             = new Dictionary<(ModerationActionType, InfractionType?), string>()
             {
                 { (ModerationActionType.InfractionCreated,   InfractionType.Notice),  "`[{0}]` **{1}** recorded the following note for **{3}** (`{4}`) ```\n{5}```" },

--- a/Modix.Bot/Behaviors/ModerationLoggingBehavior.cs
+++ b/Modix.Bot/Behaviors/ModerationLoggingBehavior.cs
@@ -8,6 +8,7 @@ using Discord;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Modix.Bot.Extensions;
 using Modix.Common;
 using Modix.Data.Models.Core;
 using Modix.Data.Models.Moderation;
@@ -105,7 +106,7 @@ namespace Modix.Behaviors
         {
             Path = "/logs/deletedMessages",
             Query = "batchId={14}"
-        }.ToString().Replace(":80", "").Replace(":443", "");
+        }.ToString(true);
 
         private static readonly Dictionary<(ModerationActionType, InfractionType?), string> _renderTemplates
             = new Dictionary<(ModerationActionType, InfractionType?), string>()

--- a/Modix.Bot/Behaviors/ModerationLoggingBehavior.cs
+++ b/Modix.Bot/Behaviors/ModerationLoggingBehavior.cs
@@ -100,6 +100,7 @@ namespace Modix.Behaviors
 
         internal static protected ModixConfig Config { get; private set; }
 
+        // https://modix.gg/logs/deletedMessages?batchId={14}
         private static string _batchDeletedUrl = new UriBuilder(Config.WebsiteBaseUrl)
         {
             Path = "/logs/deletedMessages",

--- a/Modix.Bot/Extensions/UriBuilderExtensions.cs
+++ b/Modix.Bot/Extensions/UriBuilderExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Modix.Bot.Extensions
 {
@@ -11,13 +9,13 @@ namespace Modix.Bot.Extensions
         /// </summary>
         /// <param name="trimDefaultPort">True to trim the default port; otherwise false.</param>
         /// <remarks>If <param name="trimDefaultPort" /> is false, the result is the same as running <see cref="UriBuilder.ToString"/>.</remarks>
-        /// <returns></returns>
-        public static string ToString(this UriBuilder builder, bool trimDefaultPort)
+        /// <returns>The UriBuilder instance for command chaining</returns>
+        public static UriBuilder RemoveDefaultPort(this UriBuilder builder)
         {
-            if (trimDefaultPort && builder.Uri.IsDefaultPort)
+            if (builder.Uri.IsDefaultPort)
                 builder.Port = -1;
 
-            return builder.Uri.ToString();
+            return builder;
         }
     }
 }

--- a/Modix.Bot/Extensions/UriBuilderExtensions.cs
+++ b/Modix.Bot/Extensions/UriBuilderExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Modix.Bot.Extensions
+{
+    public static class UriBuilderExtensions
+    {
+        public static string ToString(this UriBuilder builder, bool trimDefaultPort)
+        {
+            if (trimDefaultPort && builder.Uri.IsDefaultPort)
+                builder.Port = -1;
+
+            return builder.Uri.ToString();
+        }
+    }
+}

--- a/Modix.Bot/Extensions/UriBuilderExtensions.cs
+++ b/Modix.Bot/Extensions/UriBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace Modix.Bot.Extensions
         /// </summary>
         /// <param name="trimDefaultPort">True to trim the default port; otherwise false.</param>
         /// <remarks>If <param name="trimDefaultPort" /> is false, the result is the same as running <see cref="UriBuilder.ToString"/>.</remarks>
-        /// <returns>The UriBuilder instance for command chaining</returns>
+        /// <returns>The UriBuilder instance for command chaining.</returns>
         public static UriBuilder RemoveDefaultPort(this UriBuilder builder)
         {
             if (builder.Uri.IsDefaultPort)

--- a/Modix.Bot/Extensions/UriBuilderExtensions.cs
+++ b/Modix.Bot/Extensions/UriBuilderExtensions.cs
@@ -6,6 +6,12 @@ namespace Modix.Bot.Extensions
 {
     public static class UriBuilderExtensions
     {
+        /// <summary>
+        /// Returns the display string for the specified <see cref="UriBuilder"/> instance.
+        /// </summary>
+        /// <param name="trimDefaultPort">True to trim the default port; otherwise false.</param>
+        /// <remarks>If <param name="trimDefaultPort" /> is false, the result is the same as running <see cref="UriBuilder.ToString"/>.</remarks>
+        /// <returns></returns>
         public static string ToString(this UriBuilder builder, bool trimDefaultPort)
         {
             if (trimDefaultPort && builder.Uri.IsDefaultPort)

--- a/Modix.Bot/Extensions/UriBuilderExtensions.cs
+++ b/Modix.Bot/Extensions/UriBuilderExtensions.cs
@@ -5,10 +5,8 @@ namespace Modix.Bot.Extensions
     public static class UriBuilderExtensions
     {
         /// <summary>
-        /// Returns the display string for the specified <see cref="UriBuilder"/> instance.
+        /// Removes the port specification from the builder if it's the default port for the specified scheme.
         /// </summary>
-        /// <param name="trimDefaultPort">True to trim the default port; otherwise false.</param>
-        /// <remarks>If <param name="trimDefaultPort" /> is false, the result is the same as running <see cref="UriBuilder.ToString"/>.</remarks>
         /// <returns>The UriBuilder instance for command chaining.</returns>
         public static UriBuilder RemoveDefaultPort(this UriBuilder builder)
         {

--- a/Modix.Bot/ModixBot.cs
+++ b/Modix.Bot/ModixBot.cs
@@ -218,7 +218,7 @@ namespace Modix
             {
                 Log.LogTrace("Discord client is ready. Setting game status.");
                 _client.Ready -= OnClientReady;
-                await _client.SetGameAsync($"https://{_config.ManagementDomain}/");
+                await _client.SetGameAsync(_config.WebsiteBaseUrl);
             }
         }
     }

--- a/Modix.Bot/ModixBot.cs
+++ b/Modix.Bot/ModixBot.cs
@@ -218,7 +218,7 @@ namespace Modix
             {
                 Log.LogTrace("Discord client is ready. Setting game status.");
                 _client.Ready -= OnClientReady;
-                await _client.SetGameAsync("https://mod.gg/");
+                await _client.SetGameAsync($"https://{_config.ManagementDomain}/");
             }
         }
     }

--- a/Modix.Bot/Modules/DesignatedChannelModule.cs
+++ b/Modix.Bot/Modules/DesignatedChannelModule.cs
@@ -38,7 +38,7 @@ namespace Modix.Modules
             var url = new UriBuilder(Config.WebsiteBaseUrl)
             {
                 Path = "/config/channels"
-            }.ToString();
+            }.ToString(true);
 
             var builder = new EmbedBuilder()
             {

--- a/Modix.Bot/Modules/DesignatedChannelModule.cs
+++ b/Modix.Bot/Modules/DesignatedChannelModule.cs
@@ -38,7 +38,7 @@ namespace Modix.Modules
             var url = new UriBuilder(Config.WebsiteBaseUrl)
             {
                 Path = "/config/channels"
-            }.ToString(true);
+            }.RemoveDefaultPort().ToString();
 
             var builder = new EmbedBuilder()
             {

--- a/Modix.Bot/Modules/DesignatedChannelModule.cs
+++ b/Modix.Bot/Modules/DesignatedChannelModule.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Humanizer;
+using Microsoft.Extensions.Options;
 using Modix.Bot.Extensions;
 using Modix.Data.Models.Core;
 using Modix.Services.Core;
@@ -18,10 +19,13 @@ namespace Modix.Modules
         public IAuthorizationService AuthorizationService { get; }
         public IDesignatedChannelService DesignatedChannelService { get; }
 
-        public DesignatedChannelModule(IAuthorizationService authorizationService, IDesignatedChannelService designatedChannelService)
+        public ModixConfig Config { get; }
+
+        public DesignatedChannelModule(IAuthorizationService authorizationService, IDesignatedChannelService designatedChannelService, IOptions<ModixConfig> config)
         {
             AuthorizationService = authorizationService;
             DesignatedChannelService = designatedChannelService;
+            Config = config.Value;
         }
 
         [Command]
@@ -30,10 +34,16 @@ namespace Modix.Modules
         {
             var channels = await DesignatedChannelService.GetDesignatedChannelsAsync(Context.Guild.Id);
 
+            // https://mod.gg/config/channels
+            var url = new UriBuilder(Config.WebsiteBaseUrl)
+            {
+                Path = "/config/channels"
+            }.ToString();
+
             var builder = new EmbedBuilder()
             {
                 Title = "Assigned Channel Designations",
-                Url = "https://mod.gg/config/channels",
+                Url = url,
                 Color = Color.Gold,
                 Timestamp = DateTimeOffset.UtcNow
             };

--- a/Modix.Bot/Modules/DesignatedRoleModule.cs
+++ b/Modix.Bot/Modules/DesignatedRoleModule.cs
@@ -38,7 +38,7 @@ namespace Modix.Modules
             var url = new UriBuilder(Config.WebsiteBaseUrl)
             {
                 Path = "/config/roles"
-            }.ToString(true);
+            }.RemoveDefaultPort().ToString();
 
             var builder = new EmbedBuilder()
             {

--- a/Modix.Bot/Modules/DesignatedRoleModule.cs
+++ b/Modix.Bot/Modules/DesignatedRoleModule.cs
@@ -34,6 +34,7 @@ namespace Modix.Modules
         {
             var roles = await DesignatedRoleService.GetDesignatedRolesAsync(Context.Guild.Id);
 
+            // https://mod.gg/config/roles
             var url = new UriBuilder(Config.WebsiteBaseUrl)
             {
                 Path = "/config/roles"

--- a/Modix.Bot/Modules/DesignatedRoleModule.cs
+++ b/Modix.Bot/Modules/DesignatedRoleModule.cs
@@ -38,7 +38,7 @@ namespace Modix.Modules
             var url = new UriBuilder(Config.WebsiteBaseUrl)
             {
                 Path = "/config/roles"
-            }.ToString();
+            }.ToString(true);
 
             var builder = new EmbedBuilder()
             {

--- a/Modix.Bot/Modules/DesignatedRoleModule.cs
+++ b/Modix.Bot/Modules/DesignatedRoleModule.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Humanizer;
+using Microsoft.Extensions.Options;
 using Modix.Bot.Extensions;
 using Modix.Data.Models.Core;
 using Modix.Services.Core;
@@ -18,10 +19,13 @@ namespace Modix.Modules
         public IAuthorizationService AuthorizationService { get; }
         public IDesignatedRoleService DesignatedRoleService { get; }
 
-        public DesignatedRoleModule(IAuthorizationService authorizationService, IDesignatedRoleService designatedRoleService)
+        public ModixConfig Config { get; }
+
+        public DesignatedRoleModule(IAuthorizationService authorizationService, IDesignatedRoleService designatedRoleService, IOptions<ModixConfig> config)
         {
             AuthorizationService = authorizationService;
             DesignatedRoleService = designatedRoleService;
+            Config = config.Value;
         }
 
         [Command]
@@ -30,10 +34,15 @@ namespace Modix.Modules
         {
             var roles = await DesignatedRoleService.GetDesignatedRolesAsync(Context.Guild.Id);
 
+            var url = new UriBuilder(Config.WebsiteBaseUrl)
+            {
+                Path = "/config/roles"
+            }.ToString();
+
             var builder = new EmbedBuilder()
             {
                 Title = "Assigned Role Designations",
-                Url = "https://mod.gg/config/roles",
+                Url = url,
                 Color = Color.Gold,
                 Timestamp = DateTimeOffset.UtcNow
             };

--- a/Modix.Bot/Modules/HelpModule.cs
+++ b/Modix.Bot/Modules/HelpModule.cs
@@ -7,6 +7,7 @@ using Discord;
 using Discord.Commands;
 using Discord.Net;
 using Microsoft.Extensions.Options;
+using Modix.Bot.Extensions;
 using Modix.Data.Models.Core;
 using Modix.Services.CommandHelp;
 using Modix.Services.Utilities;

--- a/Modix.Bot/Modules/HelpModule.cs
+++ b/Modix.Bot/Modules/HelpModule.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.Net;
+using Microsoft.Extensions.Options;
+using Modix.Data.Models.Core;
 using Modix.Services.CommandHelp;
 using Modix.Services.Utilities;
 
@@ -16,10 +18,12 @@ namespace Modix.Modules
     public sealed class HelpModule : ModuleBase
     {
         private readonly ICommandHelpService _commandHelpService;
+        private readonly ModixConfig Config;
 
-        public HelpModule(ICommandHelpService commandHelpService)
+        public HelpModule(ICommandHelpService commandHelpService, IOptions<ModixConfig> config)
         {
             _commandHelpService = commandHelpService;
+            Config = config.Value;
         }
 
         [Command("help"), Summary("Prints a neat list of all commands.")]
@@ -29,6 +33,12 @@ namespace Modix.Modules
                 .Select(d => d.Name)
                 .OrderBy(d => d);
 
+            // https://mod.gg/commands
+            var url = new UriBuilder(Config.WebsiteBaseUrl)
+            {
+                Path = "/commands"
+            }.ToString().Replace(":80", "").Replace(":443", "");
+
             var descriptionBuilder = new StringBuilder()
                 .AppendLine("Modules:")
                 .AppendJoin(", ", modules)
@@ -36,7 +46,7 @@ namespace Modix.Modules
                 .AppendLine()
                 .AppendLine("Do \"!help dm\" to have everything DMed to you. (Spammy!)")
                 .AppendLine("Do \"!help [module name] to have that module's commands listed.")
-                .AppendLine("Visit https://mod.gg/commands to view all the commands!");
+                .AppendLine($"Visit {url} to view all the commands!");
 
             var embed = new EmbedBuilder()
                 .WithTitle("Help")

--- a/Modix.Bot/Modules/HelpModule.cs
+++ b/Modix.Bot/Modules/HelpModule.cs
@@ -37,7 +37,7 @@ namespace Modix.Modules
             var url = new UriBuilder(Config.WebsiteBaseUrl)
             {
                 Path = "/commands"
-            }.ToString().Replace(":80", "").Replace(":443", "");
+            }.ToString(true);
 
             var descriptionBuilder = new StringBuilder()
                 .AppendLine("Modules:")

--- a/Modix.Bot/Modules/HelpModule.cs
+++ b/Modix.Bot/Modules/HelpModule.cs
@@ -19,12 +19,12 @@ namespace Modix.Modules
     public sealed class HelpModule : ModuleBase
     {
         private readonly ICommandHelpService _commandHelpService;
-        private readonly ModixConfig Config;
+        private readonly ModixConfig _config;
 
         public HelpModule(ICommandHelpService commandHelpService, IOptions<ModixConfig> config)
         {
             _commandHelpService = commandHelpService;
-            Config = config.Value;
+            _config = config.Value;
         }
 
         [Command("help"), Summary("Prints a neat list of all commands.")]
@@ -35,10 +35,10 @@ namespace Modix.Modules
                 .OrderBy(d => d);
 
             // https://mod.gg/commands
-            var url = new UriBuilder(Config.WebsiteBaseUrl)
+            var url = new UriBuilder(_config.WebsiteBaseUrl)
             {
                 Path = "/commands"
-            }.ToString(true);
+            }.RemoveDefaultPort().ToString();
 
             var descriptionBuilder = new StringBuilder()
                 .AppendLine("Modules:")

--- a/Modix.Bot/Modules/InfractionModule.cs
+++ b/Modix.Bot/Modules/InfractionModule.cs
@@ -87,6 +87,7 @@ namespace Modix.Modules
 
             foreach (var infraction in infractionQuery)
             {
+                // https://modix.gg/infractions?id=123
                 var infractionUrl = new UriBuilder(Config.WebsiteBaseUrl)
                 {
                     Path = "/infractions",

--- a/Modix.Bot/Modules/InfractionModule.cs
+++ b/Modix.Bot/Modules/InfractionModule.cs
@@ -77,7 +77,7 @@ namespace Modix.Modules
             {
                 Path = "/infractions",
                 Query = $"subject={subject.UserId}"
-            }.ToString(true);
+            }.RemoveDefaultPort().ToString();
 
             var builder = new EmbedBuilder()
                 .WithTitle($"Infractions for user: {subject.GetFullUsername()}")
@@ -119,7 +119,6 @@ namespace Modix.Modules
 
         internal protected IModerationService ModerationService { get; }
         internal protected IUserService UserService { get; }
-
         internal protected ModixConfig Config { get; }
     }
 }

--- a/Modix.Bot/Modules/InfractionModule.cs
+++ b/Modix.Bot/Modules/InfractionModule.cs
@@ -77,7 +77,7 @@ namespace Modix.Modules
             {
                 Path = "/infractions",
                 Query = $"subject={subject.UserId}"
-            }.ToString();
+            }.ToString(true);
 
             var builder = new EmbedBuilder()
                 .WithTitle($"Infractions for user: {subject.GetFullUsername()}")

--- a/Modix.Bot/Modules/PromotionsModule.cs
+++ b/Modix.Bot/Modules/PromotionsModule.cs
@@ -44,7 +44,7 @@ namespace Modix.Modules
             var url = new UriBuilder(Config.WebsiteBaseUrl)
             {
                 Path = "/promotions"
-            }.ToString(true);
+            }.RemoveDefaultPort().ToString();
 
             var embed = new EmbedBuilder()
             {

--- a/Modix.Bot/Modules/PromotionsModule.cs
+++ b/Modix.Bot/Modules/PromotionsModule.cs
@@ -4,8 +4,9 @@ using System.Threading.Tasks;
 
 using Discord;
 using Discord.Commands;
-
+using Microsoft.Extensions.Options;
 using Modix.Bot.Extensions;
+using Modix.Data.Models.Core;
 using Modix.Data.Models.Promotions;
 using Modix.Data.Utilities;
 using Modix.Services.CommandHelp;
@@ -23,7 +24,7 @@ namespace Modix.Modules
     {
         private const string DefaultApprovalMessage = "I approve of this nomination.";
 
-        public PromotionsModule(IPromotionsService promotionsService)
+        public PromotionsModule(IPromotionsService promotionsService, IOptions<ModixConfig> config)
         {
             PromotionsService = promotionsService;
         }
@@ -39,10 +40,16 @@ namespace Modix.Modules
                 IsClosed = false                
             });
 
+            // https://mod.gg/promotions
+            var url = new UriBuilder(Config.WebsiteBaseUrl)
+            {
+                Path = "/promotions"
+            }.ToString();
+
             var embed = new EmbedBuilder()
             {
                 Title = Format.Bold("Active Promotion Campaigns"),
-                Url = "https://mod.gg/promotions",
+                Url = url,
                 Color = Color.Gold,
                 Timestamp = DateTimeOffset.Now,
                 Description = campaigns.Any() ? null : "There are no active promotion campaigns."
@@ -156,5 +163,7 @@ namespace Modix.Modules
         }
 
         internal protected IPromotionsService PromotionsService { get; }
+
+        internal protected ModixConfig Config { get; }
     }
 }

--- a/Modix.Bot/Modules/PromotionsModule.cs
+++ b/Modix.Bot/Modules/PromotionsModule.cs
@@ -44,7 +44,7 @@ namespace Modix.Modules
             var url = new UriBuilder(Config.WebsiteBaseUrl)
             {
                 Path = "/promotions"
-            }.ToString();
+            }.ToString(true);
 
             var embed = new EmbedBuilder()
             {

--- a/Modix.Bot/Modules/TagModule.cs
+++ b/Modix.Bot/Modules/TagModule.cs
@@ -221,7 +221,7 @@ namespace Modix.Bot.Modules
                 var url = new UriBuilder(Config.WebsiteBaseUrl)
                 {
                     Path = "/tags"
-                }.ToString(true);
+                }.RemoveDefaultPort().ToString();
 
                 builder.AddField(x => x.WithName(fieldName)
                                        .WithValue($"View at {url}"));

--- a/Modix.Bot/Modules/TagModule.cs
+++ b/Modix.Bot/Modules/TagModule.cs
@@ -5,8 +5,9 @@ using System.Threading.Tasks;
 
 using Discord;
 using Discord.Commands;
-
+using Microsoft.Extensions.Options;
 using Modix.Bot.Extensions;
+using Modix.Data.Models.Core;
 using Modix.Data.Models.Tags;
 using Modix.Services.CodePaste;
 using Modix.Services.Core;
@@ -21,11 +22,16 @@ namespace Modix.Bot.Modules
     [Alias("tags")]
     public class TagModule : ModuleBase
     {
-        public TagModule(ITagService tagService, CodePasteService codePasteService, IUserService userService)
+        public TagModule(
+            ITagService tagService,
+            CodePasteService codePasteService,
+            IUserService userService,
+            IOptions<ModixConfig> config)
         {
             TagService = tagService;
             CodePasteService = codePasteService;
             UserService = userService;
+            Config = config.Value;
         }
 
         [Command("create")]
@@ -166,6 +172,8 @@ namespace Modix.Bot.Modules
 
         protected IUserService UserService { get; }
 
+        protected ModixConfig Config { get; }
+
         private async Task HandleTagError(string message)
         {
             var embed = new EmbedBuilder()
@@ -209,8 +217,14 @@ namespace Modix.Bot.Modules
             {
                 var fieldName = $"and {tags.Count - tagsToDisplay} more";
 
+                // https://modix.gg/tags
+                var url = new UriBuilder(Config.WebsiteBaseUrl)
+                {
+                    Path = "/tags"
+                }.ToString().Replace(":80", "").Replace(":443", "");
+
                 builder.AddField(x => x.WithName(fieldName)
-                                       .WithValue($"View at https://mod.gg/tags"));
+                                       .WithValue($"View at {url}"));
             }
 
             return builder.Build();

--- a/Modix.Bot/Modules/TagModule.cs
+++ b/Modix.Bot/Modules/TagModule.cs
@@ -221,7 +221,7 @@ namespace Modix.Bot.Modules
                 var url = new UriBuilder(Config.WebsiteBaseUrl)
                 {
                     Path = "/tags"
-                }.ToString().Replace(":80", "").Replace(":443", "");
+                }.ToString(true);
 
                 builder.AddField(x => x.WithName(fieldName)
                                        .WithValue($"View at {url}"));

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -208,7 +208,7 @@ namespace Modix.Modules
             {
                 Path = "/infractions",
                 Query = $"subject={userId}"
-            }.ToString();
+            }.ToString(true);
 
             builder.AppendLine();
             builder.AppendLine($"**\u276F Infractions [See here]({url})**");

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -208,7 +208,7 @@ namespace Modix.Modules
             {
                 Path = "/infractions",
                 Query = $"subject={userId}"
-            }.ToString(true);
+            }.RemoveDefaultPort().ToString();
 
             builder.AppendLine();
             builder.AppendLine($"**\u276F Infractions [See here]({url})**");

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -10,6 +10,7 @@ using Discord.WebSocket;
 using Humanizer;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Modix.Bot.Extensions;
 using Modix.Data.Models;
 using Modix.Data.Models.Core;
@@ -41,7 +42,8 @@ namespace Modix.Modules
             IMessageRepository messageRepository,
             IEmojiRepository emojiRepository,
             IPromotionsService promotionsService,
-            IImageService imageService)
+            IImageService imageService,
+            IOptions<ModixConfig> config)
         {
             _log = logger ?? new NullLogger<UserInfoModule>();
             _userService = userService;
@@ -51,6 +53,7 @@ namespace Modix.Modules
             _emojiRepository = emojiRepository;
             _promotionsService = promotionsService;
             _imageService = imageService;
+            _config = config.Value;
         }
 
         private readonly ILogger<UserInfoModule> _log;
@@ -61,6 +64,7 @@ namespace Modix.Modules
         private readonly IEmojiRepository _emojiRepository;
         private readonly IPromotionsService _promotionsService;
         private readonly IImageService _imageService;
+        private readonly ModixConfig _config;
 
         [Command("info")]
         [Summary("Retrieves information about the supplied user, or the current user if one is not provided.")]
@@ -199,8 +203,15 @@ namespace Modix.Modules
 
         private async Task AddInfractionsToEmbedAsync(ulong userId, StringBuilder builder)
         {
+            // https://modix.gg/infractions?subject=1234
+            var url = new UriBuilder(_config.WebsiteBaseUrl)
+            {
+                Path = "/infractions",
+                Query = $"subject={userId}"
+            }.ToString();
+
             builder.AppendLine();
-            builder.AppendLine($"**\u276F Infractions [See here](https://mod.gg/infractions?subject={userId})**");
+            builder.AppendLine($"**\u276F Infractions [See here]({url})**");
 
             if (!(Context.Channel as IGuildChannel).IsPublic())
             {

--- a/Modix.Data/Models/Core/ModixConfig.cs
+++ b/Modix.Data/Models/Core/ModixConfig.cs
@@ -21,5 +21,7 @@
         public string ReplUrl { get; set; }
 
         public string IlUrl { get; set; }
+
+        public string WebsiteBaseUrl { get; set; } = "https://mod.gg";
     }
 }

--- a/Modix/developmentSettings.default.json
+++ b/Modix/developmentSettings.default.json
@@ -8,5 +8,6 @@
   "StackoverflowToken": "",
   "MessageCacheSize": "",
   "ReplUrl": "",
-  "IlUrl":  ""
+  "IlUrl": "",
+  "WebsiteBaseUrl": ""
 }


### PR DESCRIPTION
This PR adds a new configuration item (either to the bot environment variables or `developmentSettings.json`) which determines the urls used for modals and the "now playing" text.

NOTE: This is completely disparate to any configuration for the actual website. If your website is on `localhost:5000` but the WebsiteBaseUrl is set to `modix.gg`, the modals and now playing will use `modix.gg` as their url and your website will not be touched.

The default WebsiteBaseUrl is `https://modix.gg`, meaning we will not have to change our configuration.

NOTE 2: Reviewers should check the spelling in my UriBuilder paths and queries! If there is a typo, we should find it now before we break things.

That said, I've designed this around *not* being a breaking change. Our instance shouldn't have to touch a things after this PR is merged, even if the code base is updated. This is only for those who want to modify this config item.

We should add a note to the wiki stating that the WebsiteBaseUrl should have the protocol, domain, and the host (if not default).

Fixes #471 
Fixes #472 