### PR TITLE
Add 'ompf' and 'omfp' as aliases for 'info'

### DIFF
--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -67,6 +67,7 @@ namespace Modix.Modules
         private readonly ModixConfig _config;
 
         [Command("info")]
+        [Alias("ompf")]
         [Summary("Retrieves information about the supplied user, or the current user if one is not provided.")]
         public async Task GetUserInfoAsync(
             [Summary("The user to retrieve information about, if any.")]

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -67,7 +67,7 @@ namespace Modix.Modules
         private readonly ModixConfig _config;
 
         [Command("info")]
-        [Alias("ompf")]
+        [Alias("ompf", "omfp")]
         [Summary("Retrieves information about the supplied user, or the current user if one is not provided.")]
         public async Task GetUserInfoAsync(
             [Summary("The user to retrieve information about, if any.")]


### PR DESCRIPTION
The 'i', 'n', 'f', and 'o' keys are all very close to the 'o', 'm', 'p', and 'f' keys. So close, that if your right hand is placed one key to the right of where it should be, _and_ you make a typo, then it's common for a user to type 'ompf' instead of 'info'. For a better user experience in that situation, we should add an alias so MODiX does the Right Thing:tm:.