### PR TITLE
Fix DataDog crash when running in production without analytics url

### DIFF
--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -149,10 +149,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddStatsD(this IServiceCollection services, IHostingEnvironment environment)
         {
-            services.AddSingleton<IDogStatsd, DebugDogStatsd>();
-            return services;
-
-            /*
             var cfg = new StatsdConfig { Prefix = "modix" };
 
             if (!environment.IsProduction() && string.IsNullOrWhiteSpace(cfg.StatsdServerName))
@@ -171,7 +167,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 return service;
             });
             return services;
-            */
         }
     }
 }

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -149,6 +149,10 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceCollection AddStatsD(this IServiceCollection services, IHostingEnvironment environment)
         {
+            services.AddSingleton<IDogStatsd, DebugDogStatsd>();
+            return services;
+
+            /*
             var cfg = new StatsdConfig { Prefix = "modix" };
 
             if (!environment.IsProduction() && string.IsNullOrWhiteSpace(cfg.StatsdServerName))
@@ -167,6 +171,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 return service;
             });
             return services;
+            */
         }
     }
 }

--- a/Modix/Startup.cs
+++ b/Modix/Startup.cs
@@ -75,7 +75,7 @@ namespace Modix
                     options.SerializerSettings.Converters.Add(new StringULongConverter());
                 });
 
-            services.AddStatsD(_hostingEnvironment);
+            // services.AddStatsD(_hostingEnvironment);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Modix/Startup.cs
+++ b/Modix/Startup.cs
@@ -75,7 +75,7 @@ namespace Modix
                     options.SerializerSettings.Converters.Add(new StringULongConverter());
                 });
 
-            // services.AddStatsD(_hostingEnvironment);
+            services.AddStatsD(_hostingEnvironment);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Fixes #547 

Currently, when running in production, if the `MODIX_DD_AGENT_HOST` environment variable is not set, the bot will crash.

This adds a switch env var, `MODIX_ENABLESTATSD`, which defaults to false if not provided.

@Cisien You will need to update the container to have this env var and `true` as the value when this change is merged.

@jrusbatch Here's your requested ping.

Edit: Give me a moment on this one. It grabbed some unrelated changes and I'm trying to figure out how to fix it.