### PR TITLE
.NET Core 3.0 Port

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;
+      https://www.myget.org/F/discord-net/api/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <!--
+    Directory.Build.targets is automatically picked up and imported by
+    Microsoft.Common.targets. This file needs to exist, even if empty so that
+    files in the parent directory tree, with the same name, are not imported
+    instead. The import fairly late and most other props/targets will have been
+    imported beforehand. We also don't need to add ourselves to
+    MSBuildAllProjects, as that is done by the file that imports us.
+  -->
+
+  <!-- Package versions for package references across all projects -->
+  <ItemGroup>
+    <PackageReference Update="Discord.Net" Version="2.2.0-dev-20191025.3" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="3.0.0"/>
+    <PackageReference Update="Nito.AsyncEx.Coordination" Version="5.0.0" />
+    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
+    <PackageReference Update="AspNet.Security.OAuth.Discord" Version="3.0.0" />
+    <PackageReference Update="DogStatsD-CSharp-Client" Version="3.3.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="3.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Hosting" Version="3.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Http" Version="3.0.0" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
+
+    <PackageReference Update="Serilog" Version="2.8.0" />
+    <PackageReference Update="Serilog.AspNetCore" Version="3.1.0" />
+    <PackageReference Update="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Update="Serilog.Sinks.Literate" Version="3.0.0" />
+    <PackageReference Update="Serilog.Sinks.Sentry" Version="2.4.1" />
+    <PackageReference Update="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Update="Serilog.Sinks.RollingFile" Version="3.3.0" />
+    <PackageReference Update="Serilog.Sinks.Sentry" Version="2.4.1" />
+    
+    <PackageReference Update="Humanizer.Core" Version="2.5.16" />
+    <PackageReference Update="Newtonsoft.Json" Version="12.0.2" />
+
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Update="Moq" Version="4.10.1" />
+    <PackageReference Update="Moq.AutoMock" Version="1.2.0.120" />
+    <PackageReference Update="NUnit" Version="3.11.0" />
+    <PackageReference Update="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Update="Shouldly" Version="3.0.2" />
+
+    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
+    <PackageReference Update="NSubstitute" Version="4.2.1" />
+
+    <PackageReference Update="AsyncEvent" Version="0.2.0" />
+    <PackageReference Update="Kitsu" Version="1.4.1" />
+    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="3.0.0" />
+    <PackageReference Update="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
+  </ItemGroup>
+
+</Project>

--- a/Discord.Net.Abstractions/Discord.Net.Abstractions.csproj
+++ b/Discord.Net.Abstractions/Discord.Net.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.2.0-dev-20191024.6" />
+    <PackageReference Include="Discord.Net" />
   </ItemGroup>
 
 </Project>

--- a/Discord.Net.Abstractions/Discord.Net.Abstractions.csproj
+++ b/Discord.Net.Abstractions/Discord.Net.Abstractions.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <RootNamespace>Discord</RootNamespace>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.1.1" />
+    <PackageReference Include="Discord.Net" Version="2.2.0-dev-20191024.6" />
   </ItemGroup>
 
 </Project>

--- a/Discord.Net.Abstractions/Rest/IRestGroupUser.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGroupUser.cs
@@ -47,6 +47,8 @@ namespace Discord.Rest
         public string VoiceSessionId
             => (RestGroupUser as IVoiceState).VoiceSessionId;
 
+        public bool IsStreaming => (RestGroupUser as IVoiceState).IsStreaming;
+
         /// <summary>
         /// The existing <see cref="Rest.RestGroupUser"/> being abstracted.
         /// </summary>

--- a/Discord.Net.Abstractions/Rest/IRestGuild.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGuild.cs
@@ -685,33 +685,32 @@ namespace Discord.Rest
         public override string ToString()
             => RestGuild.ToString();
 
-        public Task<IReadOnlyCollection<IAuditLogEntry>> GetAuditLogsAsync(int limit = 100, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null, ulong? beforeId = null, ulong? userId = null, ActionType? actionType = null)
-        {
-            throw new NotImplementedException();
-        }
+        public async Task<IReadOnlyCollection<IAuditLogEntry>> GetAuditLogsAsync(int limit = 100, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null, ulong? beforeId = null, ulong? userId = null, ActionType? actionType = null)
+            => (await RestGuild.GetAuditLogsAsync(limit, options, beforeId, userId, actionType).FlattenAsync())
+            .ToArray();
 
         /// <summary>
         /// The existing <see cref="Rest.RestGuild"/> being abstracted.
         /// </summary>
         protected RestGuild RestGuild { get; }
 
-        public PremiumTier PremiumTier => throw new NotImplementedException();
+        public PremiumTier PremiumTier => RestGuild.PremiumTier;
 
-        public string BannerId => throw new NotImplementedException();
+        public string BannerId => RestGuild.BannerId;
 
-        public string BannerUrl => throw new NotImplementedException();
+        public string BannerUrl => RestGuild.BannerUrl;
 
-        public string VanityURLCode => throw new NotImplementedException();
+        public string VanityURLCode => RestGuild.VanityURLCode;
 
-        public SystemChannelMessageDeny SystemChannelFlags => throw new NotImplementedException();
+        public SystemChannelMessageDeny SystemChannelFlags => RestGuild.SystemChannelFlags;
 
-        public string Description => throw new NotImplementedException();
+        public string Description => RestGuild.Description;
 
-        public int PremiumSubscriptionCount => throw new NotImplementedException();
+        public int PremiumSubscriptionCount => RestGuild.PremiumSubscriptionCount;
 
-        public string PreferredLocale => throw new NotImplementedException();
+        public string PreferredLocale => RestGuild.PreferredLocale;
 
-        public CultureInfo PreferredCulture => throw new NotImplementedException();
+        public CultureInfo PreferredCulture => RestGuild.PreferredCulture;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestGuild.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGuild.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -684,10 +685,33 @@ namespace Discord.Rest
         public override string ToString()
             => RestGuild.ToString();
 
+        public Task<IReadOnlyCollection<IAuditLogEntry>> GetAuditLogsAsync(int limit = 100, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null, ulong? beforeId = null, ulong? userId = null, ActionType? actionType = null)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// The existing <see cref="Rest.RestGuild"/> being abstracted.
         /// </summary>
         protected RestGuild RestGuild { get; }
+
+        public PremiumTier PremiumTier => throw new NotImplementedException();
+
+        public string BannerId => throw new NotImplementedException();
+
+        public string BannerUrl => throw new NotImplementedException();
+
+        public string VanityURLCode => throw new NotImplementedException();
+
+        public SystemChannelMessageDeny SystemChannelFlags => throw new NotImplementedException();
+
+        public string Description => throw new NotImplementedException();
+
+        public int PremiumSubscriptionCount => throw new NotImplementedException();
+
+        public string PreferredLocale => throw new NotImplementedException();
+
+        public CultureInfo PreferredCulture => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestGuildUser.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGuildUser.cs
@@ -108,9 +108,9 @@ namespace Discord.Rest
         protected RestGuildUser RestGuildUser
             => RestUser as RestGuildUser;
 
-        public DateTimeOffset? PremiumSince => throw new NotImplementedException();
+        public DateTimeOffset? PremiumSince => RestGuildUser.PremiumSince;
 
-        public bool IsStreaming => throw new NotImplementedException();
+        public bool IsStreaming => (RestGuildUser as IGuildUser).IsStreaming;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestGuildUser.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGuildUser.cs
@@ -107,6 +107,10 @@ namespace Discord.Rest
         /// </summary>
         protected RestGuildUser RestGuildUser
             => RestUser as RestGuildUser;
