### PR TITLE
Add development user secrets

### DIFF
--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <SpaRoot>ClientApp\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
+    <UserSecretsId>5B9ECED8-0E0C-443E-98B1-F1E508AB292B</UserSecretsId>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -23,6 +24,7 @@
     <PackageReference Include="JustEat.StatsD" Version="4.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/Modix/Program.cs
+++ b/Modix/Program.cs
@@ -16,10 +16,21 @@ namespace Modix
     {
         public static int Main(string[] args)
         {
-            var config = new ConfigurationBuilder()
+            const string DEVELOPMENT_ENVIRONMENT_VARIABLE = "ASPNETCORE_ENVIRONMENT";
+            const string DEVELOPMENT_ENVIRONMENT_KEY = "Development";
+
+            var environment = Environment.GetEnvironmentVariable(DEVELOPMENT_ENVIRONMENT_VARIABLE);
+
+            var configBuilder = new ConfigurationBuilder()
                 .AddEnvironmentVariables("MODIX_")
-                .AddJsonFile("developmentSettings.json", optional: true, reloadOnChange: false)
-                .Build();
+                .AddJsonFile("developmentSettings.json", optional: true, reloadOnChange: false);
+
+            if(environment is DEVELOPMENT_ENVIRONMENT_KEY)
+            {
+                configBuilder.AddUserSecrets<Startup>();
+            }
+
+            var config = configBuilder.Build();
 
             var loggerConfig = new LoggerConfiguration()
                 .MinimumLevel.Verbose()


### PR DESCRIPTION
Adds the ability to set development time user secrets via `dotnet user-secrets`

See more here: https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-2.2&tabs=windows