### PR TITLE
Fix fatal crash if logging embed content exceeds max characters, fixes #648

### DIFF
--- a/Modix.Services/Utilities/DiscordWebhookSink.cs
+++ b/Modix.Services/Utilities/DiscordWebhookSink.cs
@@ -39,6 +39,10 @@ namespace Modix.Services.Utilities
             var formattedMessage = logEvent.RenderMessage(_formatProvider);
             var webhookClient = new DiscordWebhookClient(_webhookId, _webhookToken);
 
+            var messagePayload = $"{formattedMessage}\n{logEvent.Exception?.Message}";
+
+            const int DiscordStringTruncateLength = 1000;
+
             var message = new EmbedBuilder()
                 .WithAuthor("DiscordLogger")
                 .WithTitle("Modix")
@@ -47,7 +51,7 @@ namespace Modix.Services.Utilities
                 .AddField(new EmbedFieldBuilder()
                     .WithIsInline(false)
                     .WithName($"LogLevel: {logEvent.Level}")
-                    .WithValue(Format.Code($"{formattedMessage}\n{logEvent.Exception?.Message}")));
+                    .WithValue(Format.Code(messagePayload.TruncateTo(DiscordStringTruncateLength))));
             try
             {
                 var eventAsJson = JsonConvert.SerializeObject(logEvent, _jsonSerializerSettings);
@@ -65,11 +69,11 @@ namespace Modix.Services.Utilities
                 message.AddField(new EmbedFieldBuilder()
                     .WithIsInline(false)
                     .WithName("Stack Trace")
-                    .WithValue(Format.Code($"{formattedMessage}\n{logEvent.Exception?.ToString().TruncateTo(1000)}")));
+                    .WithValue(Format.Code($"{formattedMessage}\n{logEvent.Exception?.ToString().TruncateTo(DiscordStringTruncateLength)}")));
                 message.AddField(new EmbedFieldBuilder()
                     .WithIsInline(false)
                     .WithName("Upload Failure Exception")
-                    .WithValue(Format.Code($"{ex.ToString().TruncateTo(1000)}")));
+                    .WithValue(Format.Code($"{ex.ToString().TruncateTo(DiscordStringTruncateLength)}")));
             }
             webhookClient.SendMessageAsync(string.Empty, embeds: new[] { message.Build() }, username: "Modix Logger");
         }

--- a/Modix.Services/Utilities/DiscordWebhookSink.cs
+++ b/Modix.Services/Utilities/DiscordWebhookSink.cs
@@ -36,24 +36,25 @@ namespace Modix.Services.Utilities
         }
         public void Emit(LogEvent logEvent)
         {
+            const int DiscordStringTruncateLength = 1000;
+
             var formattedMessage = logEvent.RenderMessage(_formatProvider);
             var webhookClient = new DiscordWebhookClient(_webhookId, _webhookToken);
 
-            var messagePayload = $"{formattedMessage}\n{logEvent.Exception?.Message}";
-
-            const int DiscordStringTruncateLength = 1000;
-
-            var message = new EmbedBuilder()
-                .WithAuthor("DiscordLogger")
-                .WithTitle("Modix")
-                .WithTimestamp(DateTimeOffset.UtcNow)
-                .WithColor(Color.Red)
-                .AddField(new EmbedFieldBuilder()
-                    .WithIsInline(false)
-                    .WithName($"LogLevel: {logEvent.Level}")
-                    .WithValue(Format.Code(messagePayload.TruncateTo(DiscordStringTruncateLength))));
             try
             {
+                var messagePayload = $"{formattedMessage}\n{logEvent.Exception?.Message}";
+
+                var message = new EmbedBuilder()
+                    .WithAuthor("DiscordLogger")
+                    .WithTitle("Modix")
+                    .WithTimestamp(DateTimeOffset.UtcNow)
+                    .WithColor(Color.Red)
+                    .AddField(new EmbedFieldBuilder()
+                        .WithIsInline(false)
+                        .WithName($"LogLevel: {logEvent.Level}")
+                        .WithValue(Format.Code(messagePayload.TruncateTo(DiscordStringTruncateLength))));
+
                 var eventAsJson = JsonConvert.SerializeObject(logEvent, _jsonSerializerSettings);
 
                 var url = CodePasteService.UploadCodeAsync(eventAsJson, "json").GetAwaiter().GetResult();


### PR DESCRIPTION
If the exception message (or indeed just the content) of the logging embed is too long, and exceeds 1024, MODiX crashes fatally after we attempt to log via the embed. This truncates the exception message and relies on the hastebin upload to retain the exception information.