### PR TITLE
Fix #615 where punctuations break inline tags.

### DIFF
--- a/Modix.Services/Tags/TagInlineParsingHandler.cs
+++ b/Modix.Services/Tags/TagInlineParsingHandler.cs
@@ -14,7 +14,7 @@ namespace Modix.Services.Tags
 {
     public class TagInlineParsingHandler : INotificationHandler<MessageReceivedNotification>
     {
-        private static readonly Regex _inlineTagRegex = new Regex(@"\$(\S+)\s?");
+        private static readonly Regex _inlineTagRegex = new Regex(@"\$(\S+)\b");
 
         public DiscordSocketClient DiscordClient { get; }
         public IAuthorizationService AuthorizationService { get; }


### PR DESCRIPTION
This just uses the `\b` to match a word boundary. This allows you to still use punctuation inside of the inline tag, as long as it's in the middle. "Did you get the `$foo.bar`?"