### PR TITLE
Update promotions precision

### DIFF
--- a/Modix.Bot/Modules/PromotionsModule.cs
+++ b/Modix.Bot/Modules/PromotionsModule.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Humanizer;
+using Humanizer.Localisation;
 using Microsoft.Extensions.Options;
 
 using Modix.Bot.Extensions;
@@ -65,7 +66,7 @@ namespace Modix.Modules
 
                 var approvalLabel = $"👍 {campaign.GetNumberOfApprovals()} / 👎 {campaign.GetNumberOfOppositions()}";
                 var timeRemaining = campaign.GetTimeUntilCampaignCanBeClosed();
-                var timeRemainingLabel = timeRemaining < TimeSpan.FromSeconds(1) ? "Can be closed now" : $"{timeRemaining.Humanize()} until close";
+                var timeRemainingLabel = timeRemaining < TimeSpan.FromSeconds(1) ? "Can be closed now" : $"{timeRemaining.Humanize(precision: 2, minUnit: TimeUnit.Minute)} until close";
 
                 embed.AddField(new EmbedFieldBuilder()
                 {


### PR DESCRIPTION
Currently, the promotions command shows 1 significant figure when humanizing the time left. This is rather inconvenient, as it means campaigns that were just started have `1 day`  as their time left, when in reality they have 1 day, 23 hours, and 59 minutes left. This sets the number of significant figures to 2, and sets the minimum unit to be minutes. This means that you'd have strings like:
`1 day, 3 hours`
`1 day, 5 minutes`
`12 hours, 10 minutes`
`27 minutes`

Instead of the current `1 day` for all of the first day.