### PR TITLE
Improve the color-retrieval logic in !info

### DIFF
--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -115,8 +115,6 @@ namespace Modix.Modules
             var moderationRead = await _authorizationService.HasClaimsAsync(Context.User as IGuildUser, AuthorizationClaim.ModerationRead);
             var promotions = await _promotionsService.GetPromotionsForUserAsync(Context.Guild.Id, userId);
 
-            embedBuilder.WithColor(await colorTask);
-
             if (userInfo.IsBanned)
             {
                 builder.AppendLine("Status: **Banned** \\🔨");
@@ -160,6 +158,8 @@ namespace Modix.Modules
             }
 
             embedBuilder.Description = builder.ToString();
+
+            embedBuilder.WithColor(await colorTask);
 
             timer.Stop();
             embedBuilder.WithFooter(footer => footer.Text = $"Completed after {timer.ElapsedMilliseconds} ms");

--- a/Modix.Services/CodePaste/CodePasteService.cs
+++ b/Modix.Services/CodePaste/CodePasteService.cs
@@ -39,7 +39,7 @@ namespace Modix.Services.CodePaste
             var content = FormatUtilities.BuildContent(code);
             HttpResponseMessage response;
 
-            var client = _httpClientFactory.CreateClient(nameof(CodePasteService));
+            var client = _httpClientFactory.CreateClient(HttpClientNames.TimeoutFiveSeconds);
 
             try
             {
@@ -61,7 +61,7 @@ namespace Modix.Services.CodePaste
             var pasteKey = JObject.Parse(urlResponse)["key"].Value<string>();
 
             var domain = usingFallback ? FallbackApiReferenceUrl : ApiReferenceUrl;
-            return $"{domain}{pasteKey}.{language ?? (FormatUtilities.GetCodeLanguage(code) ?? "cs")}";
+            return $"{domain}{pasteKey}.{language ?? FormatUtilities.GetCodeLanguage(code) ?? "cs"}";
         }
 
         /// <summary>

--- a/Modix.Services/Images/ImageService.cs
+++ b/Modix.Services/Images/ImageService.cs
@@ -8,6 +8,9 @@ using Discord;
 using Microsoft.Extensions.Caching.Memory;
 
 using Modix.Services.Images.ColorQuantization;
+using Modix.Services.Utilities;
+
+using Serilog;
 
 namespace Modix.Services.Images
 {
@@ -47,17 +50,25 @@ namespace Modix.Services.Images
         /// <inheritdoc />
         public async ValueTask<Color> GetDominantColorAsync(Uri location)
         {
-            var key = GetKey(location);
-
-            if (!_cache.TryGetValue(key, out Color color))
+            try
             {
-                var imageBytes = await _httpClientFactory.CreateClient().GetByteArrayAsync(location);
-                color = GetDominantColor(imageBytes.AsSpan());
+                var key = GetKey(location);
 
-                _cache.Set(key, color, TimeSpan.FromDays(7));
+                if (!_cache.TryGetValue(key, out Color color))
+                {
+                    var imageBytes = await _httpClientFactory.CreateClient(HttpClientNames.TimeoutFiveSeconds).GetByteArrayAsync(location);
+                    color = GetDominantColor(imageBytes.AsSpan());
+
+                    _cache.Set(key, color, TimeSpan.FromDays(7));
+                }
+
+                return color;
             }
-
-            return color;
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An error occurred while attempting to determine the dominant color of an image.");
+                return Color.Default;
+            }
         }
 
         /// <inheritdoc />

--- a/Modix.Services/StackExchange/StackExchangeService.cs
+++ b/Modix.Services/StackExchange/StackExchangeService.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Modix.Services.Utilities;
+using Newtonsoft.Json;
 using System;
 using System.Net;
 using System.Net.Http;
@@ -28,7 +29,7 @@ namespace Modix.Services.StackExchange
             tags = Uri.EscapeDataString(tags);
             var query = _apiReferenceUrl += $"&site={site}&tags={tags}&q={phrase}";
 
-            var client = HttpClientFactory.CreateClient(nameof(StackExchangeService));
+            var client = HttpClientFactory.CreateClient(HttpClientNames.AutomaticGZipDecompression);
 
             var response = await client.GetAsync(query);
 

--- a/Modix.Services/Utilities/HttpClientNames.cs
+++ b/Modix.Services/Utilities/HttpClientNames.cs
@@ -1,0 +1,12 @@
+﻿namespace Modix.Services.Utilities
+{
+    /// <summary>
+    /// Provides name values for each named HttpClient that is configured in the application.
+    /// </summary>
+    public static class HttpClientNames
+    {
+        public static string AutomaticGZipDecompression { get; } = nameof(AutomaticGZipDecompression);
+
+        public static string TimeoutFiveSeconds { get; } = nameof(TimeoutFiveSeconds);
+    }
+}

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ using Modix.Services.Quote;
 using Modix.Services.StackExchange;
 using Modix.Services.Starboard;
 using Modix.Services.Tags;
+using Modix.Services.Utilities;
 using Modix.Services.Wikipedia;
 using StatsdClient;
 
@@ -51,13 +52,13 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.AddHttpClient();
 
-            services.AddHttpClient(nameof(CodePasteService))
+            services.AddHttpClient(HttpClientNames.TimeoutFiveSeconds)
                 .ConfigureHttpClient(client =>
                 {
                     client.Timeout = TimeSpan.FromSeconds(5);
                 });
 
-            services.AddHttpClient(nameof(StackExchangeService))
+            services.AddHttpClient(HttpClientNames.AutomaticGZipDecompression)
                 .ConfigurePrimaryHttpMessageHandler(() =>
                 new HttpClientHandler()
                 {


### PR DESCRIPTION
Gracefully handles errors encountered when retrieving the user's profile picture by wrapping everything in a try-catch. This should fix issues like what we experienced this week with trying to perform !info on John. Logs the error and returns a default color (black) if any exceptions occurred.

Uses an `HttpClient` with five second timeout so that the color retrieval doesn't hold up !info whenever Discord is having latency issues.

Moves awaiting the color task to later in !info execution, so that it can spend most of its time in the background while we're retrieving message counts, etc. from the database.