### PR TITLE
 web: add Pie graph showing Message count by channel to User lookup page

### DIFF
--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -239,7 +239,7 @@ namespace Modix.Modules
             StringBuilder builder,
             GuildUserParticipationStatistics userRank,
             IReadOnlyDictionary<DateTime, int> messagesByDate,
-            IReadOnlyDictionary<ulong, int> messageCountsByChannel,
+            IReadOnlyDictionary<MessageCountPerChannel, int> messageCountsByChannel,
             IReadOnlyCollection<EmojiUsageStatistics> emojiCounts)
         {
             var lastWeek = _utcNow - TimeSpan.FromDays(7);
@@ -285,7 +285,7 @@ namespace Modix.Modules
                 {
                     foreach (var kvp in messageCountsByChannel.OrderByDescending(x => x.Value))
                     {
-                        var channel = await Context.Guild.GetChannelAsync(kvp.Key);
+                        var channel = await Context.Guild.GetChannelAsync(kvp.Key.ChannelId);
 
                         if (channel.IsPublic())
                         {

--- a/Modix.Data/Models/Core/MessageCountPerChannel.cs
+++ b/Modix.Data/Models/Core/MessageCountPerChannel.cs
@@ -1,0 +1,14 @@
+﻿namespace Modix.Data.Models.Core
+{
+    public class MessageCountPerChannel
+    {
+        public ulong ChannelId { get; }
+        public string ChannelName { get; }
+
+        public MessageCountPerChannel(ulong channelId, string channelName)
+        {
+            ChannelId = channelId;
+            ChannelName = channelName;
+        }
+    }
+}

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -73,19 +73,7 @@ namespace Modix.Data.Repositories
         /// A <see cref="Task"/> which will complete when the operation is complete,
         /// containing a dictionary which contains the number of messages the given user has sent in each channel within the given timeframe.
         /// </returns>
-        Task<IReadOnlyDictionary<ulong, int>> GetGuildUserMessageCountByChannel(ulong guildId, ulong userId, TimeSpan timespan);
-
-        /// <summary>
-        /// Searches the message logs for message records matching the supplied guild ID and user ID within a given timeframe.
-        /// </summary>
-        /// <param name="guildId">The unique Discord snowflake ID of the guild to search in.</param>
-        /// <param name="userId">The unique Discord snowflake ID of the user to get a message count for.</param>
-        /// <param name="timespan">The timeframe the query should be based on.</param>
-        /// <returns>
-        /// A <see cref="Task"/> which will complete when the operation is complete,
-        /// containing a dictionary which contains the number of messages the given user has sent in each channel within the given timeframe.
-        /// </returns>
-        Task<IReadOnlyDictionary<string, int>> GetGuildUserMessageCountByChannel2(ulong guildId, ulong userId, TimeSpan timespan);
+        Task<IReadOnlyDictionary<MessageCountPerChannel, int>> GetGuildUserMessageCountByChannel(ulong guildId, ulong userId, TimeSpan timespan);
 
         /// <summary>
         /// Calculates a given number of users contributions (through messages) in a given guild in a specific timeframe.
@@ -198,19 +186,7 @@ namespace Modix.Data.Repositories
         }
 
         /// <inheritdoc />
-        public async Task<IReadOnlyDictionary<ulong, int>> GetGuildUserMessageCountByChannel(ulong guildId, ulong userId, TimeSpan timespan)
-        {
-            var messages = await GetGuildUserMessages(guildId, userId, timespan)
-                .Select(x => x.ChannelId)
-                .ToListAsync();
-
-            return messages
-                .GroupBy(x => x)
-                .ToDictionary(x => x.Key, x => x.Count());
-        }
-
-        /// <inheritdoc />
-        public async Task<IReadOnlyDictionary<string, int>> GetGuildUserMessageCountByChannel2(ulong guildId, ulong userId, TimeSpan timespan)
+        public async Task<IReadOnlyDictionary<MessageCountPerChannel, int>> GetGuildUserMessageCountByChannel(ulong guildId, ulong userId, TimeSpan timespan)
         {
             var messages = await GetGuildUserMessages(guildId, userId, timespan)
                                  .Select(x => new
@@ -222,7 +198,7 @@ namespace Modix.Data.Repositories
 
             return messages
                    .GroupBy(x => x.ChannelId)
-                   .ToDictionary(x => x.First().ChannelName, x => x.Count());
+                   .ToDictionary(x => new MessageCountPerChannel(x.Key, x.First().ChannelName), x => x.Count());
         }
 
         /// <inheritdoc />

--- a/Modix.Services/Utilities/ColorUtils.cs
+++ b/Modix.Services/Utilities/ColorUtils.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using Discord;
+
+namespace Modix.Services.Utilities
+{
+    public class ColorUtils
+    {
+        /// <summary>
+        /// Returns rainbow table of <see cref="colorCount"/> colors
+        /// </summary>
+        public static List<Color> GetRainbowColors(int colorCount)
+        {
+            var ret = new List<Color>(colorCount);
+            var p = 360f / colorCount;
+
+            for (var n = 0; n < colorCount; n++)
+            {
+                ret.Add(HsvToRgb(n * p, 1f, 1f));
+            }
+
+            return ret;
+        }
+
+        /// <summary>
+        /// HSV -> RGB color
+        /// </summary>
+        public static Color HsvToRgb(float h, float s, float v)
+        {
+            var hi = (int) Math.Floor(h / 60.0) % 6;
+            var f = (h / 60f) - MathF.Floor(h / 60f);
+
+            var p = v * (1f - s);
+            var q = v * (1f - (f * s));
+            var t = v * (1f - ((1f - f) * s));
+
+            var color = hi switch
+            {
+                0 => new Color(v, t, p),
+                1 => new Color(q, v, p),
+                2 => new Color(p, v, t),
+                3 => new Color(p, q, v),
+                4 => new Color(t, p, v),
+                5 => new Color(v, p, q),
+                _ => new Color(0x00, 0x00, 0x00)
+            };
+            return color;
+        }
+    }
+}

--- a/Modix/ClientApp/src/components/PieChart.vue
+++ b/Modix/ClientApp/src/components/PieChart.vue
@@ -28,17 +28,18 @@ export default class PieChart extends Vue
         return this.$refs.chart as HTMLCanvasElement;
     }
 
+    @Watch('stats')
     updateChart()
     {
-        let array = Array.from(this.stats);
+        let array = Array.from(this.stats || []);
 
         this.pieChart.data = {
-            labels: Array.from(this.stats).map(d=> d.name),
+            labels: array.map(d=> d.name),
             datasets:
             [
                 {
-                    backgroundColor: Array.from(this.stats).map(d=> d.color),
-                    data: Array.from(this.stats).map(d=> d.count)
+                    backgroundColor: array.map(d=> d.color),
+                    data: array.map(d=> d.count)
                 }
             ]
         };

--- a/Modix/ClientApp/src/components/PieChart.vue
+++ b/Modix/ClientApp/src/components/PieChart.vue
@@ -10,6 +10,7 @@ import { Chart } from 'chart.js';
 
 import * as store from "@/app/Store";
 import { GuildRoleCount } from '@/models/GuildStatApiData';
+import { PieChartItem } from '@/models/PieChart';
 import {config, Theme} from '@/models/PersistentConfig';
 
 @Component({
@@ -20,7 +21,7 @@ export default class PieChart extends Vue
     private pieChart: any | null = null;
 
     @Prop({default: []})
-    public stats!: GuildRoleCount[];
+    public stats!: PieChartItem[];
 
     get chartCanvas(): HTMLCanvasElement
     {

--- a/Modix/ClientApp/src/components/UserLookup/UserProfile.vue
+++ b/Modix/ClientApp/src/components/UserLookup/UserProfile.vue
@@ -39,9 +39,11 @@
                         <UserProfileField fieldName="Roles" :fieldValue="roles" allowHtml="true" />
                     </div>
 
-                    <div class="section-title">Messages by Channel</div>
-                    <div class="box" :v-if="messages">
-                        <PieChart :stats="messages" />
+                    <div :v-if="messages">
+                        <div class="section-title">Messages by Channel</div>
+                        <div class="box">
+                            <PieChart :stats="messages" />
+                        </div>
                     </div>
                 </template>
 
@@ -51,7 +53,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop } from 'vue-property-decorator';
+import { Component, Prop, Watch } from 'vue-property-decorator';
 import ModixComponent from '@/components/ModixComponent.vue';
 import PieChart from '@/components/PieChart.vue';
 import * as _ from 'lodash';
@@ -95,10 +97,18 @@ export default class UserProfile extends ModixComponent
                 .join(", ");
     }
 
+    @Watch('user')
+    async setMessages(): Promise<void>
+    {
+        if (this.user && this.user.id)
+        {
+            this.messages = await UserService.getMessageCountPerChannel(this.user.id);
+        }
+    }
+
     async mounted()
     {
         await store.retrieveRoles();
-        this.messages = await UserService.getMessageCountPerChannel(this.$store.state.modix.user.userId);
     }
 }
 </script>

--- a/Modix/ClientApp/src/components/UserLookup/UserProfile.vue
+++ b/Modix/ClientApp/src/components/UserLookup/UserProfile.vue
@@ -38,6 +38,11 @@
                         <UserProfileField fieldName="Joined" :fieldValue="formatDate(user.joinedAt)" default="Never" />
                         <UserProfileField fieldName="Roles" :fieldValue="roles" allowHtml="true" />
                     </div>
+
+                    <div class="section-title">Messages by Channel</div>
+                    <div class="box" :v-if="messages">
+                        <PieChart :stats="messages" />
+                    </div>
                 </template>
 
             </div>
@@ -48,18 +53,22 @@
 <script lang="ts">
 import { Component, Prop } from 'vue-property-decorator';
 import ModixComponent from '@/components/ModixComponent.vue';
+import PieChart from '@/components/PieChart.vue';
 import * as _ from 'lodash';
 import UserProfileSectionTitle from '@/components/UserLookup/UserProfileSectionTitle.vue';
 import UserProfileField from '@/components/UserLookup/UserProfileField.vue';
 import EphemeralUser from '@/models/EphemeralUser';
+import UserMessagePerChannelCount from '@/models/UserMessagePerChannelCount'
 import { formatDate, ordinalize, toQuantity } from '@/app/Util'
 import Role from '@/models/Role';
 import store from "@/app/Store";
+import UserService from '@/services/UserService';
 
 @Component({
     components:
     {
         UserProfileField,
+        PieChart
     },
     methods:
     {
@@ -72,6 +81,8 @@ export default class UserProfile extends ModixComponent
 {
     @Prop()
     user!: EphemeralUser | null;
+    
+    messages: UserMessagePerChannelCount[] | null = null;
 
     get roles(): string
     {
@@ -87,6 +98,7 @@ export default class UserProfile extends ModixComponent
     async mounted()
     {
         await store.retrieveRoles();
+        this.messages = await UserService.getMessageCountPerChannel(this.$store.state.modix.user.userId);
     }
 }
 </script>

--- a/Modix/ClientApp/src/models/GuildStatApiData.ts
+++ b/Modix/ClientApp/src/models/GuildStatApiData.ts
@@ -1,3 +1,5 @@
+import { PieChartItem } from '@/models/PieChart'
+
 export default interface GuildStatApiData
 {
     guildName: string;
@@ -5,11 +7,8 @@ export default interface GuildStatApiData
     topUserMessageCounts: PerUserMessageCount[];
 }
 
-export interface GuildRoleCount
+export interface GuildRoleCount extends PieChartItem
 {
-    name: string;
-    count: number;
-    color: string;
 }
 
 export interface PerUserMessageCount

--- a/Modix/ClientApp/src/models/PieChart.ts
+++ b/Modix/ClientApp/src/models/PieChart.ts
@@ -1,0 +1,6 @@
+export interface PieChartItem
+{
+    name: string;
+    count: number;
+    color: string;
+}

--- a/Modix/ClientApp/src/models/UserMessagePerChannelCount.ts
+++ b/Modix/ClientApp/src/models/UserMessagePerChannelCount.ts
@@ -1,0 +1,5 @@
+import { PieChartItem } from '@/models/PieChart'
+
+export default interface UserMessagePerChannelCount extends PieChartItem
+{
+}

--- a/Modix/ClientApp/src/services/UserService.ts
+++ b/Modix/ClientApp/src/services/UserService.ts
@@ -1,11 +1,19 @@
 import _ from 'lodash';
 import client from './ApiClient';
 import EphemeralUser from '@/models/EphemeralUser';
+import UserMessagePerChannelCount from '@/models/UserMessagePerChannelCount';
 
 export default class UserService
 {
     static async getUserInformation(userId: string): Promise<EphemeralUser | null>
     {
         return (await client.get(`userInformation/${userId}`)).data;
+    }
+    
+    static async getMessageCountPerChannel(userId: string, after: Date | null = null): Promise<UserMessagePerChannelCount[]>
+    {
+        const afterQuery = after ? after.toISOString() : "";
+        let response = (await client.get(`userInformation/${userId}/messages?after=${afterQuery}`)).data;
+        return response;
     }
 }

--- a/Modix/Controllers/UserInformationController.cs
+++ b/Modix/Controllers/UserInformationController.cs
@@ -89,13 +89,13 @@ namespace Modix.Controllers
                 return Ok(null);
 
             var timespan = DateTimeOffset.UtcNow - after;
-            var result = await MessageRepository.GetGuildUserMessageCountByChannel2(UserGuild.Id, userId, timespan);
+            var result = await MessageRepository.GetGuildUserMessageCountByChannel(UserGuild.Id, userId, timespan);
             var colors = ColorUtils.GetRainbowColors(result.Count);
 
             var i = 0;
             var mapped = result.Select(x => new
                                {
-                                   Name = x.Key,
+                                   Name = x.Key.ChannelName,
                                    Count = x.Value,
                                    Color = colors[i++].ToString()
                                })

--- a/Modix/Controllers/UserInformationController.cs
+++ b/Modix/Controllers/UserInformationController.cs
@@ -81,5 +81,28 @@ namespace Modix.Controllers
 
             return Ok(mapped);
         }
+
+        [HttpGet("{userIdString}/messages")]
+        public async Task<IActionResult> GetUserMessagesPerChannelAsync(string userIdString, DateTimeOffset after = default)
+        {
+            if (!ulong.TryParse(userIdString, out var userId))
+                return Ok(null);
+
+            var timespan = DateTimeOffset.UtcNow - after;
+            var result = await MessageRepository.GetGuildUserMessageCountByChannel2(UserGuild.Id, userId, timespan);
+            var colors = ColorUtils.GetRainbowColors(result.Count);
+
+            var i = 0;
+            var mapped = result.Select(x => new
+                               {
+                                   Name = x.Key,
+                                   Count = x.Value,
+                                   Color = colors[i++].ToString()
+                               })
+                               .OrderByDescending(x => x.Count)
+                               .ToList();
+
+            return Ok(mapped);
+        }
     }
 }


### PR DESCRIPTION
Adds **Messages by Channel** section on bottom of [mod.gg/userlookup](https://mod.gg/userlookup).

Notes:
* pie chart now uses `PieChartItem` model to be more general
* when I tried setting `messages` via `Prop` from `UserLookup`, pie graph colours were not working,
so I load them in `UserProfile` (first time I work with Vue)