### PR TITLE
Fix #577, implement command to obtain avatar for user

### DIFF
--- a/Modix.Bot/Modules/FunModule.cs
+++ b/Modix.Bot/Modules/FunModule.cs
@@ -1,6 +1,8 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Discord;
 using Discord.Commands;
 using Modix.Services.CommandHelp;
 using Modix.Services.Utilities;
@@ -31,19 +33,80 @@ namespace Modix.Modules
                 var req = await client.GetStreamAsync(emojiUrl);
 
                 await Context.Channel.SendFileAsync(req, Path.GetFileName(emojiUrl), Context.User.Mention);
-                
+
                 try
                 {
                     await Context.Message.DeleteAsync();
                 }
-                catch (HttpRequestException)
+                catch (HttpRequestException ex)
                 {
-                    Log.Information("Couldn't delete message after jumbofying.");
+                    Log.Warning(ex, "Couldn't delete message after jumbofying.");
                 }
             }
-            catch (HttpRequestException)
+            catch (HttpRequestException ex)
             {
+
+                Log.Warning(ex, "Failed jumbofying emoji");
                 await ReplyAsync($"Sorry {Context.User.Mention}, I don't recognize that emoji.");
+            }
+        }
+
+        [Command("avatar"), Alias("av", "ava", "pfp"), Summary("Gets an avatar for a user")]
+        public async Task GetAvatarAsync(
+            [Summary("User that has the avatar")]
+                IUser user,
+                [Summary("Size for the avatar, defaults to 128")]
+                ushort size = 128)
+        {
+
+            try
+            {
+                const ushort MiniumSize = 128;
+                const ushort MaximumSize = 512;
+
+                // Set some minimum and maximum boundaries
+                // anything under 128 and Discord won't fetch
+                // the avatar. The upper is an arbitrary limit
+                // to prevent chat from being spammed with large
+                // avatars
+                if (size < MiniumSize)
+                {
+                    size = MiniumSize;
+                }
+                else if (size > MaximumSize)
+                {
+                    size = MaximumSize;
+                }
+
+                var avatarUrl = user.GetAvatarUrl(size: size);
+
+                if (string.IsNullOrWhiteSpace(avatarUrl))
+                {
+                    avatarUrl = user.GetDefaultAvatarUrl();
+                }
+
+                var embed = new EmbedBuilder()
+                    .WithTitle($"{user.Username}'s avatar")
+                    .WithImageUrl(avatarUrl)
+                    .WithCurrentTimestamp()
+                    .WithFooter($"Requested by {Context.User.Username}")
+                    .Build();
+
+                await ReplyAsync(embed: embed);
+
+                try
+                {
+                    await Context.Message.DeleteAsync();
+                }
+                catch (HttpRequestException ex)
+                {
+                    Log.Warning(ex, "Couldn't delete message after getting avatar.");
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                Log.Warning(ex, "Failed getting avatar for user {userId}", user.Id);
+                await ReplyAsync($"Sorry {Context.User.Mention}, I couldn't get the avatar!");
             }
         }
 

--- a/Modix.Bot/Modules/FunModule.cs
+++ b/Modix.Bot/Modules/FunModule.cs
@@ -61,7 +61,7 @@ namespace Modix.Modules
 
             try
             {
-                const ushort MiniumSize = 128;
+                const ushort MinimumSize = 128;
                 const ushort MaximumSize = 512;
 
                 // Set some minimum and maximum boundaries
@@ -69,9 +69,9 @@ namespace Modix.Modules
                 // the avatar. The upper is an arbitrary limit
                 // to prevent chat from being spammed with large
                 // avatars
-                if (size < MiniumSize)
+                if (size < MinimumSize)
                 {
-                    size = MiniumSize;
+                    size = MinimumSize;
                 }
                 else if (size > MaximumSize)
                 {


### PR DESCRIPTION
`!avatar {user} {size?}`

Usage: `!avatar @Inzanit`

Example:

![image](https://user-images.githubusercontent.com/1341180/63210207-6d937400-c0e3-11e9-8904-1cf685ac5ad3.png)
