### PR TITLE
Fix !jumbo support for Unicode emojis

### DIFF
--- a/Modix.Services/Utilities/EmojiUtilities.cs
+++ b/Modix.Services/Utilities/EmojiUtilities.cs
@@ -43,7 +43,7 @@ namespace Modix.Services.Utilities
             }
             else
             {
-                const string EmojiLink = "https://raw.githubusercontent.com/twitter/twemoji/gh-pages/2/72x72/";
+                const string EmojiLink = "https://raw.githubusercontent.com/twitter/twemoji/master/assets/72x72/";
                 var hexValues = new List<string>();
 
                 for (var i = 0; i < emoji.Length; i++)


### PR DESCRIPTION
Fixes the URL we're using to pull emoji images. The old URL stopped working because Twemoji changed some of their paths to symlinks ([link](https://github.com/twitter/twemoji/commit/1e3dce8a5525c1db68fe01448433cd61c023d9bc)).

Instead of referencing their `master/assets`, we could just point to a specific version on their `gh-pages` branch. With `master/assets`, we get updates for free, but we'd have to update if they changed their folder structure. With `gh-pages/12.1.3`, we (presumably) get greater stability, but we'd have to update if we wanted to bring in new emojis when they release a new version. I can go either way.