+
+        public DateTimeOffset? PremiumSince => throw new NotImplementedException();
+
+        public bool IsStreaming => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestMessage.cs
+++ b/Discord.Net.Abstractions/Rest/IRestMessage.cs
@@ -146,38 +146,28 @@ namespace Discord.Rest
             => RestMessage.ToString();
 
         public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => RestMessage.AddReactionAsync(emote, options);
 
         public Task RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => RestMessage.RemoveReactionAsync(emote, user, options);
 
         public Task RemoveReactionAsync(IEmote emote, ulong userId, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => RestMessage.RemoveReactionAsync(emote, userId, options);
 
         public Task RemoveAllReactionsAsync(RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => RestMessage.RemoveAllReactionsAsync(options);
 
         public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emoji, int limit, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => RestMessage.GetReactionUsersAsync(emoji, limit, options);
 
         /// <summary>
         /// The existing <see cref="Rest.RestMessage"/> being abstracted.
         /// </summary>
         protected RestMessage RestMessage { get; }
 
-        public bool IsSuppressed => throw new NotImplementedException();
+        public bool IsSuppressed => RestMessage.IsSuppressed;
 
-        public IReadOnlyDictionary<IEmote, ReactionMetadata> Reactions => throw new NotImplementedException();
+        public IReadOnlyDictionary<IEmote, ReactionMetadata> Reactions => RestMessage.Reactions;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestMessage.cs
+++ b/Discord.Net.Abstractions/Rest/IRestMessage.cs
@@ -145,10 +145,39 @@ namespace Discord.Rest
         public override string ToString()
             => RestMessage.ToString();
 
+        public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RemoveReactionAsync(IEmote emote, ulong userId, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RemoveAllReactionsAsync(RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emoji, int limit, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// The existing <see cref="Rest.RestMessage"/> being abstracted.
         /// </summary>
         protected RestMessage RestMessage { get; }
+
+        public bool IsSuppressed => throw new NotImplementedException();
+
+        public IReadOnlyDictionary<IEmote, ReactionMetadata> Reactions => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestSelfUser.cs
+++ b/Discord.Net.Abstractions/Rest/IRestSelfUser.cs
@@ -40,6 +40,12 @@ namespace Discord.Rest
         /// </summary>
         protected RestSelfUser RestSelfUser
             => RestUser as RestSelfUser;
+
+        public UserProperties Flags => throw new NotImplementedException();
+
+        public PremiumType PremiumType => throw new NotImplementedException();
+
+        public string Locale => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestUser.cs
+++ b/Discord.Net.Abstractions/Rest/IRestUser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 namespace Discord.Rest
@@ -99,6 +100,8 @@ namespace Discord.Rest
         /// The existing <see cref="Rest.RestUser"/> being abstracted.
         /// </summary>
         protected RestUser RestUser { get; }
+
+        public IImmutableSet<ClientType> ActiveClients => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestUser.cs
+++ b/Discord.Net.Abstractions/Rest/IRestUser.cs
@@ -101,7 +101,7 @@ namespace Discord.Rest
         /// </summary>
         protected RestUser RestUser { get; }
 
-        public IImmutableSet<ClientType> ActiveClients => throw new NotImplementedException();
+        public IImmutableSet<ClientType> ActiveClients => RestUser.ActiveClients;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestUserMessage.cs
+++ b/Discord.Net.Abstractions/Rest/IRestUserMessage.cs
@@ -8,8 +8,6 @@ namespace Discord.Rest
     /// <inheritdoc cref="RestUserMessage" />
     public interface IRestUserMessage : IRestMessage, IUserMessage, IDeletable
     {
-        /// <inheritdoc cref="RestUserMessage.Reactions" />
-        new IReadOnlyDictionary<IEmote, IReactionMetadata> Reactions { get; }
     }
 
     /// <summary>
@@ -26,36 +24,12 @@ namespace Discord.Rest
             : base(restUserMessage) { }
 
         /// <inheritdoc />
-        public IReadOnlyDictionary<IEmote, IReactionMetadata> Reactions
-            => RestUserMessage.Reactions
-                .ToDictionary(x => x.Key, x => x.Value.Abstract());
-
-        /// <inheritdoc />
-        public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
-            => RestUserMessage.AddReactionAsync(emote, options);
-
-        /// <inheritdoc />
-        public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emoji, int limit, RequestOptions options = null)
-            => RestUserMessage.GetReactionUsersAsync(emoji, limit, options)
-                .Select(x => x
-                    .Select(UserAbstractionExtensions.Abstract)
-                    .ToArray());
-
-        /// <inheritdoc />
         public Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)
             => RestUserMessage.ModifyAsync(func, options);
 
         /// <inheritdoc />
         public Task PinAsync(RequestOptions options = null)
             => RestUserMessage.PinAsync(options);
-
-        /// <inheritdoc />
-        public Task RemoveAllReactionsAsync(RequestOptions options = null)
-            => RestUserMessage.RemoveAllReactionsAsync(options);
-
-        /// <inheritdoc />
-        public Task RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options = null)
-            => RestUserMessage.RemoveReactionAsync(emote, user, options);
 
         /// <inheritdoc />
         public string Resolve(TagHandling userHandling = TagHandling.Name, TagHandling channelHandling = TagHandling.Name, TagHandling roleHandling = TagHandling.Name, TagHandling everyoneHandling = TagHandling.Ignore, TagHandling emojiHandling = TagHandling.Name)

--- a/Discord.Net.Abstractions/Rest/IRestUserMessage.cs
+++ b/Discord.Net.Abstractions/Rest/IRestUserMessage.cs
@@ -31,10 +31,6 @@ namespace Discord.Rest
                 .ToDictionary(x => x.Key, x => x.Value.Abstract());
 
         /// <inheritdoc />
-        IReadOnlyDictionary<IEmote, ReactionMetadata> IUserMessage.Reactions
-            => RestUserMessage.Reactions;
-
-        /// <inheritdoc />
         public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
             => RestUserMessage.AddReactionAsync(emote, options);
 
@@ -68,6 +64,11 @@ namespace Discord.Rest
         /// <inheritdoc />
         public Task UnpinAsync(RequestOptions options = null)
             => RestUserMessage.UnpinAsync(options);
+
+        public Task ModifySuppressionAsync(bool suppressEmbeds, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// The existing <see cref="Rest.RestUserMessage"/> being abstracted.

--- a/Discord.Net.Abstractions/Rest/IRestUserMessage.cs
+++ b/Discord.Net.Abstractions/Rest/IRestUserMessage.cs
@@ -66,9 +66,7 @@ namespace Discord.Rest
             => RestUserMessage.UnpinAsync(options);
 
         public Task ModifySuppressionAsync(bool suppressEmbeds, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => RestUserMessage.ModifySuppressionAsync(suppressEmbeds, options);
 
         /// <summary>
         /// The existing <see cref="Rest.RestUserMessage"/> being abstracted.

--- a/Discord.Net.Abstractions/Rest/IRestWebhookUser.cs
+++ b/Discord.Net.Abstractions/Rest/IRestWebhookUser.cs
@@ -113,6 +113,10 @@ namespace Discord.Rest
         /// </summary>
         protected RestWebhookUser RestWebhookUser
             => RestUser as RestWebhookUser;
+
+        public DateTimeOffset? PremiumSince => throw new NotImplementedException();
+
+        public bool IsStreaming => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestWebhookUser.cs
+++ b/Discord.Net.Abstractions/Rest/IRestWebhookUser.cs
@@ -114,9 +114,9 @@ namespace Discord.Rest
         protected RestWebhookUser RestWebhookUser
             => RestUser as RestWebhookUser;
 
-        public DateTimeOffset? PremiumSince => throw new NotImplementedException();
+        public DateTimeOffset? PremiumSince => (RestUser as IGuildUser).PremiumSince;
 
-        public bool IsStreaming => throw new NotImplementedException();
+        public bool IsStreaming => (RestUser as IGuildUser).IsStreaming;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketGroupUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGroupUser.cs
@@ -56,7 +56,7 @@ namespace Discord.WebSocket
         public string VoiceSessionId
             => (SocketGroupUser as IGroupUser).VoiceSessionId;
 
-        public bool IsStreaming => throw new NotImplementedException();
+        public bool IsStreaming => (SocketGroupUser as IGroupUser).IsStreaming;
 
         /// <summary>
         /// The existing <see cref="WebSocket.SocketGroupUser"/> being abstracted.

--- a/Discord.Net.Abstractions/WebSocket/ISocketGroupUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGroupUser.cs
@@ -56,6 +56,8 @@ namespace Discord.WebSocket
         public string VoiceSessionId
             => (SocketGroupUser as IGroupUser).VoiceSessionId;
 
+        public bool IsStreaming => throw new NotImplementedException();
+
         /// <summary>
         /// The existing <see cref="WebSocket.SocketGroupUser"/> being abstracted.
         /// </summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Discord.Audio;
@@ -735,10 +736,33 @@ namespace Discord.WebSocket
         public override string ToString()
             => SocketGuild.ToString();
 
+        public Task<IReadOnlyCollection<IAuditLogEntry>> GetAuditLogsAsync(int limit = 100, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null, ulong? beforeId = null, ulong? userId = null, ActionType? actionType = null)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// The existing <see cref="Rest.SocketGuild"/> being abstracted.
         /// </summary>
         protected SocketGuild SocketGuild { get; }
+
+        public PremiumTier PremiumTier => throw new NotImplementedException();
+
+        public string BannerId => throw new NotImplementedException();
+
+        public string BannerUrl => throw new NotImplementedException();
+
+        public string VanityURLCode => throw new NotImplementedException();
+
+        public SystemChannelMessageDeny SystemChannelFlags => throw new NotImplementedException();
+
+        public string Description => throw new NotImplementedException();
+
+        public int PremiumSubscriptionCount => throw new NotImplementedException();
+
+        public string PreferredLocale => throw new NotImplementedException();
+
+        public CultureInfo PreferredCulture => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
@@ -746,23 +746,23 @@ namespace Discord.WebSocket
         /// </summary>
         protected SocketGuild SocketGuild { get; }
 
-        public PremiumTier PremiumTier => throw new NotImplementedException();
+        public PremiumTier PremiumTier => SocketGuild.PremiumTier;
 
-        public string BannerId => throw new NotImplementedException();
+        public string BannerId => SocketGuild.BannerId;
 
-        public string BannerUrl => throw new NotImplementedException();
+        public string BannerUrl => SocketGuild.BannerUrl;
 
-        public string VanityURLCode => throw new NotImplementedException();
+        public string VanityURLCode => SocketGuild.VanityURLCode;
 
-        public SystemChannelMessageDeny SystemChannelFlags => throw new NotImplementedException();
+        public SystemChannelMessageDeny SystemChannelFlags => SocketGuild.SystemChannelFlags;
 
-        public string Description => throw new NotImplementedException();
+        public string Description => SocketGuild.Description;
 
-        public int PremiumSubscriptionCount => throw new NotImplementedException();
+        public int PremiumSubscriptionCount => SocketGuild.PremiumSubscriptionCount;
 
-        public string PreferredLocale => throw new NotImplementedException();
+        public string PreferredLocale => SocketGuild.PreferredLocale;
 
-        public CultureInfo PreferredCulture => throw new NotImplementedException();
+        public CultureInfo PreferredCulture => SocketGuild.PreferredCulture;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketGuildUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGuildUser.cs
@@ -159,9 +159,9 @@ namespace Discord.WebSocket
         protected SocketGuildUser SocketGuildUser
             => SocketUser as SocketGuildUser;
 
-        public DateTimeOffset? PremiumSince => throw new NotImplementedException();
+        public DateTimeOffset? PremiumSince => (SocketUser as IGuildUser).PremiumSince;
 
-        public bool IsStreaming => throw new NotImplementedException();
+        public bool IsStreaming => (SocketUser as IGuildUser).IsStreaming;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketGuildUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGuildUser.cs
@@ -158,6 +158,10 @@ namespace Discord.WebSocket
         /// </summary>
         protected SocketGuildUser SocketGuildUser
             => SocketUser as SocketGuildUser;
+
+        public DateTimeOffset? PremiumSince => throw new NotImplementedException();
+
+        public bool IsStreaming => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketMessage.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketMessage.cs
@@ -154,38 +154,28 @@ namespace Discord.WebSocket
             => SocketMessage.ToString();
 
         public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => SocketMessage.AddReactionAsync(emote, options);
 
         public Task RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => SocketMessage.RemoveReactionAsync(emote, user, options);
 
         public Task RemoveReactionAsync(IEmote emote, ulong userId, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => SocketMessage.RemoveReactionAsync(emote, userId, options);
 
         public Task RemoveAllReactionsAsync(RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => SocketMessage.RemoveAllReactionsAsync(options);
 
         public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emoji, int limit, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => SocketMessage.GetReactionUsersAsync(emoji, limit, options);
 
         /// <summary>
         /// The existing <see cref="WebSocket.SocketMessage"/> being abstracted.
         /// </summary>
         protected SocketMessage SocketMessage { get; }
 
-        public bool IsSuppressed => throw new NotImplementedException();
+        public bool IsSuppressed => SocketMessage.IsSuppressed;
 
-        public IReadOnlyDictionary<IEmote, ReactionMetadata> Reactions => throw new NotImplementedException();
+        public IReadOnlyDictionary<IEmote, ReactionMetadata> Reactions => SocketMessage.Reactions;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketMessage.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketMessage.cs
@@ -153,10 +153,39 @@ namespace Discord.WebSocket
         public override string ToString()
             => SocketMessage.ToString();
 
+        public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RemoveReactionAsync(IEmote emote, ulong userId, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task RemoveAllReactionsAsync(RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emoji, int limit, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// The existing <see cref="WebSocket.SocketMessage"/> being abstracted.
         /// </summary>
         protected SocketMessage SocketMessage { get; }
+
+        public bool IsSuppressed => throw new NotImplementedException();
+
+        public IReadOnlyDictionary<IEmote, ReactionMetadata> Reactions => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketSelfUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketSelfUser.cs
@@ -41,11 +41,11 @@ namespace Discord.WebSocket
         protected SocketSelfUser SocketSelfUser
             => SocketUser as SocketSelfUser;
 
-        public UserProperties Flags => throw new NotImplementedException();
+        public UserProperties Flags => SocketSelfUser.Flags;
 
-        public PremiumType PremiumType => throw new NotImplementedException();
+        public PremiumType PremiumType => SocketSelfUser.PremiumType;
 
-        public string Locale => throw new NotImplementedException();
+        public string Locale => SocketSelfUser.Locale;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketSelfUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketSelfUser.cs
@@ -40,6 +40,12 @@ namespace Discord.WebSocket
         /// </summary>
         protected SocketSelfUser SocketSelfUser
             => SocketUser as SocketSelfUser;
+
+        public UserProperties Flags => throw new NotImplementedException();
+
+        public PremiumType PremiumType => throw new NotImplementedException();
+
+        public string Locale => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketUser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -98,6 +99,8 @@ namespace Discord.WebSocket
         /// The existing <see cref="WebSocket.SocketUser"/> being abstracted.
         /// </summary>
         protected SocketUser SocketUser { get; }
+
+        public IImmutableSet<ClientType> ActiveClients => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketUser.cs
@@ -100,7 +100,7 @@ namespace Discord.WebSocket
         /// </summary>
         protected SocketUser SocketUser { get; }
 
-        public IImmutableSet<ClientType> ActiveClients => throw new NotImplementedException();
+        public IImmutableSet<ClientType> ActiveClients => SocketUser.ActiveClients;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketUserMessage.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketUserMessage.cs
@@ -66,9 +66,7 @@ namespace Discord.WebSocket
             => SocketUserMessage.UnpinAsync(options);
 
         public Task ModifySuppressionAsync(bool suppressEmbeds, RequestOptions options = null)
-        {
-            throw new NotImplementedException();
-        }
+            => SocketUserMessage.ModifySuppressionAsync(suppressEmbeds, options);
 
         /// <summary>
         /// The existing <see cref="WebSocket.SocketUserMessage"/> being abstracted.

--- a/Discord.Net.Abstractions/WebSocket/ISocketUserMessage.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketUserMessage.cs
@@ -8,8 +8,6 @@ namespace Discord.WebSocket
     /// <inheritdoc cref="SocketUserMessage" />
     public interface ISocketUserMessage : ISocketMessage, IUserMessage
     {
-        /// <inheritdoc cref="SocketUserMessage.Reactions" />
-        new IReadOnlyDictionary<IEmote, IReactionMetadata> Reactions { get; }
     }
 
     /// <summary>
@@ -26,36 +24,12 @@ namespace Discord.WebSocket
             : base(socketUserMessage) { }
 
         /// <inheritdoc />
-        public IReadOnlyDictionary<IEmote, IReactionMetadata> Reactions
-            => SocketUserMessage.Reactions
-                .ToDictionary(x => x.Key, x => x.Value.Abstract());
-
-        /// <inheritdoc />
-        public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
-            => SocketUserMessage.AddReactionAsync(emote, options);
-
-        /// <inheritdoc />
-        public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emoji, int limit, RequestOptions options = null)
-            => SocketUserMessage.GetReactionUsersAsync(emoji, limit, options)
-                .Select(x => x
-                    .Select(UserAbstractionExtensions.Abstract)
-                    .ToArray());
-
-        /// <inheritdoc />
         public Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)
             => SocketUserMessage.ModifyAsync(func, options);
 
         /// <inheritdoc />
         public Task PinAsync(RequestOptions options = null)
             => SocketUserMessage.PinAsync(options);
-
-        /// <inheritdoc />
-        public Task RemoveAllReactionsAsync(RequestOptions options = null)
-            => SocketUserMessage.RemoveAllReactionsAsync(options);
-
-        /// <inheritdoc />
-        public Task RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options = null)
-            => SocketUserMessage.RemoveReactionAsync(emote, user, options);
 
         /// <inheritdoc />
         public string Resolve(TagHandling userHandling = TagHandling.Name, TagHandling channelHandling = TagHandling.Name, TagHandling roleHandling = TagHandling.Name, TagHandling everyoneHandling = TagHandling.Ignore, TagHandling emojiHandling = TagHandling.Name)

--- a/Discord.Net.Abstractions/WebSocket/ISocketUserMessage.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketUserMessage.cs
@@ -31,10 +31,6 @@ namespace Discord.WebSocket
                 .ToDictionary(x => x.Key, x => x.Value.Abstract());
 
         /// <inheritdoc />
-        IReadOnlyDictionary<IEmote, ReactionMetadata> IUserMessage.Reactions
-            => (SocketUserMessage as IUserMessage).Reactions;
-
-        /// <inheritdoc />
         public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
             => SocketUserMessage.AddReactionAsync(emote, options);
 
@@ -68,6 +64,11 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public Task UnpinAsync(RequestOptions options = null)
             => SocketUserMessage.UnpinAsync(options);
+
+        public Task ModifySuppressionAsync(bool suppressEmbeds, RequestOptions options = null)
+        {
+            throw new NotImplementedException();
+        }
 
         /// <summary>
         /// The existing <see cref="WebSocket.SocketUserMessage"/> being abstracted.

--- a/Discord.Net.Abstractions/WebSocket/ISocketVoiceState.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketVoiceState.cs
@@ -58,7 +58,7 @@ namespace Discord.WebSocket
         public bool IsSelfDeafened
             => _socketVoiceState.IsSelfDeafened;
 
-        public bool IsStreaming => throw new NotImplementedException();
+        public bool IsStreaming => _socketVoiceState.IsStreaming;
 
         /// <inheritdoc cref="SocketVoiceState.ToString" />
         public override string ToString()

--- a/Discord.Net.Abstractions/WebSocket/ISocketVoiceState.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketVoiceState.cs
@@ -58,6 +58,8 @@ namespace Discord.WebSocket
         public bool IsSelfDeafened
             => _socketVoiceState.IsSelfDeafened;
 
+        public bool IsStreaming => throw new NotImplementedException();
+
         /// <inheritdoc cref="SocketVoiceState.ToString" />
         public override string ToString()
             => _socketVoiceState.ToString();

--- a/Discord.Net.Abstractions/WebSocket/ISocketWebhookUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketWebhookUser.cs
@@ -121,9 +121,9 @@ namespace Discord.WebSocket
         protected SocketWebhookUser SocketWebhookUser
             => SocketUser as SocketWebhookUser;
 
-        public DateTimeOffset? PremiumSince => throw new NotImplementedException();
+        public DateTimeOffset? PremiumSince => (SocketUser as IGuildUser).PremiumSince;
 
-        public bool IsStreaming => throw new NotImplementedException();
+        public bool IsStreaming => (SocketUser as IGuildUser).IsStreaming;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketWebhookUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketWebhookUser.cs
@@ -120,6 +120,10 @@ namespace Discord.WebSocket
         /// </summary>
         protected SocketWebhookUser SocketWebhookUser
             => SocketUser as SocketWebhookUser;
+
+        public DateTimeOffset? PremiumSince => throw new NotImplementedException();
+
+        public bool IsStreaming => throw new NotImplementedException();
     }
 
     /// <summary>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 as dotnet-test
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0 as dotnet-test
 WORKDIR /src
 COPY . .
 RUN sh build/test.sh
 
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2 as dotnet-build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0 as dotnet-build
 WORKDIR /src
 COPY . .
 
 RUN sh build/build.sh
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2.2
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.0
 WORKDIR /app
 COPY --from=dotnet-build /app .
 COPY --from=dotnet-build /src/healthcheck.sh .

--- a/Modix.Bot.Test/Modix.Bot.Test.csproj
+++ b/Modix.Bot.Test/Modix.Bot.Test.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NUnit"/>
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Modix.Bot.Test/Modix.Bot.Test.csproj
+++ b/Modix.Bot.Test/Modix.Bot.Test.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Modix.Bot/Modix.Bot.csproj
+++ b/Modix.Bot/Modix.Bot.csproj
@@ -6,16 +6,16 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DogStatsD-CSharp-Client" Version="3.3.0" />
-    <PackageReference Include="Humanizer.Core" Version="2.5.16" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-    <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.Sentry" Version="2.4.1" />
+    <PackageReference Include="DogStatsD-CSharp-Client"/>
+    <PackageReference Include="Humanizer.Core"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting"/>
+    <PackageReference Include="Microsoft.Extensions.Http"/>
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Serilog"/>
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Sinks.Literate"/>
+    <PackageReference Include="Serilog.Sinks.RollingFile" />
+    <PackageReference Include="Serilog.Sinks.Sentry"  />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Abstractions\Discord.Net.Abstractions.csproj" />

--- a/Modix.Bot/Modix.Bot.csproj
+++ b/Modix.Bot/Modix.Bot.csproj
@@ -2,13 +2,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.1.1" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="3.3.0" />
     <PackageReference Include="Humanizer.Core" Version="2.5.16" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />

--- a/Modix.Bot/ModixBot.cs
+++ b/Modix.Bot/ModixBot.cs
@@ -34,8 +34,8 @@ namespace Modix
         private readonly IServiceProvider _provider;
         private readonly ModixConfig _config;
         private readonly DiscordSerilogAdapter _serilogAdapter;
-        private readonly IApplicationLifetime _applicationLifetime;
-        private readonly IHostingEnvironment _env;
+        private readonly IHostApplicationLifetime _applicationLifetime;
+        private readonly IHostEnvironment _env;
         private readonly IDogStatsd _stats;
         private IServiceScope _scope;
         private readonly ConcurrentDictionary<ICommandContext, IServiceScope> _commandScopes = new ConcurrentDictionary<ICommandContext, IServiceScope>();
@@ -46,10 +46,10 @@ namespace Modix
             IOptions<ModixConfig> modixConfig,
             CommandService commandService,
             DiscordSerilogAdapter serilogAdapter,
-            IApplicationLifetime applicationLifetime,
+            IHostApplicationLifetime applicationLifetime,
             IServiceProvider serviceProvider,
             ILogger<ModixBot> logger,
-            IHostingEnvironment env,
+            IHostEnvironment env,
             IDogStatsd stats)
         {
             _client = discordClient ?? throw new ArgumentNullException(nameof(discordClient));

--- a/Modix.Bot/Modules/GuildInfoModule.cs
+++ b/Modix.Bot/Modules/GuildInfoModule.cs
@@ -125,14 +125,19 @@ namespace Modix.Modules
 
             var channelCounts = await _messageRepository.GetTotalMessageCountByChannelAsync(guild.Id, TimeSpan.FromDays(30));
             var orderedChannelCounts = channelCounts.OrderByDescending(x => x.Value);
-            var mostActiveChannel = orderedChannelCounts.First();
+            var mostActiveChannel = orderedChannelCounts.FirstOrDefault();
 
             stringBuilder
                 .AppendLine(Format.Bold("\u276F Guild Participation"))
                 .AppendLine($"Last 7 days: {"message".ToQuantity(weekTotal, "n0")}")
                 .AppendLine($"Last 30 days: {"message".ToQuantity(monthTotal, "n0")}")
-                .AppendLine($"Avg. per day: {"message".ToQuantity(monthTotal / 30, "n0")}")
-                .AppendLine($"Most active channel: {MentionUtils.MentionChannel(mostActiveChannel.Key)} ({"message".ToQuantity(mostActiveChannel.Value, "n0")} in 30 days)");
+                .AppendLine($"Avg. per day: {"message".ToQuantity(monthTotal / 30, "n0")}");
+
+            if (!(mostActiveChannel is { }))
+            {
+                stringBuilder
+                    .AppendLine($"Most active channel: {MentionUtils.MentionChannel(mostActiveChannel.Key)} ({"message".ToQuantity(mostActiveChannel.Value, "n0")} in 30 days)");
+            }
 
             var emojiCounts = await _emojiRepository.GetEmojiStatsAsync(guild.Id, SortDirection.Ascending, 1);
 

--- a/Modix.Bot/Modules/GuildInfoModule.cs
+++ b/Modix.Bot/Modules/GuildInfoModule.cs
@@ -133,7 +133,7 @@ namespace Modix.Modules
                 .AppendLine($"Last 30 days: {"message".ToQuantity(monthTotal, "n0")}")
                 .AppendLine($"Avg. per day: {"message".ToQuantity(monthTotal / 30, "n0")}");
 
-            if (!(mostActiveChannel is { }))
+            if (mostActiveChannel is { })
             {
                 stringBuilder
                     .AppendLine($"Most active channel: {MentionUtils.MentionChannel(mostActiveChannel.Key)} ({"message".ToQuantity(mostActiveChannel.Value, "n0")} in 30 days)");

--- a/Modix.Common.Test/Modix.Common.Test.csproj
+++ b/Modix.Common.Test/Modix.Common.Test.csproj
@@ -3,11 +3,12 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
     <PackageReference Include="Shouldly" Version="3.0.2" />

--- a/Modix.Common.Test/Modix.Common.Test.csproj
+++ b/Modix.Common.Test/Modix.Common.Test.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.2" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Shouldly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Modix.Common/Modix.Common.csproj
+++ b/Modix.Common/Modix.Common.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Serilog" />
   </ItemGroup>
 
 </Project>

--- a/Modix.Common/Modix.Common.csproj
+++ b/Modix.Common/Modix.Common.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />

--- a/Modix.Data.Test/Assertions/DbContextSequenceExtensions.cs
+++ b/Modix.Data.Test/Assertions/DbContextSequenceExtensions.cs
@@ -74,9 +74,6 @@ namespace Microsoft.EntityFrameworkCore
 
             var entity = context.Model.FindEntityType(typeof(TEntity).FullName);
 
-            if (entity.IsQueryType)
-                throw new ArgumentException($"{entity.Name} is a query record, not a table record.", nameof(tableSelector));
-
             if (!(propertySelector.Body is MemberExpression memberSelector) || (memberSelector.Member.MemberType != MemberTypes.Property))
                 throw new ArgumentException($"Expression {propertySelector.Body.ToString()} does not select a property of record type {entity.Name}", nameof(propertySelector));
 

--- a/Modix.Data.Test/Modix.Data.Test.csproj
+++ b/Modix.Data.Test/Modix.Data.Test.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="NSubstitute" Version="4.0.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NSubstitute"/>
+    <PackageReference Include="NUnit"/>
+    <PackageReference Include="NUnit3TestAdapter"/>
+    <PackageReference Include="Shouldly"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Modix.Data.Test/Modix.Data.Test.csproj
+++ b/Modix.Data.Test/Modix.Data.Test.csproj
@@ -3,12 +3,13 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NSubstitute" Version="4.0.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/Modix.Data.Test/Repositories/ClaimMappingRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/ClaimMappingRepositoryTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+using Modix.Data;
 using Modix.Data.Models.Core;
 using Modix.Data.Repositories;
 using Modix.Data.Test.TestData;
@@ -341,6 +342,7 @@ namespace Modix.Data.Test.Repositories
             claimMapping.DeleteActionId.ShouldNotBeNull();
 
             modixContext.ClaimMappings
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ClaimMappings.Entities
                     .Select(x => x.Id));
@@ -390,6 +392,7 @@ namespace Modix.Data.Test.Repositories
             result.ShouldBeFalse();
 
             modixContext.ClaimMappings
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ClaimMappings.Entities
                     .Select(x => x.Id));
@@ -399,6 +402,7 @@ namespace Modix.Data.Test.Repositories
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.ConfigurationActions
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => !(x.ClaimMappingId is null))

--- a/Modix.Data.Test/Repositories/DesignatedChannelMappingRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/DesignatedChannelMappingRepositoryTests.cs
@@ -362,11 +362,13 @@ namespace Modix.Data.Test.Repositories
                 });
 
             modixContext.DesignatedChannelMappings
