### PR TITLE
Fix NullReferenceException on deleted messages in EmojiUsageHandler

### DIFF
--- a/Modix.Services/EmojiStats/EmojiUsageHandler.cs
+++ b/Modix.Services/EmojiStats/EmojiUsageHandler.cs
@@ -207,7 +207,7 @@ namespace Modix.Services.EmojiStats
                 return;
 
             var message = await notification.Message.GetOrDownloadAsync();
-            if (message.Author.IsBot)
+            if (message is { Author: { IsBot: true } })
                 return;
 
             var channel = notification.Channel as ITextChannel;


### PR DESCRIPTION
Uses recursive pattern matching to ensure that the message is non-null before checking whether the author is a bot.

For reference, since recursive pattern matching is pretty new and kinda alien-looking,
```cs
if (message is { Author: { IsBot: true } })
    return;
```
is equivalent to
```cs
if (message != null)
{
    IUser author = message.Author;
    if (author != null && author.IsBot)
    {
        return;
    }
}
```