### PR TITLE
Rewrite raw SQL query to EF in info2 command

### DIFF
--- a/Modix.Services/UserInfo/UserInfoCommand.cs
+++ b/Modix.Services/UserInfo/UserInfoCommand.cs
@@ -286,7 +286,7 @@ namespace Modix.Services.UserInfo
                 {
                     AuthorId = x.Key,
                     Count = x.Count(),
-                    AveragePerDay = x.Count() / 30
+                    AveragePerDay = x.Count() / NumberOfDays
                 })
                 .OrderByDescending(x => x.AveragePerDay);
 

--- a/Modix.Services/UserInfo/UserInfoCommand.cs
+++ b/Modix.Services/UserInfo/UserInfoCommand.cs
@@ -246,7 +246,7 @@ namespace Modix.Services.UserInfo
             }
 
             var numberOfMessagesIn7DayPeriod = messages.Where(x => x.Date > weekThreshold).Sum(d => d.NumberOfMessages);
-            var participationForUser = await _messageRepository.GetGuildUserParticipationStatistics(guild.Id, userId);
+            var participationForUser = await GetGuildUserParticipationStatistics(guild.Id, userId, cancellationToken);
 
             var participation = new UserInfoParticipationDto(participationForUser.Rank, messages.Sum(d => d.NumberOfMessages),
                 numberOfMessagesIn7DayPeriod, participationForUser.AveragePerDay, participationForUser.Percentile);
@@ -268,6 +268,47 @@ namespace Modix.Services.UserInfo
             }
 
             return participation;
+        }
+
+        private async Task<GuildUserParticipationStatistics> GetGuildUserParticipationStatistics(ulong guildId, ulong userId, CancellationToken cancellationToken)
+        {
+            const int NumberOfDays = 30;
+
+            var minimumTime = DateTimeOffset.UtcNow - TimeSpan.FromDays(NumberOfDays);
+
+            var groupedMessages = _modixContext.Messages
+                .Where(x => x.Channel.DesignatedChannelMappings
+                    .Any(x => x.Type == DesignatedChannelType.CountsTowardsParticipation))
+                .Where(x => x.GuildId == guildId)
+                .Where(x => x.Timestamp >= minimumTime)
+                .GroupBy(x => x.AuthorId)
+                .Select(x => new
+                {
+                    AuthorId = x.Key,
+                    Count = x.Count(),
+                    AveragePerDay = x.Count() / 30
+                })
+                .OrderByDescending(x => x.AveragePerDay);
+
+            var totalCount = await groupedMessages.SumAsync(x => x.Count, cancellationToken);
+            var thisUser = await groupedMessages.SingleOrDefaultAsync(x => x.AuthorId == userId, cancellationToken);
+            var percentile = thisUser.Count / totalCount * 100;
+
+            // rank = number of users with an average per day higher than this
+            // user plus one as it is 1-based rather than 0-based
+            var rank = await groupedMessages
+                .Where(x => x.AveragePerDay > thisUser.AveragePerDay)
+                .CountAsync(cancellationToken) + 1;
+
+            return new GuildUserParticipationStatistics
+            {
+                GuildId = guildId,
+                UserId = userId,
+
+                Rank = rank,
+                AveragePerDay = thisUser.AveragePerDay,
+                Percentile = percentile
+            };
         }
     }
 }


### PR DESCRIPTION
More work on #690, attempting to get the performance up even more.

Doing some testing locally (sample set size between 1 and 3 million messages), I appear to get faster query times for `!info2` with this code compared to the original raw SQL query. Making a PR so we can test in actual working conditions to confirm.

We could probably merge the two individual queries in this part of the code, but I spent 5 minutes looking at it and couldn't think of anything so I left it for now.