+                .AsEnumerable()
                 .Where(x => !designatedChannelMappingIds.Contains(x.Id) || DesignatedChannelMappings.Entities
                     .Any(y => (y.Id == x.Id) && (x.DeleteActionId == null)))
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.ConfigurationActions
+                .AsEnumerable()
                 .Where(x => DesignatedChannelMappings.Entities
                     .Any(y => (y.DeleteActionId == x.Id) && designatedChannelMappingIds.Contains(y.Id)))
                 .EachShould(x => x.ShouldNotHaveChanged());

--- a/Modix.Data.Test/Repositories/DesignatedChannelMappingRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/DesignatedChannelMappingRepositoryTests.cs
@@ -187,7 +187,11 @@ namespace Modix.Data.Test.Repositories
 
             await Should.ThrowAsync<ArgumentNullException>(uut.CreateAsync(null));
 
-            modixContext.DesignatedChannelMappings.Select(x => x.Id).ShouldBe(DesignatedChannelMappings.Entities.Select(x => x.Id));
+            modixContext.DesignatedChannelMappings
+                .AsQueryable()
+                .Select(x => x.Id)
+                .ShouldBe(DesignatedChannelMappings.Entities.Select(x => x.Id));
+
             modixContext.DesignatedChannelMappings.EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -327,6 +331,7 @@ namespace Modix.Data.Test.Repositories
                 .Count());
 
             modixContext.DesignatedChannelMappings
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedChannelMappings.Entities.Select(x => x.Id));
 
