### PR TITLE
Give MODiX the ability to love

### DIFF
--- a/Modix.Services.Test/Modix.Services.Test.csproj
+++ b/Modix.Services.Test/Modix.Services.Test.csproj
@@ -12,8 +12,8 @@
         <PackageReference Include="Moq" />
         <PackageReference Include="Moq.AutoMock" />
         <PackageReference Include="NUnit" />
-        <PackageReference Include="NUnit3TestAdapter"/>
-        <PackageReference Include="Shouldly"/>
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="Shouldly" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Modix.Services.Test/UtilityTests/EnumerableExtensionsTests.cs
+++ b/Modix.Services.Test/UtilityTests/EnumerableExtensionsTests.cs
@@ -1,0 +1,52 @@
+﻿using Modix.Services.Utilities;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace Modix.Services.Test.UtilityTests
+{
+    [TestFixture]
+    public class EnumerableExtensionsTests
+    {
+        [Test]
+        public void SkipLast_GivenAlwaysFalsePredicate_ReturnsEntireEnumerable()
+        {
+            var enumerable = new[] { 1, 2, 3, 4, 5 };
+
+            var result = enumerable.SkipLast(_ => false);
+
+            result.ShouldBe(enumerable);
+        }
+
+        [Test]
+        public void SkipLast_GivenAlwaysTruePredicate_ReturnsEmptyEnumerable()
+        {
+            var enumerable = new[] { 1, 2, 3, 4, 5 };
+
+            var result = enumerable.SkipLast(_ => true);
+
+            result.ShouldBeEmpty();
+        }
+
+        [Test]
+        public void SkipLast_GivenMatchingPredicate_ReturnsEnumerableWithoutTrailingMatches()
+        {
+            var enumerable = new[] { 1, 2, 3, 4, 5, 2, 4, 6 };
+
+            var result = enumerable.SkipLast(x => x % 2 == 0);
+
+            result.ShouldBe(new[] { 1, 2, 3, 4, 5 });
+        }
+
+        [Test]
+        public void SkipLast_GivenNonmatchingPredicate_ReturnsEntireEnumerable()
+        {
+            var enumerable = new[] { 1, 2, 3, 4, 5, 2, 4, 6 };
+
+            var result = enumerable.SkipLast(x => x % 2 != 0);
+
+            result.ShouldBe(enumerable);
+        }
+    }
+}

--- a/Modix.Services/Utilities/EmojiUtilities.cs
+++ b/Modix.Services/Utilities/EmojiUtilities.cs
@@ -51,7 +51,7 @@ namespace Modix.Services.Utilities
                 var withoutTrailingVariantSelectors = runes.SkipLast(x => IsVariantSelector(x));
                 var hexValues = string.Join('-', withoutTrailingVariantSelectors.Select(x => x.Value.ToString("x")));
 
-                return $"{EmojiLink}{string.Join('-', hexValues)}.png";
+                return $"{EmojiLink}{hexValues}.png";
             }
 
             static bool IsVariantSelector(Rune rune)

--- a/Modix.Services/Utilities/EmojiUtilities.cs
+++ b/Modix.Services/Utilities/EmojiUtilities.cs
@@ -1,10 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
-using Discord;
+﻿using Discord;
 using Discord.WebSocket;
+
 using Modix.Data.Models.Emoji;
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Modix.Services.Utilities
 {
@@ -44,23 +46,17 @@ namespace Modix.Services.Utilities
             else
             {
                 const string EmojiLink = "https://raw.githubusercontent.com/twitter/twemoji/master/assets/72x72/";
-                var hexValues = new List<string>();
 
-                for (var i = 0; i < emoji.Length; i++)
-                {
-                    var codepoint = char.ConvertToUtf32(emoji, i);
-                    hexValues.Add(codepoint.ToString("x"));
-
-                    // ConvertToUtf32() might have parsed an extra character as some characters are combinations of two 16-bit characters
-                    // Which start at 0x00d800 and end at 0x00dfff (Called surrogate low and surrogate high)
-                    // If the character is in this span, we have already essentially parsed the next index of the string as well.
-                    // Therefore we make sure to skip the next one.
-                    if (char.IsSurrogate(emoji, i))
-                        i++;
-                }
+                var runes = emoji.EnumerateRunes();
+                var withoutTrailingVariantSelectors = runes.SkipLast(x => IsVariantSelector(x));
+                var hexValues = string.Join('-', withoutTrailingVariantSelectors.Select(x => x.Value.ToString("x")));
 
                 return $"{EmojiLink}{string.Join('-', hexValues)}.png";
             }
+
+            static bool IsVariantSelector(Rune rune)
+                => rune.Value == 0xfe0e
+                || rune.Value == 0xfe0f;
         }
 
         // https://stackoverflow.com/a/48148218/1896401


### PR DESCRIPTION
`!jumbo ❤️` stopped working, because Discord started sending a [variation selector](https://en.wikipedia.org/wiki/Variation_Selectors_(Unicode_block)) (`0xfe0f`) after the heart emoji.

This PR adds logic to ignore any trailing variation selectors when generating the emoji URL. (Internal variation selectors cannot be ignored. For example, 🏳‍🌈 needs to generate the hex string `1f3f3-fe0f-200d-1f308`.)

This PR also takes the opportunity to update the codepoint logic to use the new `Rune` type that was added in .NET Core 3.0.