### PR TITLE
Fix next rank determination logic in promotions

### DIFF
--- a/Modix.Services/Promotions/PromotionsService.cs
+++ b/Modix.Services/Promotions/PromotionsService.cs
@@ -149,7 +149,7 @@ namespace Modix.Services.Promotions
             var rankRoles = await GetRankRolesAsync(AuthorizationService.CurrentGuildId.Value);
             var subject = await UserService.GetGuildUserAsync(AuthorizationService.CurrentGuildId.Value, subjectId);
 
-            if (!TryGetNextRankRoleForUser(subjectId, rankRoles, subject, out var nextRankRole, out var message))
+            if (!TryGetNextRankRoleForUser(rankRoles, subject, out var nextRankRole, out var message))
                 throw new InvalidOperationException(message);
 
             await PerformCommonCreateCampaignValidationsAsync(subject, nextRankRole, rankRoles);
@@ -182,7 +182,7 @@ namespace Modix.Services.Promotions
             var rankRoles = await GetRankRolesAsync(AuthorizationService.CurrentGuildId.Value);
             var subject = await UserService.GetGuildUserAsync(AuthorizationService.CurrentGuildId.Value, subjectId);
 
-            if (TryGetNextRankRoleForUser(subjectId, rankRoles, subject, out var nextRankRole, out _))
+            if (TryGetNextRankRoleForUser(rankRoles, subject, out var nextRankRole, out _))
                 return nextRankRole;
 
             return null;
@@ -514,7 +514,7 @@ namespace Modix.Services.Promotions
         }
 
         private bool TryGetNextRankRoleForUser(
-            ulong subjectId, GuildRoleBrief[] rankRoles, IGuildUser subject, out GuildRoleBrief nextRankRole, out string message)
+            GuildRoleBrief[] rankRoles, IGuildUser subject, out GuildRoleBrief nextRankRole, out string message)
         {
             var userRankRoles = rankRoles.Where(r => subject.RoleIds.Contains(r.Id));
             var userCurrentRankRole = userRankRoles.OrderByDescending(r => r.Position).FirstOrDefault();
@@ -536,7 +536,7 @@ namespace Modix.Services.Promotions
             }
             else
             {
-                nextRankRole = rankRoles.FirstOrDefault(r => r.Position == userCurrentRankRole.Position + 1);
+                nextRankRole = rankRoles.OrderBy(x => x.Position).FirstOrDefault(r => r.Position > userCurrentRankRole.Position);
 
                 if (nextRankRole is null)
                 {


### PR DESCRIPTION
It was erroneously requiring rank roles to be directly next to one another in the role hierarchy.

Also, removed unused `subjectId` parameter.