### PR TITLE
DateTimeOffset SQL Translations

### DIFF
--- a/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMemberTranslator.cs
+++ b/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMemberTranslator.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Reflection;
+
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations
+{
+    public class DateTimeOffsetMemberTranslator
+        : IMemberTranslator
+    {
+        public DateTimeOffsetMemberTranslator(
+            ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        public SqlExpression? Translate(
+                SqlExpression instance,
+                MemberInfo member,
+                Type returnType)
+            => ((member.DeclaringType == typeof(DateTimeOffset))
+                    && (member.Name == nameof(DateTimeOffset.Date)))
+                ? _sqlExpressionFactory.Function("DATE_TRUNC", new[] { _sqlExpressionFactory.Constant("day"), instance }, returnType)
+                : null;
+
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+    }
+}

--- a/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMemberTranslatorPlugin.cs
+++ b/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMemberTranslatorPlugin.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations
+{
+    public class DateTimeOffsetMemberTranslatorPlugin
+        : IMemberTranslatorPlugin
+    {
+        public DateTimeOffsetMemberTranslatorPlugin(
+            ISqlExpressionFactory sqlExpressionFactory)
+        {
+            Translators = new[]
+            {
+                new DateTimeOffsetMemberTranslator(sqlExpressionFactory)
+            };
+        }
+
+        public IEnumerable<IMemberTranslator> Translators { get; }
+    }
+}

--- a/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMethodCallTranslator.cs
+++ b/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMethodCallTranslator.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
+
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations
+{
+    public class DateTimeOffsetMethodCallTranslator
+        : IMethodCallTranslator
+    {
+        public DateTimeOffsetMethodCallTranslator(
+            ISqlExpressionFactory sqlExpressionFactory)
+        {
+            _sqlExpressionFactory = sqlExpressionFactory;
+        }
+
+        #pragma warning disable EF1001 // Internal EF Core API usage.
+        public SqlExpression? Translate(
+                SqlExpression instance,
+                MethodInfo method,
+                IReadOnlyList<SqlExpression> arguments)
+            => ((method.DeclaringType == typeof(DateTimeOffset))
+                    && (method.Name == nameof(DateTimeOffset.ToUniversalTime))
+                    && _sqlExpressionFactory is NpgsqlSqlExpressionFactory npgsqlSqlExpressionFactory)
+                ? npgsqlSqlExpressionFactory.AtTimeZone(
+                    instance,
+                    npgsqlSqlExpressionFactory.Constant("UTC"),
+                    method.ReturnType)
+                : null;
+        #pragma warning restore EF1001 // Internal EF Core API usage.
+
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+    }
+}

--- a/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMethodCallTranslatorPlugin.cs
+++ b/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMethodCallTranslatorPlugin.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations
+{
+    public class DateTimeOffsetMethodCallTranslatorPlugin
+        : IMethodCallTranslatorPlugin
+    {
+        public DateTimeOffsetMethodCallTranslatorPlugin(
+            ISqlExpressionFactory sqlExpressionFactory)
+        {
+            Translators = new[]
+            {
+                new DateTimeOffsetMethodCallTranslator(sqlExpressionFactory)
+            };
+        }
+
+        public IEnumerable<IMethodCallTranslator> Translators { get; }
+    }
+}

--- a/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetTranslationsInfo.cs
+++ b/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetTranslationsInfo.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations
+{
+    public class DateTimeOffsetTranslationsInfo
+        : DbContextOptionsExtensionInfo
+    {
+        public DateTimeOffsetTranslationsInfo(
+                IDbContextOptionsExtension extension)
+            : base(
+                extension) { }
+
+        public override bool IsDatabaseProvider
+            => false;
+
+        public override string LogFragment { get; }
+            = "using DateTimeOffset translation extension";
+
+        public override long GetServiceProviderHashCode()
+            => 0;
+
+        public override void PopulateDebugInfo(IDictionary<string, string> debugInfo) { }
+    }
+}

--- a/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetTranslationsOptions.cs
+++ b/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetTranslationsOptions.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations
+{
+    public class DateTimeOffsetTranslationsOptions
+        : IDbContextOptionsExtension
+    {
+        public DateTimeOffsetTranslationsOptions()
+        {
+            Info = new DateTimeOffsetTranslationsInfo(this);
+        }
+
+        public DbContextOptionsExtensionInfo Info { get; }
+
+        public void ApplyServices(IServiceCollection services)
+            => services
+                .AddSingleton<IMemberTranslatorPlugin, DateTimeOffsetMemberTranslatorPlugin>()
+                .AddSingleton<IMethodCallTranslatorPlugin, DateTimeOffsetMethodCallTranslatorPlugin>();
+
+        public void Validate(IDbContextOptions options) { }
+    }
+}

--- a/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/NpgsqlDbContextOptionsBuilderExtensions.cs
+++ b/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/NpgsqlDbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+
+using Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class NpgsqlDbContextOptionsBuilderExtensions
+    {
+        // TODO: Remove this if https://github.com/npgsql/efcore.pg/issues/473 ever gets resolved.
+        public static NpgsqlDbContextOptionsBuilder UseDateTimeOffsetTranslations(
+            this NpgsqlDbContextOptionsBuilder optionsBuilder)
+        {
+            ((optionsBuilder as IRelationalDbContextOptionsBuilderInfrastructure)
+                .OptionsBuilder as IDbContextOptionsBuilderInfrastructure)
+                .AddOrUpdateExtension(new DateTimeOffsetTranslationsOptions());
+
+            return optionsBuilder;
+        }
+    }
+}

--- a/Modix/Startup.cs
+++ b/Modix/Startup.cs
@@ -61,10 +61,9 @@ namespace Modix
             services.AddTransient<IConfigureOptions<StaticFileOptions>, StaticFilesConfiguration>();
             services.AddTransient<IStartupFilter, ModixConfigValidator>();
 
-            services.AddDbContext<ModixContext>(options =>
-            {
-                options.UseNpgsql(_configuration.GetValue<string>(nameof(ModixConfig.DbConnection)));
-            });
+            services.AddDbContext<ModixContext>(options => options
+                .UseNpgsql(_configuration.GetValue<string>(nameof(ModixConfig.DbConnection)), npgsqlOptions => npgsqlOptions
+                    .UseDateTimeOffsetTranslations()));
 
             services
                 .AddModixHttpClients()


### PR DESCRIPTION
Added an EF extension to handle translation of (a few) DateTimeOffset member call expressions to SQL. This will support efforts by @Inzanit to convert raw SQL queries to LINQ queries, at least until https://github.com/npgsql/efcore.pg/issues/473 is resolved and released.

Temporary workaround for #683 