### PR TITLE
Update to .NET Core 3.1, along with package updates

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,45 +13,43 @@
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
     <PackageReference Update="Discord.Net" Version="2.2.0-dev-20191025.3" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="3.0.0" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="3.0.0"/>
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="3.1.0"/>
     <PackageReference Update="Nito.AsyncEx.Coordination" Version="5.0.0" />
-    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
+    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.0" />
     <PackageReference Update="AspNet.Security.OAuth.Discord" Version="3.0.0" />
-    <PackageReference Update="DogStatsD-CSharp-Client" Version="3.3.0" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
-    <PackageReference Update="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="3.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Hosting" Version="3.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Http" Version="3.0.0" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.0.1" />
+    <PackageReference Update="DogStatsD-CSharp-Client" Version="4.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
+    <PackageReference Update="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.0" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.0" />
+    <PackageReference Update="Microsoft.Extensions.Hosting" Version="3.1.0" />
+    <PackageReference Update="Microsoft.Extensions.Http" Version="3.1.0" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
 
-    <PackageReference Update="Serilog" Version="2.8.0" />
-    <PackageReference Update="Serilog.AspNetCore" Version="3.1.0" />
-    <PackageReference Update="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Update="Serilog" Version="2.9.0" />
+    <PackageReference Update="Serilog.AspNetCore" Version="3.2.0" />
+    <PackageReference Update="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Update="Serilog.Sinks.Literate" Version="3.0.0" />
     <PackageReference Update="Serilog.Sinks.Sentry" Version="2.4.1" />
     <PackageReference Update="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Update="Serilog.Sinks.RollingFile" Version="3.3.0" />
-    <PackageReference Update="Serilog.Sinks.Sentry" Version="2.4.1" />
     
-    <PackageReference Update="Humanizer.Core" Version="2.5.16" />
-    <PackageReference Update="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Update="Humanizer.Core" Version="2.7.9" />
+    <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
 
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Update="Moq" Version="4.10.1" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Moq.AutoMock" Version="1.2.0.120" />
-    <PackageReference Update="NUnit" Version="3.11.0" />
-    <PackageReference Update="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Update="NUnit" Version="3.12.0" />
+    <PackageReference Update="NUnit3TestAdapter" Version="3.16.0" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
 
-    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
     <PackageReference Update="NSubstitute" Version="4.2.1" />
 
     <PackageReference Update="AsyncEvent" Version="0.2.0" />
-    <PackageReference Update="Kitsu" Version="1.4.1" />
-    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="3.0.0" />
+    <PackageReference Update="Kitsu" Version="1.4.2" />
+    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="3.1.0" />
     <PackageReference Update="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
   </ItemGroup>
 

--- a/Discord.Net.Abstractions/Discord.Net.Abstractions.csproj
+++ b/Discord.Net.Abstractions/Discord.Net.Abstractions.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <RootNamespace>Discord</RootNamespace>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 as dotnet-test
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as dotnet-test
 WORKDIR /src
 COPY . .
 RUN sh build/test.sh
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0 as dotnet-build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as dotnet-build
 WORKDIR /src
 COPY . .
 
 RUN sh build/build.sh
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.0
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 WORKDIR /app
 COPY --from=dotnet-build /app .
 COPY --from=dotnet-build /src/healthcheck.sh .

--- a/Modix.Bot.Test/Modix.Bot.Test.csproj
+++ b/Modix.Bot.Test/Modix.Bot.Test.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/Modix.Bot/Modix.Bot.csproj
+++ b/Modix.Bot/Modix.Bot.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DogStatsD-CSharp-Client" />
     <PackageReference Include="Humanizer.Core" />

--- a/Modix.Common.Test/Modix.Common.Test.csproj
+++ b/Modix.Common.Test/Modix.Common.Test.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Modix.Common/Modix.Common.csproj
+++ b/Modix.Common/Modix.Common.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Serilog" />

--- a/Modix.Data.Test/Modix.Data.Test.csproj
+++ b/Modix.Data.Test/Modix.Data.Test.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Modix.Data/Modix.Data.csproj
+++ b/Modix.Data/Modix.Data.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Discord.Net" />

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -294,7 +294,7 @@ namespace Modix.Data.Repositories
                     where ""UserId"" = cast(:UserId as numeric(20))",
                     new NpgsqlParameter(":GuildId", guildId.ToString()),
                     new NpgsqlParameter(":UserId", userId.ToString()))
-                .AsNoTracking()
+                .AsAsyncEnumerable()
                 .OrderByDescending(x => x.AveragePerDay)
                 .FirstOrDefaultAsync() ?? new GuildUserParticipationStatistics();
 

--- a/Modix.Services.Test/Modix.Services.Test.csproj
+++ b/Modix.Services.Test/Modix.Services.Test.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <IsPackable>false</IsPackable>
       <IsPublishable>false</IsPublishable>
-      <TargetFramework>netcoreapp3.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Modix.Services/Modix.Services.csproj
+++ b/Modix.Services/Modix.Services.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncEvent" />
     <PackageReference Include="Discord.Net" />

--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -11,7 +11,6 @@
     <NpmBuild Condition=" '$(Configuration)' == 'Debug' ">build-dev</NpmBuild>
     <NpmBuild Condition=" '$(NpmBuild)' == '' ">build</NpmBuild>
     <DevServerRunning>false</DevServerRunning>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrades project to .NET Core 3.1, minor query change for EF Core 3.1.

Reverts my previous mistake of reinserting all 3.0 references into the individual project files, and places 3.1 target into the `Directory.Build.props` file.