### PR TITLE
Fix invite purging to always recognize invites for the guild the message was posted in

### DIFF
--- a/Modix.Services.Test/Moderation/InvitePurgingBehaviorTests.cs
+++ b/Modix.Services.Test/Moderation/InvitePurgingBehaviorTests.cs
@@ -44,13 +44,13 @@ namespace Modix.Services.Test.Moderation
             var mockGuild = autoMocker.GetMock<IGuild>();
             mockGuild
                 .Setup(x => x.GetInvitesAsync(It.IsAny<RequestOptions>()))
-                .ReturnsAsync(GuildInviteLinks
+                .ReturnsAsync(GuildInviteCodes
                     .Select(x =>
                     {
                         var mockInviteMetadata = new Mock<IInviteMetadata>();
 
                         mockInviteMetadata
-                            .Setup(y => y.Url)
+                            .Setup(y => y.Code)
                             .Returns(x);
 
                         return mockInviteMetadata.Object;
@@ -121,7 +121,14 @@ namespace Modix.Services.Test.Moderation
             = {
                 "https://discord.gg/123456",
                 "https://discord.gg/234567",
-                "https://discord.gg/345678"
+                "https://discord.gg/345678",
+            };
+
+        private static readonly string[] GuildInviteCodes
+            = {
+                "123456",
+                "234567",
+                "345678",
             };
 
         #endregion Test Data

--- a/Modix.Services/Moderation/InvitePurgingBehavior.cs
+++ b/Modix.Services/Moderation/InvitePurgingBehavior.cs
@@ -98,10 +98,10 @@ namespace Modix.Services.Moderation
 
             // Allow invites to the guild in which the message was posted
             var externalInvites = matches
-                .Select(x => x.Value)
+                .Select(x => x.Groups["Code"].Value)
                 .Except((await author.Guild
                     .GetInvitesAsync())
-                    .Select(x => x.Url));
+                    .Select(x => x.Code));
 
             if (!externalInvites.Any())
             {
@@ -120,7 +120,7 @@ namespace Modix.Services.Moderation
 
         private static readonly Regex _inviteLinkMatcher
             = new Regex(
-                pattern: @"(https?:\/\/)?(www\.)?(discord\.(gg|io|me|li)|discordapp\.com\/invite)\/\w+",
+                pattern: @"(https?://)?(www\.)?(discord\.(gg|io|me|li)|discordapp\.com/invite)/(?<Code>\w+)",
                 options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
                 matchTimeout: TimeSpan.FromSeconds(2));
     }


### PR DESCRIPTION
Matches same-guild invites on code rather than URL