### PR TITLE
Allow either a user ID or a message ID in commands

### DIFF
--- a/Modix.Bot/Modules/InfractionModule.cs
+++ b/Modix.Bot/Modules/InfractionModule.cs
@@ -32,16 +32,16 @@ namespace Modix.Modules
         [Priority(10)]
         public async Task SearchAsync(
             [Summary("The user whose infractions are to be displayed.")]
-                DiscordUserEntity subjectEntity)
+                DiscordUserOrMessageAuthorEntity subjectEntity)
         {
             var requestor = Context.User.Mention;
-            var subject = await UserService.GetGuildUserSummaryAsync(Context.Guild.Id, subjectEntity.Id);
+            var subject = await UserService.GetGuildUserSummaryAsync(Context.Guild.Id, subjectEntity.UserId);
 
             var infractions = await ModerationService.SearchInfractionsAsync(
                 new InfractionSearchCriteria
                 {
                     GuildId = Context.Guild.Id,
-                    SubjectId = subjectEntity.Id,
+                    SubjectId = subjectEntity.UserId,
                     IsDeleted = false
                 },
                 new[]
@@ -70,7 +70,7 @@ namespace Modix.Modules
                 Rescinded = infraction.RescindAction != null
             }).OrderBy(s => s.Type);
 
-            var counts = await ModerationService.GetInfractionCountsForUserAsync(subjectEntity.Id);
+            var counts = await ModerationService.GetInfractionCountsForUserAsync(subjectEntity.UserId);
 
             // https://modix.gg/infractions?subject=12345
             var url = new UriBuilder(Config.WebsiteBaseUrl)

--- a/Modix.Bot/Modules/ModerationModule.cs
+++ b/Modix.Bot/Modules/ModerationModule.cs
@@ -28,45 +28,45 @@ namespace Modix.Modules
         [Summary("Applies a note to a user's infraction history.")]
         public async Task NoteAsync(
             [Summary("The user to which the note is being applied.")]
-                DiscordUserEntity subject,
+                DiscordUserOrMessageAuthorEntity subject,
             [Summary("The reason for the note.")]
             [Remainder]
                 string reason)
         {
             var reasonWithUrls = AppendUrlsFromMessage(reason);
 
-            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Notice, subject.Id, reasonWithUrls, null);
-            await ConfirmAndReplyWithCountsAsync(subject.Id);
+            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Notice, subject.UserId, reasonWithUrls, null);
+            await ConfirmAndReplyWithCountsAsync(subject.UserId);
         }
 
         [Command("warn")]
         [Summary("Issue a warning to a user.")]
         public async Task WarnAsync(
             [Summary("The user to which the warning is being issued.")]
-                DiscordUserEntity subject,
+                DiscordUserOrMessageAuthorEntity subject,
             [Summary("The reason for the warning.")]
             [Remainder]
                 string reason)
         {
             var reasonWithUrls = AppendUrlsFromMessage(reason);
 
-            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Warning, subject.Id, reasonWithUrls, null);
-            await ConfirmAndReplyWithCountsAsync(subject.Id);
+            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Warning, subject.UserId, reasonWithUrls, null);
+            await ConfirmAndReplyWithCountsAsync(subject.UserId);
         }
 
         [Command("mute")]
         [Summary("Mute a user.")]
         public async Task MuteAsync(
             [Summary("The user to be muted.")]
-                DiscordUserEntity subject,
+                DiscordUserOrMessageAuthorEntity subject,
             [Summary("The reason for the mute.")]
             [Remainder]
                 string reason)
         {
             var reasonWithUrls = AppendUrlsFromMessage(reason);
 
-            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Mute, subject.Id, reasonWithUrls, null);
-            await ConfirmAndReplyWithCountsAsync(subject.Id);
+            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Mute, subject.UserId, reasonWithUrls, null);
+            await ConfirmAndReplyWithCountsAsync(subject.UserId);
         }
 
         [Command("tempmute")]