@@ -380,6 +385,7 @@ namespace Modix.Data.Test.Repositories
             result.ShouldBe(0);
 
             modixContext.DesignatedChannelMappings
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedChannelMappings.Entities
                     .Select(x => x.Id));
@@ -388,6 +394,7 @@ namespace Modix.Data.Test.Repositories
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.ConfigurationActions
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => x.DesignatedChannelMappingId != null)
@@ -428,6 +435,7 @@ namespace Modix.Data.Test.Repositories
             designatedChannelMapping.DeleteActionId.ShouldNotBeNull();
 
             modixContext.DesignatedChannelMappings
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedChannelMappings.Entities
                     .Select(x => x.Id));
@@ -477,6 +485,7 @@ namespace Modix.Data.Test.Repositories
             result.ShouldBeFalse();
 
             modixContext.DesignatedChannelMappings
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedChannelMappings.Entities
                     .Select(x => x.Id));
@@ -485,6 +494,7 @@ namespace Modix.Data.Test.Repositories
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.ConfigurationActions
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => !(x.DesignatedChannelMappingId is null))

--- a/Modix.Data.Test/Repositories/DesignatedRoleMappingRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/DesignatedRoleMappingRepositoryTests.cs
@@ -187,7 +187,8 @@ namespace Modix.Data.Test.Repositories
 
             await Should.ThrowAsync<ArgumentNullException>(uut.CreateAsync(null));
 
