### PR TITLE
Don't attempt to quote messages that MODiX does not have access to

### DIFF
--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -75,10 +75,23 @@ namespace Modix.Services.Quote
                     {
                         var channel = DiscordClient.GetChannel(channelId);
 
-                        if (channel is IGuildChannel &&
+                        if (channel is IGuildChannel guildChannel &&
                             channel is ISocketMessageChannel messageChannel)
                         {
-                            var msg = await messageChannel.GetMessageAsync(messageId);
+                            var currentUser = await guildChannel.Guild.GetCurrentUserAsync();
+                            var channelPermissions = currentUser.GetPermissions(guildChannel);
+
+                            if (!channelPermissions.ViewChannel)
+                            {
+                                return;
+                            }
+
+                            var cacheMode = channelPermissions.ReadMessageHistory
+                                ? CacheMode.AllowDownload
+                                : CacheMode.CacheOnly;
+
+                            var msg = await messageChannel.GetMessageAsync(messageId, cacheMode);
+
                             if (msg == null) return;
 
                             var success = await SendQuoteEmbedAsync(msg, guildUser, userMessage.Channel);


### PR DESCRIPTION
Should fix this error that occurs when someone quotes a message from a channel that MODiX cannot read: <https://paste.mod.gg/amezeqekun.json>
```
An error occured while attempting to create a quote embed.
The server responded with error 50001: Missing Access
```