### PR TITLE
Gracefully handle unmuting users who are no longer in the guild

### DIFF
--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -4,15 +4,16 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using Discord;
+using Discord.Net;
 
 using Modix.Data.Models;
 using Modix.Data.Models.Core;
 using Modix.Data.Models.Moderation;
 using Modix.Data.Repositories;
 using Modix.Services.Core;
+using Modix.Services.Utilities;
 
 using Serilog;
-using Discord.Net;
 
 namespace Modix.Services.Moderation
 {
@@ -884,7 +885,12 @@ namespace Modix.Services.Moderation
             {
                 case InfractionType.Mute:
                     if (!await UserService.GuildUserExistsAsync(guild.Id, infraction.Subject.Id))
-                        throw new InvalidOperationException("Cannot unmute a user who is not in the server.");
+                    {
+                        Log.Information("Attempted to remove the mute role from {0} ({1}), but they were not in the server.",
+                            infraction.Subject.GetFullUsername(),
+                            infraction.Subject.Id);
+                        break;
+                    }
 
                     var subject = await UserService.GetGuildUserAsync(guild.Id, infraction.Subject.Id);
                     await subject.RemoveRoleAsync(await GetDesignatedMuteRoleAsync(guild));


### PR DESCRIPTION
Log an informational message instead of throwing an exception when unmuting a user who is no longer in the guild.

We've had issues in the past where, if multiple users are muted and the first user leaves the guild or is banned, the autorescind handler will throw an exception when it tries to unmute the first user. Because of this, the timer in the handler is never restarted and as a result the second user is never unmuted, even after the mute should have expired.

The changes in this PR affect both manual and automatic unmutes. I considered keeping the exception for manual unmutes, but I decided against that because the exception message is confusing and essentially useless to the moderator. By this point, the logic that rescinds the mute infraction in MODiX has already completed successfully, so the only part that fails is removing the role from the user. And the moderator doesn't really need to care about whether that part succeeded, because the user isn't in the guild anymore anyway.