@@ -74,7 +74,7 @@ namespace Modix.Modules
         [Summary("Mute a user, for a temporary amount of time.")]
         public async Task TempMuteAsync(
             [Summary("The user to be muted.")]
-                DiscordUserEntity subject,
+                DiscordUserOrMessageAuthorEntity subject,
             [Summary("The duration of the mute.")]
                 TimeSpan duration,
             [Summary("The reason for the mute.")]
@@ -83,8 +83,8 @@ namespace Modix.Modules
         {
             var reasonWithUrls = AppendUrlsFromMessage(reason);
 
-            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Mute, subject.Id, reasonWithUrls, duration);
-            await ConfirmAndReplyWithCountsAsync(subject.Id);
+            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Mute, subject.UserId, reasonWithUrls, duration);
+            await ConfirmAndReplyWithCountsAsync(subject.UserId);
         }
 
         [Command("tempmute")]
@@ -94,25 +94,25 @@ namespace Modix.Modules
             [Summary("The duration of the mute.")]
                 TimeSpan duration,
             [Summary("The user to be muted.")]
-                DiscordUserEntity subject,
+                DiscordUserOrMessageAuthorEntity subject,
             [Summary("The reason for the mute.")]
             [Remainder]
                 string reason)
         {
             var reasonWithUrls = AppendUrlsFromMessage(reason);
 
-            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Mute, subject.Id, reasonWithUrls, duration);
-            await ConfirmAndReplyWithCountsAsync(subject.Id);
+            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Mute, subject.UserId, reasonWithUrls, duration);
+            await ConfirmAndReplyWithCountsAsync(subject.UserId);
         }
 
         [Command("unmute")]
         [Summary("Remove a mute that has been applied to a user.")]
         public async Task UnMuteAsync(
             [Summary("The user to be un-muted.")]
-                DiscordUserEntity subject)
+                DiscordUserOrMessageAuthorEntity subject)
         {
-            await ModerationService.RescindInfractionAsync(InfractionType.Mute, subject.Id);
-            await ConfirmAndReplyWithCountsAsync(subject.Id);
+            await ModerationService.RescindInfractionAsync(InfractionType.Mute, subject.UserId);
+            await ConfirmAndReplyWithCountsAsync(subject.UserId);
         }
 
         [Command("ban")]
