### PR TITLE
Improvements to !infractions

### DIFF
--- a/Modix.Bot/Modules/InfractionModule.cs
+++ b/Modix.Bot/Modules/InfractionModule.cs
@@ -4,7 +4,9 @@ using System.Threading.Tasks;
 
 using Discord;
 using Discord.Commands;
+
 using Microsoft.Extensions.Options;
+
 using Modix.Bot.Extensions;
 using Modix.Data.Models;
 using Modix.Data.Models.Core;
@@ -63,12 +65,10 @@ namespace Modix.Modules
             {
                 Id = infraction.Id,
                 Created = infraction.CreateAction.Created.ToUniversalTime().ToString("yyyy MMM dd"),
-                Type = infraction.Type.ToString(),
-                Subject = infraction.Subject.Username,
-                Creator = infraction.CreateAction.CreatedBy.GetFullUsername(),
+                Type = infraction.Type,
                 Reason = infraction.Reason,
                 Rescinded = infraction.RescindAction != null
-            }).OrderBy(s => s.Type);
+            });
 
             var counts = await ModerationService.GetInfractionCountsForUserAsync(subjectEntity.Id);
 
@@ -93,8 +93,11 @@ namespace Modix.Modules
                     Path = "/infractions",
                     Query = $"id={infraction.Id}"
                 }.ToString();
+
+                var emoji = GetEmojiForInfractionType(infraction.Type);
+
                 builder.AddField(
-                    $"#{infraction.Id} - {infraction.Type} - Created: {infraction.Created}{(infraction.Rescinded ? " - [RESCINDED]" : "")}",
+                    $"#{infraction.Id} - \\{emoji} {infraction.Type} - Created: {infraction.Created}{(infraction.Rescinded ? " - [RESCINDED]" : "")}",
                     Format.Url($"Reason: {infraction.Reason}", infractionUrl)
                 );
             }
@@ -120,5 +123,15 @@ namespace Modix.Modules
         internal protected IModerationService ModerationService { get; }
         internal protected IUserService UserService { get; }
         internal protected ModixConfig Config { get; }
+
+        private static string GetEmojiForInfractionType(InfractionType infractionType)
+            => infractionType switch
+            {
+                InfractionType.Notice => "📝",
+                InfractionType.Warning => "⚠️",
+                InfractionType.Mute => "🔇",
+                InfractionType.Ban => "🔨",
+                _ => "❔",
+            };
     }
 }


### PR DESCRIPTION
This PR contains the following changes to the `!infractions <userid>` command:
* Infractions are now ordered strictly by date, instead of date within type. This was achieved by removing the `.OrderBy(s => s.Type)`; the database already sorts by date, as we're passing in `SortingCriteria`. Rationale: ordering by date alone makes it easier to see a "timeline" of how infractions were carried out on a user.
* An emoji is now displayed next to the infraction type in the embed. Rationale: this makes it easier to see at a glance what the infraction types are.
* Removed unused properties in the `.Select()` query. Rationale: makes the code cleaner.

![image](https://user-images.githubusercontent.com/2829282/62891853-d27e5100-bd14-11e9-8f9e-e09e83d1e732.png)
