### PR TITLE
Fix invite purging behavior for vanity links to the current guild

### DIFF
--- a/Modix.Services/Moderation/InvitePurgingBehavior.cs
+++ b/Modix.Services/Moderation/InvitePurgingBehavior.cs
@@ -94,33 +94,23 @@ namespace Modix.Services.Moderation
             if (await DesignatedChannelService.ChannelHasDesignationAsync(channel.Guild, channel, DesignatedChannelType.Unmoderated))
                 return;
 
-            if (await AuthorizationService.HasClaimsAsync(author, AuthorizationClaim.PostInviteLink))
-            {
-                Log.Debug("Message {MessageId} was skipped because the author {Author} has the PostInviteLink claim",
-                    message.Id, message.Author.Id);
-                return;
-            }
+            //if (await AuthorizationService.HasClaimsAsync(author, AuthorizationClaim.PostInviteLink))
+            //{
+            //    Log.Debug("Message {MessageId} was skipped because the author {Author} has the PostInviteLink claim",
+            //        message.Id, message.Author.Id);
+            //    return;
+            //}
 
-            var actualInvites = new List<IInvite>(matches.Count);
+            var invites = new List<IInvite>(matches.Count);
 
             foreach (var code in matches.Select(x => x.Groups["Code"].Value))
             {
                 var invite = await DiscordClient.GetInviteAsync(code);
-
-                if (invite is { })
-                {
-                    actualInvites.Add(invite);
-                }
-            }
-
-            if (actualInvites.Count == 0)
-            {
-                Log.Debug("Message {MessageId} was skipped because it didn't contain any real invites", message.Id);
-                return;
+                invites.Add(invite);
             }
 
             // Allow invites to the guild in which the message was posted
-            if (actualInvites.All(x => x.GuildId == author.GuildId))
+            if (invites.All(x => x?.GuildId == author.GuildId))
             {
                 Log.Debug("Message {MessageId} was skipped because the invite was to this server", message.Id);
                 return;

--- a/Modix.Services/Moderation/InvitePurgingBehavior.cs
+++ b/Modix.Services/Moderation/InvitePurgingBehavior.cs
@@ -94,12 +94,12 @@ namespace Modix.Services.Moderation
             if (await DesignatedChannelService.ChannelHasDesignationAsync(channel.Guild, channel, DesignatedChannelType.Unmoderated))
                 return;
 
-            //if (await AuthorizationService.HasClaimsAsync(author, AuthorizationClaim.PostInviteLink))
-            //{
-            //    Log.Debug("Message {MessageId} was skipped because the author {Author} has the PostInviteLink claim",
-            //        message.Id, message.Author.Id);
-            //    return;
-            //}
+            if (await AuthorizationService.HasClaimsAsync(author, AuthorizationClaim.PostInviteLink))
+            {
+                Log.Debug("Message {MessageId} was skipped because the author {Author} has the PostInviteLink claim",
+                    message.Id, message.Author.Id);
+                return;
+            }
 
             var invites = new List<IInvite>(matches.Count);
 


### PR DESCRIPTION
Uses the Discord client to determine whether any suspected invites are real and, if so, whether they're to the current guild or to an external guild.

~~If the message only contains fake invites or invites to the current guild, don't purge the message.~~
Updated to disallow fake invites. Only invites that we can verify belong to the current guild are allowed.