-            modixContext.DesignatedRoleMappings.Select(x => x.Id).ShouldBe(DesignatedRoleMappings.Entities.Select(x => x.Id));
+            modixContext.DesignatedRoleMappings
+                .AsQueryable().Select(x => x.Id).ShouldBe(DesignatedRoleMappings.Entities.Select(x => x.Id));
             modixContext.DesignatedRoleMappings.EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -301,6 +302,7 @@ namespace Modix.Data.Test.Repositories
                 .Count());
 
             modixContext.DesignatedRoleMappings
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedRoleMappings.Entities.Select(x => x.Id));
 
@@ -354,6 +356,7 @@ namespace Modix.Data.Test.Repositories
             result.ShouldBe(0);
 
             modixContext.DesignatedRoleMappings
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedRoleMappings.Entities
                     .Select(x => x.Id));
@@ -362,6 +365,7 @@ namespace Modix.Data.Test.Repositories
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.ConfigurationActions
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => x.DesignatedRoleMappingId != null)
@@ -402,6 +406,7 @@ namespace Modix.Data.Test.Repositories
             designatedRoleMapping.DeleteActionId.ShouldNotBeNull();
 
             modixContext.DesignatedRoleMappings
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedRoleMappings.Entities
                     .Select(x => x.Id));
@@ -451,6 +456,7 @@ namespace Modix.Data.Test.Repositories
             result.ShouldBeFalse();
 
             modixContext.DesignatedRoleMappings
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedRoleMappings.Entities
                     .Select(x => x.Id));
@@ -459,6 +465,7 @@ namespace Modix.Data.Test.Repositories
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.ConfigurationActions
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => !(x.DesignatedRoleMappingId is null))

--- a/Modix.Data.Test/Repositories/DesignatedRoleMappingRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/DesignatedRoleMappingRepositoryTests.cs
@@ -333,11 +333,13 @@ namespace Modix.Data.Test.Repositories
                 });
 
             modixContext.DesignatedRoleMappings
+                .AsEnumerable()
                 .Where(x => !designatedRoleMappingIds.Contains(x.Id) || DesignatedRoleMappings.Entities
                     .Any(y => (y.Id == x.Id) && (x.DeleteActionId == null)))
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.ConfigurationActions
+                .AsEnumerable()
                 .Where(x => DesignatedRoleMappings.Entities
                     .Any(y => (y.DeleteActionId == x.Id) && designatedRoleMappingIds.Contains(y.Id)))
                 .EachShould(x => x.ShouldNotHaveChanged());

--- a/Modix.Data.Test/Repositories/GuildChannelRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/GuildChannelRepositoryTests.cs
@@ -121,6 +121,7 @@ namespace Modix.Data.Test.Repositories
             await Should.ThrowAsync<ArgumentNullException>(uut.CreateAsync(null));
 
             modixContext.GuildChannels
+                .AsQueryable()
                 .Select(x => x.ChannelId)
                 .ShouldBe(GuildChannels.Entities
                     .Select(x => x.ChannelId));
@@ -172,6 +173,7 @@ namespace Modix.Data.Test.Repositories
             await Should.ThrowAsync<InvalidOperationException>(uut.CreateAsync(data));
 
             modixContext.GuildChannels
+                .AsQueryable()
                 .Select(x => x.ChannelId)
                 .ShouldBe(GuildChannels.Entities
                     .Select(x => x.ChannelId));
@@ -196,6 +198,7 @@ namespace Modix.Data.Test.Repositories
                 await uut.TryUpdateAsync(1, null));
 
             modixContext.GuildChannels
+                .AsQueryable()
                 .Select(x => x.ChannelId)
                 .ShouldBe(GuildChannels.Entities
                     .Select(x => x.ChannelId));
@@ -233,6 +236,7 @@ namespace Modix.Data.Test.Repositories
                 guildChannel.Name.ShouldBe(mutatedData.Name);
 
                 modixContext.GuildChannels
+                .AsQueryable()
                     .Select(x => x.ChannelId)
                     .ShouldBe(GuildChannels.Entities
                         .Select(x => x.ChannelId));
@@ -261,6 +265,7 @@ namespace Modix.Data.Test.Repositories
                 .Invoke(Arg.Any<GuildChannelMutationData>());
 
             modixContext.GuildChannels
+                .AsQueryable()
                 .Select(x => x.ChannelId)
                 .ShouldBe(GuildChannels.Entities
                     .Select(x => x.ChannelId));

--- a/Modix.Data.Test/Repositories/GuildRoleRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/GuildRoleRepositoryTests.cs
@@ -104,6 +104,7 @@ namespace Modix.Data.Test.Repositories
             await Should.ThrowAsync<ArgumentNullException>(uut.CreateAsync(null));
 
             modixContext.GuildRoles
+                .AsQueryable()
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));
@@ -151,6 +152,7 @@ namespace Modix.Data.Test.Repositories
             await Should.ThrowAsync<InvalidOperationException>(uut.CreateAsync(data));
 
             modixContext.GuildRoles
