### PR TITLE
Respect the Unmoderated designation when autoconfiguring channels

### DIFF
--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -349,6 +349,13 @@ namespace Modix.Services.Moderation
 
             if (channel is IGuildChannel guildChannel)
             {
+                var isUnmoderated = await DesignatedChannelService.ChannelHasDesignationAsync(guildChannel.Guild, channel, DesignatedChannelType.Unmoderated);
+
+                if (isUnmoderated)
+                {
+                    return;
+                }
+
                 var muteRole = await GetOrCreateDesignatedMuteRoleAsync(guildChannel.Guild, AuthorizationService.CurrentUserId.Value);
 
                 await ConfigureChannelMuteRolePermissionsAsync(guildChannel, muteRole);


### PR DESCRIPTION
It was respecting Unmoderated in some circumstances but not others.

For instance, when autoconfiguring the guild (after a restart for example), it's respecting the designation.

When autoconfiguring individual channels, it doesn't appear to be checking the designation at all.