### PR TITLE
MessageEntity column type compatibility fix

### DIFF
--- a/Modix.Data/Migrations/20200123011342_MessageEntityColumnTypeCompatibility.Designer.cs
+++ b/Modix.Data/Migrations/20200123011342_MessageEntityColumnTypeCompatibility.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Modix.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -9,9 +10,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Modix.Data.Migrations
 {
     [DbContext(typeof(ModixContext))]
-    partial class ModixContextModelSnapshot : ModelSnapshot
+    [Migration("20200123011342_MessageEntityColumnTypeCompatibility")]
+    partial class MessageEntityColumnTypeCompatibility
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modix.Data/Migrations/20200123011342_MessageEntityColumnTypeCompatibility.cs
+++ b/Modix.Data/Migrations/20200123011342_MessageEntityColumnTypeCompatibility.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Modix.Data.Migrations
+{
+    public partial class MessageEntityColumnTypeCompatibility : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<long>(
+                name: "StarboardEntryId",
+                table: "Messages",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<long>(
+                name: "GuildId",
+                table: "Messages",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "ChannelId",
+                table: "Messages",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "AuthorId",
+                table: "Messages",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<long>(
+                name: "Id",
+                table: "Messages",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "StarboardEntryId",
+                table: "Messages",
+                type: "numeric(20)",
+                nullable: true,
+                oldClrType: typeof(long),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "GuildId",
+                table: "Messages",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(long));
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "ChannelId",
+                table: "Messages",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(long));
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "AuthorId",
+                table: "Messages",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(long));
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "Messages",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(long));
+        }
+    }
+}

--- a/Modix.Data/Models/Core/MessageEntity.cs
+++ b/Modix.Data/Models/Core/MessageEntity.cs
@@ -32,23 +32,23 @@ namespace Modix.Data.Models.Core
 
             modelBuilder.Entity<MessageEntity>()
                 .Property(x => x.Id)
-                .HasColumnType("numeric(20)");
+                .HasConversion<long>();
 
             modelBuilder.Entity<MessageEntity>()
                 .Property(x => x.GuildId)
-                .HasColumnType("numeric(20)");
+                .HasConversion<long>();
 
             modelBuilder.Entity<MessageEntity>()
                 .Property(x => x.ChannelId)
-                .HasColumnType("numeric(20)");
+                .HasConversion<long>();
 
             modelBuilder.Entity<MessageEntity>()
                 .Property(x => x.AuthorId)
-                .HasColumnType("numeric(20)");
+                .HasConversion<long>();
 
             modelBuilder.Entity<MessageEntity>()
                 .Property(x => x.StarboardEntryId)
-                .HasColumnType("numeric(20)");
+                .HasConversion<long>();
 
             modelBuilder.Entity<MessageEntity>()
                 .HasIndex(x => new { x.GuildId, x.AuthorId });

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -265,7 +265,7 @@ namespace Modix.Data.Repositories
                         select msg.""AuthorId"", msg.""Id"" as ""MessageId"", msg.""GuildId""
                         from ""Messages"" as msg
                         left outer join ""DesignatedChannelMappings"" as dcm on msg.""ChannelId"" = dcm.""ChannelId""
-                        where msg.""GuildId"" = cast(:GuildId as numeric(20))
+                        where msg.""GuildId"" = cast(:GuildId as bigint)
                         and dcm.""Type"" = 'CountsTowardsParticipation'
                         and ""Timestamp"" >= (current_date - interval '30 day')
                     ),
@@ -291,7 +291,7 @@ namespace Modix.Data.Repositories
                     )
                     select ""AveragePerDay"", ""Percentile"", ""Rank"", ""GuildId"", ""UserId""
                     from ranked_users
-                    where ""UserId"" = cast(:UserId as numeric(20))",
+                    where ""UserId"" = cast(:UserId as bigint)",
                     new NpgsqlParameter(":GuildId", guildId.ToString()),
                     new NpgsqlParameter(":UserId", userId.ToString()))
                 .AsAsyncEnumerable()


### PR DESCRIPTION
Fixed that MessageEntity used different column types in the database to store ulong values, than the rest of the application. This makes it impossible to add navigational properties in the EF Model between MessageEntity and other entities, which Inzanit is currently in the process of doing.

The only issue with converting from `numeric()` to `bigint` would be if any values exceed the upper limit of a 64-bit signed integer, in which case we'd need to manually roll those around to the negative end of the 64-bit signed range, to preserve proper conversion to `ulong` in .NET land. Fortunately, Discord still seems to be serving snowflakes a whole sigfig below `long.MaxValue`, so there should be no risk of data loss here.

Also, I've run the migration locally, on my limited dataset.