### PR TITLE
Ignore aliases with the same name as the command

### DIFF
--- a/Modix.Bot/Modules/HelpModule.cs
+++ b/Modix.Bot/Modules/HelpModule.cs
@@ -130,7 +130,7 @@ namespace Modix.Modules
         {
             var summaryBuilder = new StringBuilder(command.Summary ?? "No summary.").AppendLine();
             var name = command.Aliases.FirstOrDefault();
-            var summary = AppendAliases(summaryBuilder, command.Aliases.Where(a => !a.Equals(name)).ToList());
+            var summary = AppendAliases(summaryBuilder, command.Aliases.Where(a => !a.Equals(name, StringComparison.OrdinalIgnoreCase)).ToList());
 
             embedBuilder.AddField(new EmbedFieldBuilder()
                                  .WithName($"Command: !{name} {GetParams(command)}")

--- a/Modix.Bot/Modules/HelpModule.cs
+++ b/Modix.Bot/Modules/HelpModule.cs
@@ -129,10 +129,11 @@ namespace Modix.Modules
         private EmbedBuilder AddCommandFields(EmbedBuilder embedBuilder, CommandHelpData command)
         {
             var summaryBuilder = new StringBuilder(command.Summary ?? "No summary.").AppendLine();
-            var summary = AppendAliases(summaryBuilder, command.Aliases);
+            var name = command.Aliases.FirstOrDefault();
+            var summary = AppendAliases(summaryBuilder, command.Aliases.Where(a => !a.Equals(name)).ToList());
 
             embedBuilder.AddField(new EmbedFieldBuilder()
-                                 .WithName($"Command: !{command.Aliases.FirstOrDefault()} {GetParams(command)}")
+                                 .WithName($"Command: !{name} {GetParams(command)}")
                                  .WithValue(summary.ToString()));
 
             return embedBuilder;


### PR DESCRIPTION
Fix an issue where aliases always showed the same command despite not being an actual alias itself.
> Not sure why `command.Name` wasn't used, but I kept `command.Aliases.FirstOrDefault()` for brevity.

|Before|After|
|---|---|
|![Before](https://chito.ge/4BjUDjE.png)|![After](https://chito.ge/5a82UGx.png)|

Ignore the parameter information, this was not changed.