### PR TITLE
Site leaderboard should take channel designation into account

### DIFF
--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -213,9 +213,11 @@ namespace Modix.Data.Repositories
                             count(*) as ""MessageCount"",
                             ""AuthorId"" = :UserId as ""IsCurrentUser""
                         from ""Messages""
-                        where ""GuildId"" = :GuildId
+                        left outer join ""DesignatedChannelMappings"" on ""Messages"".""ChannelId"" = ""DesignatedChannelMappings"".""ChannelId""
+                        where ""Messages"".""GuildId"" = :GuildId
+                            and ""DesignatedChannelMappings"".""Type"" = 'CountsTowardsParticipation'
                             and ""Timestamp"" >= :StartTimestamp
-                        group by ""AuthorId"", ""GuildId""
+                        group by ""AuthorId"", ""Messages"".""GuildId""
                     ),
                     currentUserCount as (
                         select ""UserId"", ""Rank"", ""MessageCount"", ""IsCurrentUser""


### PR DESCRIPTION
These changes update the leaderboard on the site to only take designated channels into consideration when calculating message counts, bringing it in line with what the `!info` command would show.