### PR TITLE
Remove redundant "Exception: " label

### DIFF
--- a/Modix.Bot/Behaviors/CommandListeningBehavior.cs
+++ b/Modix.Bot/Behaviors/CommandListeningBehavior.cs
@@ -76,7 +76,7 @@ namespace Modix.Bot.Behaviors
                     Log.Warning(error);
 
                 if (commandResult.Error == CommandError.Exception)
-                    await commandContext.Channel.SendMessageAsync($"Error: {FormatUtilities.SanitizeEveryone(error)}");
+                    await commandContext.Channel.SendMessageAsync($"Error: {FormatUtilities.SanitizeEveryone(commandResult.ErrorReason)}");
                 else
                     await CommandErrorHandler.AssociateError(userMessage, error);
             }


### PR DESCRIPTION
Currently, when a command invocation causes an exception to be thrown, MODiX replies with something like `Error: Exception: Something bad happened.`.

This PR removes the redundant "Exception: " label, so that the same error will now be reported as `Error: Something bad happened.`.