+                .AsQueryable()
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));
@@ -175,6 +177,7 @@ namespace Modix.Data.Test.Repositories
                 await uut.TryUpdateAsync(1, null));
 
             modixContext.GuildRoles
+                .AsQueryable()
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));
@@ -214,6 +217,7 @@ namespace Modix.Data.Test.Repositories
             guildRole.Position.ShouldBe(mutatedData.Position);
 
             modixContext.GuildRoles
+                .AsQueryable()
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));
@@ -241,6 +245,7 @@ namespace Modix.Data.Test.Repositories
                 .Invoke(Arg.Any<GuildRoleMutationData>());
 
             modixContext.GuildRoles
+                .AsQueryable()
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));

--- a/Modix.Data.Test/Repositories/GuildUserRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/GuildUserRepositoryTests.cs
@@ -114,6 +114,7 @@ namespace Modix.Data.Test.Repositories
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.Users
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
@@ -168,6 +169,7 @@ namespace Modix.Data.Test.Repositories
             user.Discriminator.ShouldBe(data.Discriminator);
 
             modixContext.Users
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
@@ -198,6 +200,7 @@ namespace Modix.Data.Test.Repositories
             user.Username.ShouldBe(previousUser.Username);
 
             modixContext.Users
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
@@ -228,6 +231,7 @@ namespace Modix.Data.Test.Repositories
             user.Discriminator.ShouldBe(previousUser.Discriminator);
 
             modixContext.Users
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
@@ -284,6 +288,7 @@ namespace Modix.Data.Test.Repositories
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.Users
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
@@ -342,6 +347,7 @@ namespace Modix.Data.Test.Repositories
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.Users
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
@@ -399,6 +405,7 @@ namespace Modix.Data.Test.Repositories
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.Users
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
@@ -434,6 +441,7 @@ namespace Modix.Data.Test.Repositories
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             modixContext.Users
+                .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));

--- a/Modix.Data.Test/Repositories/TagRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/TagRepositoryTests.cs
@@ -190,7 +190,7 @@ namespace Modix.Data.Test.Repositories
 
             await Should.ThrowAsync<ArgumentNullException>(uut.CreateAsync(null));
 
-            modixContext.Tags.Select(x => x.Id).ShouldBe(Tags.Entities.Select(x => x.Id));
+            modixContext.Tags.AsQueryable().Select(x => x.Id).ShouldBe(Tags.Entities.Select(x => x.Id));
             modixContext.Tags.EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()

--- a/Modix.Data/DbSetExtensions.cs
+++ b/Modix.Data/DbSetExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Modix.Data
 {
@@ -17,6 +18,21 @@ namespace Modix.Data
         public static IQueryable<TEntity> Where<TEntity>(this Microsoft.EntityFrameworkCore.DbSet<TEntity> obj, System.Linq.Expressions.Expression<Func<TEntity, bool>> predicate) where TEntity : class
         {
             return System.Linq.Queryable.Where(obj, predicate);
+        }
+
+        public static IQueryable<bool> Select<TEntity>(this Microsoft.EntityFrameworkCore.DbSet<TEntity> obj, System.Linq.Expressions.Expression<Func<TEntity, bool>> selector) where TEntity : class
+        {
+            return System.Linq.Queryable.Select(obj, selector);
+        }
+
+        public static Task<TEntity> FirstOrDefaultAsync<TEntity>(this Microsoft.EntityFrameworkCore.DbSet<TEntity> obj, System.Linq.Expressions.Expression<Func<TEntity, bool>> predicate) where TEntity : class
+        {
+            return Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.FirstOrDefaultAsync(obj, predicate);
+        }
+
+        public static Task<TEntity> FirstOrDefaultAsync<TEntity>(this Microsoft.EntityFrameworkCore.DbSet<TEntity> obj) where TEntity : class
+        {
+            return Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.FirstOrDefaultAsync(obj);
         }
     }
 }

--- a/Modix.Data/DbSetExtensions.cs
+++ b/Modix.Data/DbSetExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Modix.Data
+{
+    // Unfortunately this is required as per https://github.com/aspnet/EntityFrameworkCore/issues/18124
+    // to fix ambiguous calls between EF and AsyncEnumerable in System.Interactive
+
+    public static class DbSetExtensions
+    {
+        public static IAsyncEnumerable<TEntity> AsAsyncEnumerable<TEntity>(this Microsoft.EntityFrameworkCore.DbSet<TEntity> obj) where TEntity : class
+        {
+            return Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.AsAsyncEnumerable(obj);
+        }
+
+        public static IQueryable<TEntity> Where<TEntity>(this Microsoft.EntityFrameworkCore.DbSet<TEntity> obj, System.Linq.Expressions.Expression<Func<TEntity, bool>> predicate) where TEntity : class
+        {
+            return System.Linq.Queryable.Where(obj, predicate);
+        }
+    }
+}

--- a/Modix.Data/ExpandableQueries/ExpandableQuery.cs
+++ b/Modix.Data/ExpandableQueries/ExpandableQuery.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Modix.Data.ExpandableQueries
 {
@@ -18,8 +20,10 @@ namespace Modix.Data.ExpandableQueries
         public IEnumerator<T> GetEnumerator()
             => _provider.Execute<IEnumerable<T>>(Expression).GetEnumerator();
 
-        IAsyncEnumerator<T> IAsyncEnumerable<T>.GetEnumerator()
-            => _provider.ExecuteAsync<T>(Expression).GetEnumerator();
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+#pragma warning disable EF1001 // Internal EF Core API usage.
+            => ((IAsyncQueryProvider)_provider).ExecuteAsync<IAsyncEnumerable<T>>(Expression).GetAsyncEnumerator();
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();

--- a/Modix.Data/ExpandableQueries/ExpandableQueryProvider.cs
+++ b/Modix.Data/ExpandableQueries/ExpandableQueryProvider.cs
@@ -43,15 +43,10 @@ namespace Modix.Data.ExpandableQueries
         public object Execute(Expression expression)
             => _provider.Execute(Visit(expression));
 
-        public IAsyncEnumerable<TResult> ExecuteAsync<TResult>(Expression expression)
-            => (_provider is IAsyncQueryProvider asyncProvider)
-                ? asyncProvider.ExecuteAsync<TResult>(Visit(expression))
-                : throw new InvalidOperationException("This query cannot be executed asynchronously");
-
-        public Task<TResult> ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
-            => (_provider is IAsyncQueryProvider asyncProvider)
-                ? asyncProvider.ExecuteAsync<TResult>(Visit(expression), cancellationToken)
-                : throw new InvalidOperationException("This query cannot be executed asynchronously");
+        TResult IAsyncQueryProvider.ExecuteAsync<TResult>(Expression expression, CancellationToken cancellationToken)
+#pragma warning disable EF1001 // Internal EF Core API usage.
+            => ((IAsyncQueryProvider)_provider).ExecuteAsync<TResult>(Visit(expression));
+#pragma warning restore EF1001 // Internal EF Core API usage.
 
         internal readonly IQueryProvider _provider;
 

--- a/Modix.Data/Models/Core/EphemeralUser.cs
+++ b/Modix.Data/Models/Core/EphemeralUser.cs
@@ -68,11 +68,11 @@ namespace Modix.Data.Models.Core
 
         public string BanReason { get; private set; }
 
-        public DateTimeOffset? PremiumSince => throw new NotImplementedException();
+        public DateTimeOffset? PremiumSince { get; private set; }
 
-        public IImmutableSet<ClientType> ActiveClients => throw new NotImplementedException();
+        public IImmutableSet<ClientType> ActiveClients { get; private set; }
 
-        public bool IsStreaming => throw new NotImplementedException();
+        public bool IsStreaming { get; private set; }
 
         public async Task AddRoleAsync(IRole role, RequestOptions options = null)
         {

--- a/Modix.Data/Models/Core/EphemeralUser.cs
+++ b/Modix.Data/Models/Core/EphemeralUser.cs
@@ -1,6 +1,7 @@
 ﻿using Discord;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 namespace Modix.Data.Models.Core
@@ -66,6 +67,12 @@ namespace Modix.Data.Models.Core
         public bool IsBanned { get; private set; }
 
         public string BanReason { get; private set; }
+
+        public DateTimeOffset? PremiumSince => throw new NotImplementedException();
+
+        public IImmutableSet<ClientType> ActiveClients => throw new NotImplementedException();
+
+        public bool IsStreaming => throw new NotImplementedException();
 
         public async Task AddRoleAsync(IRole role, RequestOptions options = null)
         {

--- a/Modix.Data/Models/Promotions/PromotionCampaignSummary.cs
+++ b/Modix.Data/Models/Promotions/PromotionCampaignSummary.cs
@@ -52,7 +52,12 @@ namespace Modix.Data.Models.Promotions
         /// A summarization of <see cref="PromotionCampaignEntity.Comments"/>,
         /// summarizing the total number of comments, grouped by <see cref="PromotionCommentEntity.Sentiment"/>.
         /// </summary>
-        public IReadOnlyDictionary<PromotionSentiment, int> CommentCounts { get; set; }
+        public IReadOnlyDictionary<PromotionSentiment, int> CommentCounts => SentimentsGiven
+            .GroupBy(x => x)
+            .Select(x => new { x.Key, Count = x.Count() })
+            .ToDictionary(x => x.Key, x => x.Count);
+
+        public List<PromotionSentiment> SentimentsGiven { get; set; }
 
         [ExpansionExpression]
         internal static Expression<Func<PromotionCampaignEntity, PromotionCampaignSummary>> FromEntityProjection
@@ -67,11 +72,12 @@ namespace Modix.Data.Models.Promotions
                 CloseAction = (entity.CloseAction == null)
                     ? null
                     : entity.CloseAction.Project(PromotionActionBrief.FromEntityProjection),
-                CommentCounts = entity.Comments
+                SentimentsGiven = entity.Comments
                     .Where(x => x.ModifyActionId == null)
-                    .GroupBy(x => x.Sentiment)
-                    .Select(x => new { x.Key, Count = x.Count() })
-                    .ToDictionary(x => x.Key, x => x.Count)
+                    .Select(x => x.Sentiment)
+                    .ToList(),
             };
+
+
     }
 }

