### PR TITLE
[Breaking] Fix DataDog crash when running without analytics url

### DIFF
--- a/Modix.Data/Models/Core/ModixConfig.cs
+++ b/Modix.Data/Models/Core/ModixConfig.cs
@@ -24,6 +24,6 @@
 
         public string WebsiteBaseUrl { get; set; } = "https://mod.gg";
 
-        public bool EnableStatsd { get; set; } = false;
+        public bool EnableStatsd { get; set; }
     }
 }

--- a/Modix.Data/Models/Core/ModixConfig.cs
+++ b/Modix.Data/Models/Core/ModixConfig.cs
@@ -23,5 +23,7 @@
         public string IlUrl { get; set; }
 
         public string WebsiteBaseUrl { get; set; } = "https://mod.gg";
+
+        public bool EnableStatsd { get; set; } = false;
     }
 }

--- a/Modix.Services/Promotions/PromotionsService.cs
+++ b/Modix.Services/Promotions/PromotionsService.cs
@@ -504,11 +504,6 @@ namespace Modix.Services.Promotions
             }))
                 throw new InvalidOperationException($"An active campaign already exists for {subject.GetFullUsername()} to be promoted to {targetRankRole.Name}");
 
-            // JoinedAt is null, when it cannot be obtained
-            if (subject.JoinedAt.HasValue)
-                if (subject.JoinedAt.Value.DateTime > (DateTimeOffset.Now - TimeSpan.FromDays(20)))
-                    throw new InvalidOperationException($"{subject.GetFullUsername()} has joined less than 20 days prior");
-
             if (!await CheckIfUserIsRankOrHigherAsync(rankRoles, AuthorizationService.CurrentUserId.Value, targetRankRole.Id))
                 throw new InvalidOperationException($"Creating a promotion campaign requires a rank at least as high as the proposed target rank");
         }

--- a/Modix.Services/Promotions/PromotionsService.cs
+++ b/Modix.Services/Promotions/PromotionsService.cs
@@ -504,6 +504,11 @@ namespace Modix.Services.Promotions
             }))
                 throw new InvalidOperationException($"An active campaign already exists for {subject.GetFullUsername()} to be promoted to {targetRankRole.Name}");
 
+            // JoinedAt is null, when it cannot be obtained
+            if (subject.JoinedAt.HasValue)
+                if (subject.JoinedAt.Value.DateTime > (DateTimeOffset.Now - TimeSpan.FromDays(20)))
+                    throw new InvalidOperationException($"{subject.GetFullUsername()} has joined less than 20 days prior");
+
             if (!await CheckIfUserIsRankOrHigherAsync(rankRoles, AuthorizationService.CurrentUserId.Value, targetRankRole.Id))
                 throw new InvalidOperationException($"Creating a promotion campaign requires a rank at least as high as the proposed target rank");
         }

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var enableStatsd = configuration.GetValue<bool>(nameof(ModixConfig.EnableStatsd));
             if (!enableStatsd ||
-                environment.IsDevelopment() && string.IsNullOrWhiteSpace(cfg.StatsdServerName))
+                !environment.IsProduction() && string.IsNullOrWhiteSpace(cfg.StatsdServerName))
             {
                 services.AddSingleton<IDogStatsd, DebugDogStatsd>();
                 return services;

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Discord.Commands;
 using Discord.Rest;
 using Discord.WebSocket;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
 using Modix;
@@ -147,11 +148,11 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
-        public static IServiceCollection AddStatsD(this IServiceCollection services, IHostingEnvironment environment)
+        public static IServiceCollection AddStatsD(this IServiceCollection services, IHostingEnvironment environment, IConfiguration configuration)
         {
             var cfg = new StatsdConfig { Prefix = "modix" };
-            bool.TryParse(Environment.GetEnvironmentVariable("MODIX_ENABLESTATSD"), out var enableStatsd);
-               
+
+            var enableStatsd = configuration.GetValue<bool>(nameof(ModixConfig.EnableStatsd));
             if (!enableStatsd ||
                 environment.IsDevelopment() && string.IsNullOrWhiteSpace(cfg.StatsdServerName))
             {

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -150,8 +150,10 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddStatsD(this IServiceCollection services, IHostingEnvironment environment)
         {
             var cfg = new StatsdConfig { Prefix = "modix" };
-
-            if (!environment.IsProduction() && string.IsNullOrWhiteSpace(cfg.StatsdServerName))
+            bool.TryParse(Environment.GetEnvironmentVariable("MODIX_ENABLESTATSD"), out var enableStatsd);
+               
+            if (!enableStatsd ||
+                environment.IsDevelopment() && string.IsNullOrWhiteSpace(cfg.StatsdServerName))
             {
                 services.AddSingleton<IDogStatsd, DebugDogStatsd>();
                 return services;

--- a/Modix/Startup.cs
+++ b/Modix/Startup.cs
@@ -75,7 +75,7 @@ namespace Modix
                     options.SerializerSettings.Converters.Add(new StringULongConverter());
                 });
 
-            services.AddStatsD(_hostingEnvironment);
+            services.AddStatsD(_hostingEnvironment, _configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/modix-kubernetes.yml
+++ b/modix-kubernetes.yml
@@ -421,7 +421,7 @@ spec:
               key: log-webhook-token
               name: modix
         - name: MODIX_EnableStatsd
-          value: true
+          value: "true"
         image: cisien/modix:latest
         imagePullPolicy: Always
         name: modix

--- a/modix-kubernetes.yml
+++ b/modix-kubernetes.yml
@@ -420,6 +420,8 @@ spec:
             secretKeyRef:
               key: log-webhook-token
               name: modix
+        - name: MODIX_EnableStatsd
+          value: true
         image: cisien/modix:latest
         imagePullPolicy: Always
         name: modix


### PR DESCRIPTION
Fixes #547 

Currently, when running in production, if the `MODIX_DD_AGENT_HOST` environment variable is not set, the bot will crash.

This adds a switch env var, `MODIX_ENABLESTATSD`, which defaults to false if not provided.

@Cisien You will need to update the container to have this env var and `true` as the value when this change is merged.

@jrusbatch Here's your requested ping.