### PR TITLE
Allow either the requesting or requested user to remove the info embed

### DIFF
--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -82,7 +82,6 @@ namespace Modix.Modules
             var timer = Stopwatch.StartNew();
 
             var userInfo = await _userService.GetUserInformationAsync(Context.Guild.Id, userId);
-            var requesterInfo = await _userService.GetUserInformationAsync(Context.Guild.Id, Context.Guild.Id);
 
             if (userInfo == null)
             {
@@ -92,7 +91,7 @@ namespace Modix.Modules
                     .WithDescription("Sorry, we don't have any data for that user - and we couldn't find any, either.")
                     .AddField("User Id", userId);
                 await _autoRemoveMessageService.RegisterRemovableMessageAsync(
-                    requesterInfo,
+                    Context.User,
                     embed,
                     async (embedBuilder) => await ReplyAsync(embed: embedBuilder.Build()));
 
@@ -173,7 +172,7 @@ namespace Modix.Modules
             embedBuilder.WithFooter(footer => footer.Text = $"Completed after {timer.ElapsedMilliseconds} ms");
 
             await _autoRemoveMessageService.RegisterRemovableMessageAsync(
-                userInfo == requesterInfo ? new[] { userInfo } : new[] { userInfo, requesterInfo },
+                userInfo.Id == Context.User.Id ? new[] { userInfo } : new[] { userInfo, Context.User },
                 embedBuilder,
                 async (embedBuilder) => await ReplyAsync(embed: embedBuilder.Build()));
         }

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -17,6 +17,7 @@ using Modix.Data.Models.Core;
 using Modix.Data.Models.Emoji;
 using Modix.Data.Models.Promotions;
 using Modix.Data.Repositories;
+using Modix.Services.AutoRemoveMessage;
 using Modix.Services.CommandHelp;
 using Modix.Services.Core;
 using Modix.Services.Images;
@@ -43,7 +44,8 @@ namespace Modix.Modules
             IEmojiRepository emojiRepository,
             IPromotionsService promotionsService,
             IImageService imageService,
-            IOptions<ModixConfig> config)
+            IOptions<ModixConfig> config,
+            IAutoRemoveMessageService autoRemoveMessageService)
         {
             _log = logger ?? new NullLogger<UserInfoModule>();
             _userService = userService;
@@ -54,6 +56,7 @@ namespace Modix.Modules
             _promotionsService = promotionsService;
             _imageService = imageService;
             _config = config.Value;
+            _autoRemoveMessageService = autoRemoveMessageService;
         }
 
         private readonly ILogger<UserInfoModule> _log;
@@ -65,6 +68,7 @@ namespace Modix.Modules
         private readonly IPromotionsService _promotionsService;
         private readonly IImageService _imageService;
         private readonly ModixConfig _config;
+        private readonly IAutoRemoveMessageService _autoRemoveMessageService;
 
         [Command("info")]
         [Alias("ompf", "omfp")]
@@ -78,15 +82,19 @@ namespace Modix.Modules
             var timer = Stopwatch.StartNew();
 
             var userInfo = await _userService.GetUserInformationAsync(Context.Guild.Id, userId);
+            var requesterInfo = await _userService.GetUserInformationAsync(Context.Guild.Id, Context.Guild.Id);
 
             if (userInfo == null)
             {
-                await ReplyAsync("", embed: new EmbedBuilder()
+                var embed = new EmbedBuilder()
                     .WithTitle("Retrieval Error")
                     .WithColor(Color.Red)
                     .WithDescription("Sorry, we don't have any data for that user - and we couldn't find any, either.")
-                    .AddField("User Id", userId)
-                    .Build());
+                    .AddField("User Id", userId);
+                await _autoRemoveMessageService.RegisterRemovableMessageAsync(
+                    requesterInfo,
+                    embed,
+                    async (embedBuilder) => await ReplyAsync(embed: embedBuilder.Build()));
 
                 return;
             }
@@ -164,7 +172,10 @@ namespace Modix.Modules
             timer.Stop();
             embedBuilder.WithFooter(footer => footer.Text = $"Completed after {timer.ElapsedMilliseconds} ms");
 
-            await ReplyAsync(embed: embedBuilder.Build());
+            await _autoRemoveMessageService.RegisterRemovableMessageAsync(
+                userInfo == requesterInfo ? new[] { userInfo } : new[] { userInfo, requesterInfo },
+                embedBuilder,
+                async (embedBuilder) => await ReplyAsync(embed: embedBuilder.Build()));
         }
 
         private void AddMemberInformationToEmbed(EphemeralUser member, StringBuilder builder)

