### PR TITLE
Fix Statsd and Stats behaviour to work when debugging locally

### DIFF
--- a/Modix.Services/Core/MessageLogBehavior.cs
+++ b/Modix.Services/Core/MessageLogBehavior.cs
@@ -97,7 +97,7 @@ namespace Modix.Services.Core
 
             if (guild == null)
             {
-                Log.LogInformation("Recieved message update event for non-guild message, ignoring");
+                Log.LogInformation("Received message update event for non-guild message, ignoring");
                 return;
             }
 

--- a/Modix.Services/Core/StatsBehavior.cs
+++ b/Modix.Services/Core/StatsBehavior.cs
@@ -12,20 +12,17 @@ namespace Modix.Services.Core
     public class StatsBehavior : BehaviorBase
     {
         private readonly DiscordSocketClient _discordClient;
-        private readonly IDesignatedChannelService _designatedChannelService;
         private readonly IDogStatsd _stats;
         private readonly ILogger<StatsBehavior> _log;
 
         public StatsBehavior(
             DiscordSocketClient discordClient,
-            IDesignatedChannelService designatedChannelService,
             IDogStatsd stats,
             ILogger<StatsBehavior> log,
             IServiceProvider serviceProvider)
             : base(serviceProvider)
         {
             _discordClient = discordClient;
-            _designatedChannelService = designatedChannelService;
             _stats = stats;
             _log = log;
         }
@@ -59,8 +56,9 @@ namespace Modix.Services.Core
                 var isParticipation = true;
                 try
                 {
-                    isParticipation = await _designatedChannelService.ChannelHasDesignationAsync(guild, channel, DesignatedChannelType.CountsTowardsParticipation)
-                        .ConfigureAwait(false);
+                    await SelfExecuteRequest<IDesignatedChannelService>(async d
+                        => isParticipation = await d.ChannelHasDesignationAsync(guild, channel,
+                            DesignatedChannelType.CountsTowardsParticipation));
                 }
                 catch (Exception ex)
                 {

--- a/Modix/DataDog/DebugDogStatsd.cs
+++ b/Modix/DataDog/DebugDogStatsd.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using StatsdClient;
+
+namespace Modix.DataDog
+{
+    public class DebugDogStatsd : IDogStatsd
+    {
+        public void Configure(StatsdConfig config)
+        {
+
+        }
+
+        public void Counter<T>(string statName, T value, double sampleRate = 1, string[] tags = null)
+        {
+
+        }
+
+        public void Decrement(string statName, int value = 1, double sampleRate = 1, params string[] tags)
+        {
+
+        }
+
+        public void Event(string title, string text, string alertType = null, string aggregationKey = null, string sourceType = null,
+            int? dateHappened = null, string priority = null, string hostname = null, string[] tags = null)
+        {
+
+        }
+
+        public void Gauge<T>(string statName, T value, double sampleRate = 1, string[] tags = null)
+        {
+
+        }
+
+        public void Histogram<T>(string statName, T value, double sampleRate = 1, string[] tags = null)
+        {
+
+        }
+
+        public void Distribution<T>(string statName, T value, double sampleRate = 1, string[] tags = null)
+        {
+
+        }
+
+        public void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null)
+        {
+
+        }
+
+        public void Set<T>(string statName, T value, double sampleRate = 1, string[] tags = null)
+        {
+        }
+
+        public IDisposable StartTimer(string name, double sampleRate = 1, string[] tags = null)
+        {
+            return new EmptyDisposable();
+        }
+
+        public void Time(Action action, string statName, double sampleRate = 1, string[] tags = null)
+        {
+        }
+
+        public T Time<T>(Func<T> func, string statName, double sampleRate = 1, string[] tags = null)
+        {
+            return default;
+        }
+
+        public void Timer<T>(string statName, T value, double sampleRate = 1, string[] tags = null)
+        {
+        }
+
+        public void ServiceCheck(string name, Status status, int? timestamp = null, string hostname = null, string[] tags = null,
+            string message = null)
+        {
+        }
+
+        private class EmptyDisposable : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Modix.Bot.Behaviors;
 using Modix.Common.Messaging;
 using Modix.Data.Models.Core;
 using Modix.Data.Repositories;
+using Modix.DataDog;
 using Modix.Services;
 using Modix.Services.AutoRemoveMessage;
 using Modix.Services.BehaviourConfiguration;
@@ -149,6 +150,13 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddStatsD(this IServiceCollection services)
         {
             var cfg = new StatsdConfig { Prefix = "modix" };
+
+            if (string.IsNullOrWhiteSpace(cfg.StatsdServerName))
+            {
+                services.AddSingleton<IDogStatsd, DebugDogStatsd>();
+                return services;
+            }
+
             DogStatsd.Configure(cfg);
             services.AddSingleton(cfg);
             services.AddSingleton<IDogStatsd>(provider =>


### PR DESCRIPTION
Previously runtime errors if the statsd configuration was not properly set in the dev environment, MODiX would fatally crash.

Additionally, the stats behaviour fatally crashed the bot because of service provider resolution, see:
```System.AggregateException: One or more errors occurred. (Cannot consume scoped service 'Modix.Data.Repositories.IDesignatedChannelMappingRepository' from singleton 'Modix.Services.Core.IDesignatedChannelService'.) ---> System.InvalidOperationException: Cannot consume scoped service 'Modix.Data.Repositories.IDesignatedChannelMappingRepository' from singleton 'Modix.Services.Core.IDesignatedChannelService'.```