### PR TITLE
Renamed Marker Role Manager to Topic Roles

### DIFF
--- a/Modix.Bot/Modules/MarkerRoleModule.cs
+++ b/Modix.Bot/Modules/MarkerRoleModule.cs
@@ -16,9 +16,9 @@ namespace Modix.Modules
 {
     [Group("pingrole")]
     [Alias("pingroles")]
-    [Name("Marker Role Manager")]
-    [Summary("Provides functionality for maintaining and registering or unregistering from pingable roles.")]
-    [HelpTags("marker", "pingroles", "pingable")]
+    [Name("Topic Roles")]
+    [Summary("Provides functionality for maintaining and registering or unregistering topic roles.")]
+    [HelpTags("marker", "pingroles", "pingable", "topicroles")]
     public class MarkerRoleModule : ModuleBase
     {
         private readonly IDesignatedRoleService _designatedRoleService;


### PR DESCRIPTION
Discussed changing the name of this module with @jrusbatch. I had a tough time finding this module in the UI when searching for what I later learned are called _pingroles_. We thought that calling them _Topic Roles_ would lead to better discoverability of the command.