--- a/Modix.Services/AutoRemoveMessage/AutoRemoveMessageHandler.cs
+++ b/Modix.Services/AutoRemoveMessage/AutoRemoveMessageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -33,7 +34,7 @@ namespace Modix.Services.AutoRemoveMessage
                 new RemovableMessage()
                 {
                     Message = notification.Message,
-                    User = notification.User,
+                    Users = notification.Users,
                 },
                 _messageCacheOptions);
 
@@ -47,7 +48,7 @@ namespace Modix.Services.AutoRemoveMessage
             if (cancellationToken.IsCancellationRequested
                 || notification.Reaction.Emote.Name != "❌"
                 || !Cache.TryGetValue(key, out RemovableMessage cachedMessage)
-                || notification.Reaction.UserId != cachedMessage.User.Id)
+                || !cachedMessage.Users.Any(user => user.Id == notification.Reaction.UserId))
             {
                 return;
             }

--- a/Modix.Services/AutoRemoveMessage/AutoRemoveMessageService.cs
+++ b/Modix.Services/AutoRemoveMessage/AutoRemoveMessageService.cs
@@ -26,6 +26,19 @@ namespace Modix.Services.AutoRemoveMessage
         Task RegisterRemovableMessageAsync(IUser user, EmbedBuilder embed, Func<EmbedBuilder, Task<IUserMessage>> callback);
 
         /// <summary>
+        /// Registers a removable message with the service and adds an indicator for this to the provided embed.
+        /// </summary>
+        /// <param name="user">The users who can remove the message.</param>
+        /// <param name="embed">The embed to operate on</param>
+        /// <param name="callback">A callback that returns the <see cref="IUserMessage"/> to register as removable. The modified embed is provided with this callback.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// If the provided <paramref name="callback"/> is null.
+        /// <returns>
+        /// A <see cref="Task"/> that will complete when the operation completes.
+        /// </returns>
+        Task RegisterRemovableMessageAsync(IUser[] users, EmbedBuilder embed, Func<EmbedBuilder, Task<IUserMessage>> callback);
+
+        /// <summary>
         /// Unregisters a removable message from the service.
         /// </summary>
         /// <param name="message">The removable message.</param>
@@ -43,7 +56,11 @@ namespace Modix.Services.AutoRemoveMessage
         }
 
         /// <inheritdoc />
-        public async Task RegisterRemovableMessageAsync(IUser user, EmbedBuilder embed, Func<EmbedBuilder, Task<IUserMessage>> callback)
+        public Task RegisterRemovableMessageAsync(IUser user, EmbedBuilder embed, Func<EmbedBuilder, Task<IUserMessage>> callback)
+            => RegisterRemovableMessageAsync(new[] { user }, embed, callback);
+
+        /// <inheritdoc />
+        public async Task RegisterRemovableMessageAsync(IUser[] user, EmbedBuilder embed, Func<EmbedBuilder, Task<IUserMessage>> callback)
         {
             if (callback == null)
                 throw new ArgumentNullException(nameof(callback));

--- a/Modix.Services/AutoRemoveMessage/RemovableMessage.cs
+++ b/Modix.Services/AutoRemoveMessage/RemovableMessage.cs
@@ -6,6 +6,6 @@ namespace Modix.Services.AutoRemoveMessage
     {
         public IMessage Message { get; set; }
 
-        public IUser User { get; set; }
+        public IUser[] Users { get; set; }
     }
 }

--- a/Modix.Services/AutoRemoveMessage/RemovableMessageSentNotification.cs
+++ b/Modix.Services/AutoRemoveMessage/RemovableMessageSentNotification.cs
@@ -8,14 +8,14 @@ namespace Modix.Services.AutoRemoveMessage
 {
     public class RemovableMessageSentNotification : INotification
     {
-        public RemovableMessageSentNotification(IMessage message, IUser user)
+        public RemovableMessageSentNotification(IMessage message, IUser[] users)
         {
             Message = message ?? throw new ArgumentNullException(nameof(message));
-            User = user ?? throw new ArgumentNullException(nameof(user));
+            Users = users ?? throw new ArgumentNullException(nameof(users));
         }
 
         public IMessage Message { get; }
 
-        public IUser User { get; }
+        public IUser[] Users { get; }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/discord-csharp/MODiX/issues/639. I decided to allow both the requestor and the requestee to remove the info embed, and expanded the autoremoval service to allow this. I don't have a local test server though, so I wasn't able to test this. Creating the PR for review now, and I'll try setting up a test environment sometime tomorrow.