--- a/Modix.Data/Modix.Data.csproj
+++ b/Modix.Data/Modix.Data.csproj
@@ -1,12 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.4" />
-    <PackageReference Include="Nito.AsyncEx.Coordination" Version="1.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
+    <PackageReference Include="Discord.Net" Version="2.2.0-dev-20191024.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
   </ItemGroup>
 </Project>

--- a/Modix.Data/Modix.Data.csproj
+++ b/Modix.Data/Modix.Data.csproj
@@ -4,13 +4,13 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="2.2.0-dev-20191024.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0">
+    <PackageReference Include="Discord.Net" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 </Project>

--- a/Modix.Data/ModixContext.cs
+++ b/Modix.Data/ModixContext.cs
@@ -75,11 +75,11 @@ namespace Modix.Data
             foreach(var method in onModelCreatingMethods)
                 method.Invoke(null, new [] { modelBuilder });
 
-            modelBuilder.Query<PerUserMessageCount>();
-            modelBuilder.Query<GuildUserParticipationStatistics>();
-            modelBuilder.Query<SingleEmojiStatsDto>();
-            modelBuilder.Query<EmojiStatsDto>();
-            modelBuilder.Query<GuildEmojiStats>();
+            modelBuilder.Entity<PerUserMessageCount>().HasNoKey();
+            modelBuilder.Entity<GuildUserParticipationStatistics>().HasNoKey();
+            modelBuilder.Entity<SingleEmojiStatsDto>().HasNoKey();
+            modelBuilder.Entity<EmojiStatsDto>().HasNoKey();
+            modelBuilder.Entity<GuildEmojiStats>().HasNoKey();
         }
     }
 }

--- a/Modix.Data/Repositories/EmojiRepository.cs
+++ b/Modix.Data/Repositories/EmojiRepository.cs
@@ -225,7 +225,8 @@ namespace Modix.Data.Repositories
             var query = GetQuery();
             var parameters = GetParameters();
 
-            var stats = await ModixContext.Query<SingleEmojiStatsDto>()
+            var stats = await ModixContext
+                .Query<SingleEmojiStatsDto>()
                 .AsNoTracking()
                 .FromSql(query, parameters)
                 .FirstOrDefaultAsync();

--- a/Modix.Data/Repositories/EmojiRepository.cs
+++ b/Modix.Data/Repositories/EmojiRepository.cs
@@ -226,9 +226,9 @@ namespace Modix.Data.Repositories
             var parameters = GetParameters();
 
             var stats = await ModixContext
-                .Query<SingleEmojiStatsDto>()
+                .Set<SingleEmojiStatsDto>()
+                .FromSqlRaw(query, parameters)
                 .AsNoTracking()
-                .FromSql(query, parameters)
                 .FirstOrDefaultAsync();
 
             return SingleEmojiUsageStatistics.FromDto(stats ?? new SingleEmojiStatsDto());
@@ -288,9 +288,10 @@ namespace Modix.Data.Repositories
             var parameters = GetParameters();
             var query = GetQuery();
 
-            var stats = await ModixContext.Query<EmojiStatsDto>()
+            var stats = await ModixContext
+                .Set<EmojiStatsDto>()
+                .FromSqlRaw(query, parameters)
                 .AsNoTracking()
-                .FromSql(query, parameters)
                 .ToArrayAsync();
 
             return stats.Select(x => EmojiUsageStatistics.FromDto(x ?? new EmojiStatsDto())).ToArray();
@@ -354,9 +355,10 @@ namespace Modix.Data.Repositories
             var parameters = GetParameters();
             var query = GetQuery();
 
-            var stats = await ModixContext.Query<GuildEmojiStats>()
+            var stats = await ModixContext
+                .Set<GuildEmojiStats>()
+                .FromSqlRaw(query, parameters)
                 .AsNoTracking()
-                .FromSql(query, parameters)
                 .FirstOrDefaultAsync();
 
             return stats;

--- a/Modix.Data/Repositories/GuildUserRepository.cs
+++ b/Modix.Data/Repositories/GuildUserRepository.cs
@@ -79,7 +79,9 @@ namespace Modix.Data.Repositories
 
             var guildDataEntity = data.ToGuildDataEntity();
 
-            guildDataEntity.User = await ModixContext.Users.FirstOrDefaultAsync(x => x.Id == data.UserId)
+            guildDataEntity.User = await ModixContext
+                .Users
+                .FirstOrDefaultAsync(x => x.Id == data.UserId)
                 ?? data.ToUserEntity();
 
             await ModixContext.GuildUsers.AddAsync(guildDataEntity);