@@ -120,25 +120,25 @@ namespace Modix.Modules
         [Summary("Ban a user from the current guild.")]
         public async Task BanAsync(
             [Summary("The user to be banned.")]
-                DiscordUserEntity subject,
+                DiscordUserOrMessageAuthorEntity subject,
             [Summary("The reason for the ban.")]
             [Remainder]
                 string reason)
         {
             var reasonWithUrls = AppendUrlsFromMessage(reason);
 
-            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Ban, subject.Id, reasonWithUrls, null);
-            await ConfirmAndReplyWithCountsAsync(subject.Id);
+            await ModerationService.CreateInfractionAsync(Context.Guild.Id, Context.User.Id, InfractionType.Ban, subject.UserId, reasonWithUrls, null);
+            await ConfirmAndReplyWithCountsAsync(subject.UserId);
         }
 
         [Command("unban")]
         [Summary("Remove a ban that has been applied to a user.")]
         public async Task UnBanAsync(
             [Summary("The user to be un-banned.")]
-                DiscordUserEntity subject)
+                DiscordUserOrMessageAuthorEntity subject)
         {
-            await ModerationService.RescindInfractionAsync(InfractionType.Ban, subject.Id);
-            await ConfirmAndReplyWithCountsAsync(subject.Id);
+            await ModerationService.RescindInfractionAsync(InfractionType.Ban, subject.UserId);
+            await ConfirmAndReplyWithCountsAsync(subject.UserId);
         }
 
         [Command("clean")]

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -70,13 +70,13 @@ namespace Modix.Modules
         [Summary("Retrieves information about the supplied user, or the current user if one is not provided.")]
         public async Task GetUserInfoAsync(
             [Summary("The user to retrieve information about, if any.")]
-                [Remainder] DiscordUserEntity user = null)
+                [Remainder] DiscordUserOrMessageAuthorEntity user = null)
         {
-            user ??= new DiscordUserEntity(Context.User.Id);
+            var userId = user.UserId;
 
             var timer = Stopwatch.StartNew();
 
-            var userInfo = await _userService.GetUserInformationAsync(Context.Guild.Id, user.Id);
+            var userInfo = await _userService.GetUserInformationAsync(Context.Guild.Id, userId);
 
             if (userInfo == null)
             {
@@ -84,7 +84,7 @@ namespace Modix.Modules
                     .WithTitle("Retrieval Error")
                     .WithColor(Color.Red)
                     .WithDescription("Sorry, we don't have any data for that user - and we couldn't find any, either.")
-                    .AddField("User Id", user.Id)
+                    .AddField("User Id", userId)
                     .Build());
 
                 return;
@@ -92,8 +92,8 @@ namespace Modix.Modules
 
             var builder = new StringBuilder();
             builder.AppendLine("**\u276F User Information**");
-            builder.AppendLine("ID: " + user.Id);
-            builder.AppendLine("Profile: " + MentionUtils.MentionUser(user.Id));
+            builder.AppendLine("ID: " + userId);
+            builder.AppendLine("Profile: " + MentionUtils.MentionUser(userId));
 
             var embedBuilder = new EmbedBuilder()
                 .WithUserAsAuthor(userInfo)
@@ -112,11 +112,11 @@ namespace Modix.Modules
             }
 
             var moderationReadTask = _authorizationService.HasClaimsAsync(Context.User as IGuildUser, AuthorizationClaim.ModerationRead);
-            var userRankTask = _messageRepository.GetGuildUserParticipationStatistics(Context.Guild.Id, user.Id);
-            var messagesByDateTask = _messageRepository.GetGuildUserMessageCountByDate(Context.Guild.Id, user.Id, TimeSpan.FromDays(30));
-            var messageCountsByChannelTask = _messageRepository.GetGuildUserMessageCountByChannel(Context.Guild.Id, user.Id, TimeSpan.FromDays(30));
-            var emojiCountsTask = _emojiRepository.GetEmojiStatsAsync(Context.Guild.Id, SortDirection.Ascending, 1, userId: user.Id);
-            var promotionsTask = _promotionsService.GetPromotionsForUserAsync(Context.Guild.Id, user.Id);
+            var userRankTask = _messageRepository.GetGuildUserParticipationStatistics(Context.Guild.Id, userId);
+            var messagesByDateTask = _messageRepository.GetGuildUserMessageCountByDate(Context.Guild.Id, userId, TimeSpan.FromDays(30));
+            var messageCountsByChannelTask = _messageRepository.GetGuildUserMessageCountByChannel(Context.Guild.Id, userId, TimeSpan.FromDays(30));
+            var emojiCountsTask = _emojiRepository.GetEmojiStatsAsync(Context.Guild.Id, SortDirection.Ascending, 1, userId: userId);
+            var promotionsTask = _promotionsService.GetPromotionsForUserAsync(Context.Guild.Id, userId);
 
             embedBuilder.WithColor(await colorTask);
 
