### PR TITLE
Revert "Tag message_received with guild and channel"

### DIFF
--- a/Modix.Services/Core/MessageLogBehavior.cs
+++ b/Modix.Services/Core/MessageLogBehavior.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Discord;
@@ -187,25 +186,7 @@ namespace Modix.Services.Core
         {
             Log.LogDebug("Handling message received event for message #{MessageId}.", message.Id);
 
-            var tags = new List<string>();
-
-            if (message.Channel is IGuildChannel msgChannel)
-            {
-                if (msgChannel.Guild is IGuild msgGuild)
-                {
-                    tags.Add("guild=" + msgGuild.Name);
-                }
-
-                tags.Add("channel=" + msgChannel.Name);
-            }
-
-            var stat = "message_count";
-            if (tags.Count > 0)
-            {
-                stat += ";" + string.Join(';', tags);
-            }
-
-            _stats.Increment(stat);
+            _stats.Increment("message_count");
 
             if (!message.Content.StartsWith('!') &&
                 message.Channel is IGuildChannel channel &&


### PR DESCRIPTION
Reverts discord-csharp/MODiX#529.

Tagging did not have the intended effect.
<img width="571" alt="image" src="https://user-images.githubusercontent.com/423549/62010266-c3a17700-b136-11e9-8c4b-2724e7c6e55e.png">
