### PR TITLE
Add new TimeSpanTypeReader, allowing for formats such as "24h"

### DIFF
--- a/Modix.Bot.Test/.editorconfig
+++ b/Modix.Bot.Test/.editorconfig
@@ -1,0 +1,4 @@
+[*.{cs,vb}]
+
+#Don't apply normal naming rules to test methods
+dotnet_naming_rule.async_methods_should_be_suffixed.severity = none

--- a/Modix.Bot.Test/AssemblyInfo.cs
+++ b/Modix.Bot.Test/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: Parallelizable]

--- a/Modix.Bot.Test/Modix.Bot.Test.csproj
+++ b/Modix.Bot.Test/Modix.Bot.Test.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Modix.Bot\Modix.Bot.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/Modix.Bot.Test/TimeSpanTypeReaderTests.cs
+++ b/Modix.Bot.Test/TimeSpanTypeReaderTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Modix.Bot.Test
+{
+    public class TimeSpanTypeReaderTests
+    {
+        internal static readonly string[] InvalidInputs
+            = new[]
+            {
+                "",
+                "2",
+                "z",
+                "24z",
+                "-1h",
+                "2h-1m",
+                "1hour",
+                "h20",
+                " 12h",
+                "12h ",
+                "test",
+            };
+
+        [TestCaseSource(nameof(InvalidInputs))]
+        public void TryParseTimeSpan_GivenInvalidInput_ReturnsFalse(string input)
+        {
+            var uut = new TimeSpanTypeReader();
+
+            var succeeded = uut.TryParseTimeSpan(input, out _);
+
+            succeeded.ShouldBeFalse();
+        }
+
+        internal static readonly object[] ValidInputs
+            = new[]
+            {
+                new object[] { "0s", TimeSpan.Zero },
+                new object[] { "1s", TimeSpan.FromSeconds(1) },
+                new object[] { "60s", TimeSpan.FromSeconds(60) },
+                new object[] { "61s", TimeSpan.FromSeconds(61) },
+
+                new object[] { "0m", TimeSpan.Zero },
+                new object[] { "1m", TimeSpan.FromMinutes(1) },
+                new object[] { "60m", TimeSpan.FromMinutes(60) },
+                new object[] { "61m", TimeSpan.FromMinutes(61) },
+
+                new object[] { "0h", TimeSpan.Zero },
+                new object[] { "1h", TimeSpan.FromHours(1) },
+                new object[] { "24h", TimeSpan.FromHours(24) },
+                new object[] { "25h", TimeSpan.FromHours(25) },
+
+                new object[] { "0d", TimeSpan.Zero },
+                new object[] { "1d", TimeSpan.FromDays(1) },
+                new object[] { "31d", TimeSpan.FromDays(31) },
+                new object[] { "32d", TimeSpan.FromDays(32) },
+
+                new object[] { "0d0h0m0s", TimeSpan.Zero },
+                new object[] { "1d1h1m1s", TimeSpan.FromDays(1) + TimeSpan.FromHours(1) + TimeSpan.FromMinutes(1) + TimeSpan.FromSeconds(1) },
+                new object[] { "31d24h60m60s", TimeSpan.FromDays(31) + TimeSpan.FromHours(24) + TimeSpan.FromMinutes(60) + TimeSpan.FromSeconds(60) },
+                new object[] { "32d25h61m61s", TimeSpan.FromDays(32) + TimeSpan.FromHours(25) + TimeSpan.FromMinutes(61) + TimeSpan.FromSeconds(61) },
+            };
+
+        [TestCaseSource(nameof(ValidInputs))]
+        public void TryParseTimeSpan_GivenValidInput_SuccessfullyParses(string input, TimeSpan expected)
+        {
+            var uut = new TimeSpanTypeReader();
+
+            var succeeded = uut.TryParseTimeSpan(input, out var actual);
+
+            succeeded.ShouldBeTrue();
+            actual.ShouldBe(expected);
+        }
+    }
+}

--- a/Modix.Bot/AssemblyInfo.cs
+++ b/Modix.Bot/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Modix.Bot.Test")]

--- a/Modix.Bot/TimeSpanTypeReader.cs
+++ b/Modix.Bot/TimeSpanTypeReader.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Threading.Tasks;
+using Discord.Commands;
+
+namespace Modix.Bot
+{
+    public class TimeSpanTypeReader : TypeReader
+    {
+        /// <inheritdoc />
+        public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
+            => TryParseTimeSpan(input.ToLowerInvariant(), out var timeSpan)
+                ? Task.FromResult(TypeReaderResult.FromSuccess(timeSpan))
+                : Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Failed to parse TimeSpan"));
+
+        internal protected bool TryParseTimeSpan(ReadOnlySpan<char> input, out TimeSpan result)
+        {
+            result = TimeSpan.Zero;
+
+            if (input.Length <= 1)
+                return false;
+
+            var start = 0;
+
+            while (start < input.Length)
+            {
+                if (char.IsDigit(input[start]))
+                {
+                    var i = start + 1;
+
+                    while (i < input.Length - 1 && char.IsDigit(input[i]))
+                        i++;
+
+                    if (!double.TryParse(input.Slice(start, i - start), out var timeQuantity))
+                        return false;
+
+                    switch (input[i])
+                    {
+                        case 'd':
+                            result += TimeSpan.FromDays(timeQuantity);
+                            break;
+                        case 'h':
+                            result += TimeSpan.FromHours(timeQuantity);
+                            break;
+                        case 'm':
+                            result += TimeSpan.FromMinutes(timeQuantity);
+                            break;
+                        case 's':
+                            result += TimeSpan.FromSeconds(timeQuantity);
+                            break;
+                        default:
+                            return false;
+                    }
+
+                    start = i + 1;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Modix.sln
+++ b/Modix.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Modix.Common", "Modix.Commo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Modix.Common.Test", "Modix.Common.Test\Modix.Common.Test.csproj", "{4F9BDC85-B8B2-4AC5-99BC-1F2F0CF80016}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Modix.Bot.Test", "Modix.Bot.Test\Modix.Bot.Test.csproj", "{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -151,6 +153,18 @@ Global
 		{4F9BDC85-B8B2-4AC5-99BC-1F2F0CF80016}.Release|x64.Build.0 = Release|Any CPU
 		{4F9BDC85-B8B2-4AC5-99BC-1F2F0CF80016}.Release|x86.ActiveCfg = Release|Any CPU
 		{4F9BDC85-B8B2-4AC5-99BC-1F2F0CF80016}.Release|x86.Build.0 = Release|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Debug|x64.Build.0 = Debug|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Debug|x86.Build.0 = Debug|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Release|x64.ActiveCfg = Release|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Release|x64.Build.0 = Release|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Release|x86.ActiveCfg = Release|Any CPU
+		{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+
 using Discord;
 using Discord.Commands;
 using Discord.Rest;
 using Discord.WebSocket;
+
 using Microsoft.Extensions.Options;
 
 using Modix;
@@ -96,6 +98,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     service.AddTypeReader<IEmote>(new EmoteTypeReader());
                     service.AddTypeReader<DiscordUserEntity>(new UserEntityTypeReader());
                     service.AddTypeReader<AnyGuildMessage<IUserMessage>>(new AnyGuildMessageTypeReader<IUserMessage>());
+                    service.AddTypeReader<TimeSpan>(new TimeSpanTypeReader(), true);
 
                     return service;
                 })


### PR DESCRIPTION
I felt like it was safe to allow this type reader to take precedence over the default implementation. There shouldn't be any loss of functionality over the default, and I expect the performance should be on par with the default as well.