--- a/Modix.Data/Repositories/InfractionRepository.cs
+++ b/Modix.Data/Repositories/InfractionRepository.cs
@@ -203,16 +203,20 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<IDictionary<InfractionType, int>> GetInfractionCountsAsync(InfractionSearchCriteria searchCriteria)
         {
-            var result = await ModixContext.Infractions.AsNoTracking()
+            // TODO: Group by here is not supported server side right now, should be refactored
+            var infractions = await ModixContext.Infractions
+                .AsNoTracking()
                 .FilterBy(searchCriteria)
-                .GroupBy(x => x.Type)
                 .ToArrayAsync();
+
+            var infractionGrouping = infractions
+                .GroupBy(x => x.Type);
 
             //Initialize the returned dictionary so we always have all infraction types present
             var ret = Enum.GetValues(typeof(InfractionType)).Cast<InfractionType>()
                 .ToDictionary(x => x, _ => 0);
 
-            foreach (var group in result)
+            foreach (var group in infractionGrouping)
             {
                 ret[group.Key] = group.Count();
             }

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -195,12 +195,13 @@ namespace Modix.Data.Repositories
             var earliestDateTime = DateTimeOffset.UtcNow - timespan;
             var query = GetQuery();
 
-            var counts = await ModixContext.Query<PerUserMessageCount>()
-                .AsNoTracking()
-                .FromSql(query,
+            var counts = await ModixContext
+                .Set<PerUserMessageCount>()
+                .FromSqlRaw(query,
                     new NpgsqlParameter(":GuildId", NpgsqlDbType.Bigint) { Value = unchecked((long)guildId) },
                     new NpgsqlParameter(":UserId", NpgsqlDbType.Bigint) { Value = unchecked((long)userId) },
                     new NpgsqlParameter(":StartTimestamp", NpgsqlDbType.TimestampTz) { Value = earliestDateTime })
+                .AsNoTracking()
                 .ToArrayAsync();
 
             return counts;
@@ -249,9 +250,9 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<GuildUserParticipationStatistics> GetGuildUserParticipationStatistics(ulong guildId, ulong userId)
         {
-            var stats = await ModixContext.Query<GuildUserParticipationStatistics>()
-                .AsNoTracking()
-                .FromSql(
+            var stats = await ModixContext
+                .Set<GuildUserParticipationStatistics>()
+                .FromSqlRaw(
                     @"with msgs as (
                         select msg.""AuthorId"", msg.""Id"" as ""MessageId"", msg.""GuildId""
                         from ""Messages"" as msg
@@ -285,6 +286,7 @@ namespace Modix.Data.Repositories
                     where ""UserId"" = cast(:UserId as numeric(20))",
                     new NpgsqlParameter(":GuildId", guildId.ToString()),
                     new NpgsqlParameter(":UserId", userId.ToString()))
+                .AsNoTracking()
                 .OrderByDescending(x => x.AveragePerDay)
                 .FirstOrDefaultAsync() ?? new GuildUserParticipationStatistics();
 

--- a/Modix.Services.Test/Modix.Services.Test.csproj
+++ b/Modix.Services.Test/Modix.Services.Test.csproj
@@ -7,13 +7,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="Moq" Version="4.13.1" />
-        <PackageReference Include="Moq.AutoMock" Version="1.2.0.120" />
-        <PackageReference Include="NUnit" Version="3.11.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-        <PackageReference Include="Shouldly" Version="3.0.2" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="Moq.AutoMock" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit3TestAdapter"/>
+        <PackageReference Include="Shouldly"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Modix.Services.Test/Modix.Services.Test.csproj
+++ b/Modix.Services.Test/Modix.Services.Test.csproj
@@ -3,12 +3,13 @@
     <PropertyGroup>
         <IsPackable>false</IsPackable>
       <IsPublishable>false</IsPublishable>
+      <TargetFramework>netcoreapp3.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="Moq" Version="4.10.1" />
+        <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="Moq.AutoMock" Version="1.2.0.120" />
         <PackageReference Include="NUnit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/Modix.Services/Core/UserService.cs
+++ b/Modix.Services/Core/UserService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -48,7 +49,7 @@ namespace Modix.Services.Core
         /// A <see cref="Task"/> that completes when the operation completes,
         /// containing all user information that was found for the user.
         /// </returns>
-        Task<EphemeralUser> GetUserInformationAsync(ulong guildId, ulong userId);
+        Task<EphemeralUser?> GetUserInformationAsync(ulong guildId, ulong userId);
 
         /// <summary>
         /// Retrieves the user, if any, associated with the given user ID.
@@ -137,7 +138,7 @@ namespace Modix.Services.Core
         }
 
         /// <inheritdoc />
-        public async Task<EphemeralUser> GetUserInformationAsync(ulong guildId, ulong userId)
+        public async Task<EphemeralUser?> GetUserInformationAsync(ulong guildId, ulong userId)
         {
             if (userId == 0)
                 return null;

--- a/Modix.Services/Images/ImageService.cs
+++ b/Modix.Services/Images/ImageService.cs
@@ -90,7 +90,8 @@ namespace Modix.Services.Images
 
             var mostCommonPaletteColor = colorTree.GetPalette().OrderByDescending(x => x.Weight * x.Color.GetSaturation()).FirstOrDefault().Color;
 
-            return (Color)mostCommonPaletteColor;
+            // TODO Investigate why we cannot cast here anymore (return (Color)mostCommonPaletteColor;)
+            return new Color((uint)mostCommonPaletteColor.ToArgb() << 8 >> 8);
         }
 
         private object GetKey(Uri uri) => new { Target = "DominantColor", uri.AbsoluteUri };

--- a/Modix.Services/Modix.Services.csproj
+++ b/Modix.Services/Modix.Services.csproj
@@ -3,16 +3,16 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AsyncEvent" Version="0.2.0" />
-    <PackageReference Include="Discord.Net" Version="2.2.0-dev-20191024.6" />
-    <PackageReference Include="DogStatsD-CSharp-Client" Version="3.3.0" />
-    <PackageReference Include="Humanizer.Core" Version="2.5.16" />
-    <PackageReference Include="Kitsu" Version="1.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
+    <PackageReference Include="AsyncEvent" />
+    <PackageReference Include="Discord.Net" />
+    <PackageReference Include="DogStatsD-CSharp-Client" />
+    <PackageReference Include="Humanizer.Core" />
+    <PackageReference Include="Kitsu" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="SixLabors.ImageSharp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Discord.Net.Abstractions\Discord.Net.Abstractions.csproj" />

--- a/Modix.Services/Modix.Services.csproj
+++ b/Modix.Services/Modix.Services.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncEvent" Version="0.2.0" />
-    <PackageReference Include="Discord.Net" Version="2.1.1" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="3.3.0" />
     <PackageReference Include="Humanizer.Core" Version="2.5.16" />
     <PackageReference Include="Kitsu" Version="1.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Serilog" Version="2.8.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
   </ItemGroup>

--- a/Modix.Services/Modix.Services.csproj
+++ b/Modix.Services/Modix.Services.csproj
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncEvent" Version="0.2.0" />
+    <PackageReference Include="Discord.Net" Version="2.2.0-dev-20191024.6" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="3.3.0" />
     <PackageReference Include="Humanizer.Core" Version="2.5.16" />
     <PackageReference Include="Kitsu" Version="1.4.1" />

--- a/Modix/Configuration/StaticFilesConfiguration.cs
+++ b/Modix/Configuration/StaticFilesConfiguration.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Modix.Configuration
@@ -9,9 +10,9 @@ namespace Modix.Configuration
     public class StaticFilesConfiguration : IConfigureOptions<StaticFileOptions>
     {
         private readonly IAntiforgery antiforgery;
-        private readonly IHostingEnvironment _env;
+        private readonly IWebHostEnvironment _env;
 
-        public StaticFilesConfiguration(IAntiforgery antiforgery, IHostingEnvironment env)
+        public StaticFilesConfiguration(IAntiforgery antiforgery, IWebHostEnvironment env)
         {
             this.antiforgery = antiforgery;
             _env = env;

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using Discord.Rest;
 using Discord.WebSocket;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 using Modix;
@@ -149,7 +150,7 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
-        public static IServiceCollection AddStatsD(this IServiceCollection services, IHostingEnvironment environment, IConfiguration configuration)
+        public static IServiceCollection AddStatsD(this IServiceCollection services, IHostEnvironment environment, IConfiguration configuration)
         {
             var cfg = new StatsdConfig { Prefix = "modix" };
 

--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OAuth.Discord" Version="3.0.0" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="3.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />

--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -12,6 +12,7 @@
     <NpmBuild Condition=" '$(Configuration)' == 'Debug' ">build-dev</NpmBuild>
     <NpmBuild Condition=" '$(NpmBuild)' == '' ">build</NpmBuild>
     <DevServerRunning>false</DevServerRunning>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,14 +20,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.Discord" Version="2.0.1" />
-    <PackageReference Include="Discord.Net.WebSocket" Version="2.1.1" />
+    <PackageReference Include="AspNet.Security.OAuth.Discord" Version="3.0.0" />
     <PackageReference Include="DogStatsD-CSharp-Client" Version="3.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.2.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Sentry" Version="2.4.1" />

--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -20,16 +20,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.Discord" Version="3.0.0" />
-    <PackageReference Include="DogStatsD-CSharp-Client" Version="3.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
-    <PackageReference Include="Serilog.Sinks.Sentry" Version="2.4.1" />
+    <PackageReference Include="AspNet.Security.OAuth.Discord" />
+    <PackageReference Include="DogStatsD-CSharp-Client" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions"  />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.RollingFile" />
+    <PackageReference Include="Serilog.Sinks.Sentry" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Modix/Startup.cs
+++ b/Modix/Startup.cs
@@ -68,8 +68,8 @@ namespace Modix
                 .AddModix();
 
             services.AddMvc()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_1)
-                .AddJsonOptions(options =>
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
+                .AddNewtonsoftJson(options =>
                 {
                     options.SerializerSettings.Converters.Add(new StringEnumConverter());
                     options.SerializerSettings.Converters.Add(new StringULongConverter());

--- a/Modix/Startup.cs
+++ b/Modix/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Modix.Auth;
@@ -25,12 +26,12 @@ namespace Modix
     public class Startup
     {
         private readonly IConfiguration _configuration;
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IWebHostEnvironment _webHostEnvironment;
 
-        public Startup(IConfiguration configuration, IHostingEnvironment hostingEnvironment)
+        public Startup(IConfiguration configuration, IWebHostEnvironment webHostEnvironment)
         {
             _configuration = configuration;
-            _hostingEnvironment = hostingEnvironment;
+            _webHostEnvironment = webHostEnvironment;
             Log.Information("Configuration loaded. ASP.NET Startup is a go.");
         }
 
@@ -67,7 +68,7 @@ namespace Modix
                 .AddModixHttpClients()
                 .AddModix();
 
-            services.AddMvc()
+            services.AddMvc(d => d.EnableEndpointRouting = false)
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddNewtonsoftJson(options =>
                 {
@@ -75,11 +76,11 @@ namespace Modix
                     options.SerializerSettings.Converters.Add(new StringULongConverter());
                 });
 
-            services.AddStatsD(_hostingEnvironment, _configuration);
+            services.AddStatsD(_webHostEnvironment, _configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, CodePasteService codePasteService)
+        public void Configure(IApplicationBuilder app, IHostEnvironment env, CodePasteService codePasteService)
         {
             var options = new ForwardedHeadersOptions
             {

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="Discord.Net Nightlies" value="https://www.myget.org/F/discord-net/api/v3/index.json" />
+    </packageSources>
+</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="Discord.Net Nightlies" value="https://www.myget.org/F/discord-net/api/v3/index.json" />
-    </packageSources>
-</configuration>


### PR DESCRIPTION
Starting port to .NET Core 3.0. **Do not merge. This does not yet build and hasn't been run either.**

This introduces a nightly/preview build of Discord.NET - as Core 3.0 support was recently fixed for `IAsyncEnumerable` as per https://github.com/discord-net/Discord.Net/pull/1382.

This is not on the stable Nuget channel yet - packages are pulled from the reintroduced `NuGet.config`.

Several new members of Discord.NET have not been implemented in our Discord.NET abstraction project, as I wanted to get the project to build first.

This also introduces package updates for EntityFramework, which will mean runtime exceptions in a couple of areas.