@@ -144,7 +144,7 @@ namespace Modix.Modules
 
             try
             {
-                await AddParticipationToEmbedAsync(user.Id, builder, await userRankTask, await messagesByDateTask, await messageCountsByChannelTask, await emojiCountsTask);
+                await AddParticipationToEmbedAsync(userId, builder, await userRankTask, await messagesByDateTask, await messageCountsByChannelTask, await emojiCountsTask);
             }
             catch (Exception ex)
             {
@@ -156,7 +156,7 @@ namespace Modix.Modules
 
             if (moderationRead)
             {
-                await AddInfractionsToEmbedAsync(user.Id, builder);
+                await AddInfractionsToEmbedAsync(userId, builder);
             }
 
             embedBuilder.Description = builder.ToString();

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -72,7 +72,7 @@ namespace Modix.Modules
             [Summary("The user to retrieve information about, if any.")]
                 [Remainder] DiscordUserOrMessageAuthorEntity user = null)
         {
-            var userId = user.UserId;
+            var userId = user?.UserId ?? Context.User.Id;
 
             var timer = Stopwatch.StartNew();
 

--- a/Modix.Bot/UserEntityTypeReader.cs
+++ b/Modix.Bot/UserEntityTypeReader.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
+using Modix.Services.Utilities;
 
 namespace Modix
 {
@@ -26,19 +27,7 @@ namespace Modix
 
             if (ulong.TryParse(input, out var uid) || MentionUtils.TryParseUser(input, out uid))
             {
-                //Any ulong is technically a valid snowflake, but we try to do some basic validation
-                //by parsing the timestamp (in ms) part out of it - we consider it to be an invalid snowflake if:
-                // - it's less than or equal to the discord epoch baseline
-                // - it's greater than or equal to the current timestamp
-                var snowflakeTimestamp = (long)(uid >> 22);
-                const long discordEpochUnixTime = 1420070400000;
-
-                //Jan 1, 2015
-                var discordEpoch = DateTimeOffset.FromUnixTimeMilliseconds(discordEpochUnixTime);
-
-                //The supposed timestamp
-                var snowFlakeDateTime = DateTimeOffset.FromUnixTimeMilliseconds(snowflakeTimestamp + discordEpochUnixTime);
-                if (snowFlakeDateTime <= discordEpoch || snowFlakeDateTime >= DateTimeOffset.UtcNow)
+                if (!SnowflakeUtilities.IsValidSnowflake(uid))
                 {
                     return TypeReaderResult.FromError(CommandError.ParseFailed, "Snowflake was almost certainly invalid.");
                 }

--- a/Modix.Bot/UserOrMessageAuthorEntityTypeReader.cs
+++ b/Modix.Bot/UserOrMessageAuthorEntityTypeReader.cs
@@ -1,0 +1,91 @@
+﻿using Discord;
+using Discord.Commands;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Modix.Services.Core;
+using Modix.Services.Utilities;
+
+using System;
+using System.Threading.Tasks;
+
+namespace Modix
+{
+    public class DiscordUserOrMessageAuthorEntity
+    {
+        public DiscordUserOrMessageAuthorEntity(ulong userId)
+        {
+            UserId = userId;
+        }
+
+        public DiscordUserOrMessageAuthorEntity(ulong userId, ulong messageChannelId, ulong messageId)
+        {
+            UserId = userId;
+            MessageChannelId = messageChannelId;
+            MessageId = messageId;
+        }
+
+        public ulong UserId { get; }
+
+        public ulong? MessageChannelId { get; }
+
+        public ulong? MessageId { get; }
+    }
+
+    public class UserOrMessageAuthorEntityTypeReader : UserTypeReader<IGuildUser>
+    {
+        public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
+        {
+            var baseResult = await base.ReadAsync(context, input, services);
+
+            if (baseResult.IsSuccess)
+            {
+                return TypeReaderResult.FromSuccess(new DiscordUserOrMessageAuthorEntity(((IUser)baseResult.BestMatch).Id));
+            }
+
+            if (MentionUtils.TryParseUser(input, out var userId))
+            {
+                return SnowflakeUtilities.IsValidSnowflake(userId)
+                    ? GetUserResult(userId)
+                    : GetInvalidSnowflakeResult();
+            }
+
+            // The base class covers users that are in the guild, and the previous condition covers mentioning users that are not in the guild.
+            // At this point, it's one of the following:
+            //   - A snowflake for a message in the guild.
+            //   - A snowflake for a user not in the guild.
+            //   - Something we can't handle.
+            if (ulong.TryParse(input, out var snowflake))
+            {
+                if (!SnowflakeUtilities.IsValidSnowflake(snowflake))
+                {
+                    return GetInvalidSnowflakeResult();
+                }
+
+                var messageService = services.GetRequiredService<IMessageService>();
+
+                if (await messageService.FindMessageAsync(context.Guild.Id, snowflake) is { } message)
+                {
+                    return GetMessageAuthorResult(message.Author.Id, message.Channel.Id, message.Id);
+                }
+
+                // At this point, our best guess is that the snowflake is for a user who is not in the guild.
+                return GetUserResult(snowflake);
+            }
+
+            return GetBadInputResult();
+        }
+
+        private static TypeReaderResult GetUserResult(ulong userId)
+            => TypeReaderResult.FromSuccess(new DiscordUserOrMessageAuthorEntity(userId));
+
+        private static TypeReaderResult GetMessageAuthorResult(ulong userId, ulong messageChannelId, ulong messageId)
+            => TypeReaderResult.FromSuccess(new DiscordUserOrMessageAuthorEntity(userId, messageChannelId, messageId));
+
+        private static TypeReaderResult GetInvalidSnowflakeResult()
+            => TypeReaderResult.FromError(CommandError.ParseFailed, "Snowflake was almost certainly invalid.");
+
+        private static TypeReaderResult GetBadInputResult()
+            => TypeReaderResult.FromError(CommandError.ParseFailed, "Could not find a user or message.");
+    }
+}

--- a/Modix.Services/Utilities/SnowflakeUtilities.cs
+++ b/Modix.Services/Utilities/SnowflakeUtilities.cs
@@ -7,10 +7,10 @@ namespace Modix.Services.Utilities
     {
         public static bool IsValidSnowflake(ulong snowflake)
         {
-            //Jan 1, 2015
+            // Jan 1, 2015
             var discordEpoch = SnowflakeUtils.FromSnowflake(0);
 
-            //The supposed timestamp
+            // The supposed timestamp
             var snowflakeDateTime = SnowflakeUtils.FromSnowflake(snowflake);
 
             return snowflakeDateTime > discordEpoch

--- a/Modix.Services/Utilities/SnowflakeUtilities.cs
+++ b/Modix.Services/Utilities/SnowflakeUtilities.cs
@@ -1,0 +1,20 @@
+﻿using Discord;
+using System;
+
+namespace Modix.Services.Utilities
+{
+    public static class SnowflakeUtilities
+    {
+        public static bool IsValidSnowflake(ulong snowflake)
+        {
+            //Jan 1, 2015
+            var discordEpoch = SnowflakeUtils.FromSnowflake(0);
+
+            //The supposed timestamp
+            var snowflakeDateTime = SnowflakeUtils.FromSnowflake(snowflake);
+
+            return snowflakeDateTime > discordEpoch
+                && snowflakeDateTime < DateTimeOffset.UtcNow;
+        }
+    }
+}

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     service.AddTypeReader<DiscordUserEntity>(new UserEntityTypeReader());
                     service.AddTypeReader<AnyGuildMessage<IUserMessage>>(new AnyGuildMessageTypeReader<IUserMessage>());
                     service.AddTypeReader<TimeSpan>(new TimeSpanTypeReader(), true);
+                    service.AddTypeReader<DiscordUserOrMessageAuthorEntity>(new UserOrMessageAuthorEntityTypeReader());
 
                     return service;
                 })


### PR DESCRIPTION
Resolves #518.

Often, users accidentally copy message IDs instead of user IDs when creating infractions or using `!info`. This leads to unnecessary frustration as those users go back and try to find the correct user ID, sometimes failing multiple times in the process.

This PR introduces a type reader to detect whether the user provided a user ID or a message ID. If a message ID, the type reader looks up the author of the message and returns the author as the user ID.