### PR TITLE
Wiki Tracking And Deployment

### DIFF
--- a/.github/workflows/wiki-deployment.yml
+++ b/.github/workflows/wiki-deployment.yml
@@ -1,0 +1,24 @@
+name: Wiki Deployment
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'wiki/**'    
+
+jobs:
+  sync-wiki-files:
+    name: Sync Wiki Files
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout /wiki
+        uses: actions/checkout@master
+      - name: Merge to .wiki
+        uses: SwiftDocOrg/github-wiki-publish-action@1.0.0
+        with:
+          path: wiki
+        env:
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.WIKI_DEPLOYMENT_ACCESS_TOKEN }}

--- a/Modix.sln
+++ b/Modix.sln
@@ -35,6 +35,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Modix.Common.Test", "Modix.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Modix.Bot.Test", "Modix.Bot.Test\Modix.Bot.Test.csproj", "{E9D29AA9-1B7D-4A90-839A-2E8665A8714F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "wiki", "wiki", "{092916B2-32C6-4ED9-A4EA-DF31D2F91A8F}"
+	ProjectSection(SolutionItems) = preProject
+		wiki\_Footer.md = wiki\_Footer.md
+		wiki\Developers.md = wiki\Developers.md
+		wiki\Home.md = wiki\Home.md
+		wiki\Modix-Startup.md = wiki\Modix-Startup.md
+		wiki\Orchestration-(Docker).md = wiki\Orchestration-(Docker).md
+		wiki\Project-Overview.md = wiki\Project-Overview.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -168,6 +178,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{092916B2-32C6-4ED9-A4EA-DF31D2F91A8F} = {23DA774D-7AE9-48C1-A261-F27D15A07858}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {36BDDB86-FBAB-45BF-AA22-DD4509504772}

--- a/wiki/Developers.md
+++ b/wiki/Developers.md
@@ -1,0 +1,40 @@
+Below is a guide on how to start developing Modix. Depending on the nature of the features you want to add/work on, there's a few different workflows you might want to use, each of which have different requirements.
+
+# Prerequisites
+To work on Modix, you need a few things:
+- A Discord application set up - [go here to create one](https://discordapp.com/developers/applications/), add a bot to it, and copy the **token** from the page. You can then add the bot to your server by going to ` https://discordapp.com/oauth2/authorize?scope=bot&permissions=0&client_id=[ID HERE]`, replacing `[ID HERE]` with the **Client ID** of your bot (not the token).
+- Under `https://discordapp.com/developers/applications/{CLIENT ID HERE}/oauth` make sure to add redirect to your domain such as `http://localhost:5000/signin-discord` and make sure it is appended with `/signin-discord`
+- [The latest .NET Core SDK for your chosen platform](https://www.microsoft.com/net/download) (currently 2.2)
+- [NodeJS 10.x LTS for your chosen platform](https://nodejs.org/en/download/)
+- [PostgreSQL database server](https://www.postgresql.org/download/). A docker container also works.
+- **Optional**: [Docker](https://www.docker.com/get-docker). You **do not** need Docker if you're just developing locally - it's mostly just to test if your changes are significant enough that they might break CI, or if you prefer to keep your dev environment clean. If you're on Windows, make sure you switch to Linux containers.
+
+If you're working on a feature that involves Modix's core services, and only needs to work with the Discord bot frontend, then you can proceed to opening `Modix.sln`. 
+
+# Setting Configuration
+### Config file
+You can specify configuration settings within **`developmentSettings.json`** when developing locally, or if copied into the Docker container, when developing with Docker. You can copy/paste **`developmentSettings.default.json`** as a template (make sure to remove the `.default` bit).
+> **Note**: Be sure this is marked as "Copy If Newer" in your Solution Explorer / Properties.
+
+### Environment Variables
+If you prefer to use environment variables for configuration, they must all be prefixed with **`MODIX_`**. For example, **`MODIX_DbConnection`**, **`MODIX_DiscordToken`**, etc.
+
+### List of config options
+- **Required**
+  - `DbConnection` - this is the connection string to your PostgreSQL instance. When developing locally, it'll probably be easiest to run Postgres in a container, or install it onto your development OS - whatever works. A simple connection string looks like: `Server=127.0.0.1;Port=5432;Database=myDataBase;User Id=myUsername;Password=myPassword;`
+  - `DiscordToken` - this is the bot token Modix should use to connect to the Discord API. See above.
+- **Recommended**
+  - `DiscordClientId` - also taken from the Discord API page for your bot, this is needed for the web frontend's OAuth stuff to work properly. Can be ignored if you aren't working on/with the web frontend.
+  - `DiscordClientSecret` - same as above.
+- **Optional**
+  - `MessageCacheSize` - An integer value defining the internal Discord.Net message cache size - used for logging deleted messages. Should be around 10 or more, and will default to that if unset, but you don't need it unless you're testing message deletion.
+  - `LogWebhookId` - The ID of the Discord webhook to log to. Only necessary if you want log messages to appear in a channel on the server. 
+    - `https://discordapp.com/api/webhooks/[this part]/asda2ed2klkm5lkn42n34jk`
+  - `LogWebhookToken` - Same as above, but the token of the webhook.
+    - `https://discordapp.com/api/webhooks/000000000000000000/[this part]`
+  - `StackoverflowToken` - A token for the StackOverflow API, if you need to use the StackOverflow module.
+  - `ReplUrl` - The URL of the endpoint that will be receiving REPL (`!eval`/`!exec`) requests - required if you want to test the REPL, and requires you to host it separately elsewhere.
+  - `IlUrl` - The URL of the endpoint that will be receiving IL (`!il`) requests. Same as above, and will likely be the same URL.
+
+
+After setting all this up, you can move on to learning about [how modix starts](Modix-Startup)!

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,2 @@
+**Welcome to the MODiX wiki**! This is where we'll post development & system documentation.
+[Start Here!](Project-Overview)

--- a/wiki/Modix-Startup.md
+++ b/wiki/Modix-Startup.md
@@ -1,0 +1,42 @@
+Below is a rundown of `~/Modix.Bot/ModixBot.cs`, where startup occurs. This class, derived from `BackgroundService`, utilizes ASP.NET Core's ["Hosted Services"](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-2.2) implementation and is added to the service container at the bottom of `~/Modix/ServiceCollectionExtensions.cs`, after all the "core" Modix services - including our `DiscordSocketClient`.
+
+Some services are grouped - you may see calls like
+```csharp
+services.AddModixCore()
+    .AddModixModeration()
+    .AddModixPromotions()
+//etc
+```
+
+This is mostly for code clarity - you can see the specific services registered by these methods in `Modix.Services`. If you are adding a new service, you may find it best to add it to one of these groups, to the miscellaneous services within `Install()`, or in a new group entirely.
+
+All of this registration happens before the actual "bot" starts - we leverage the aforementioned `BackgroundService` stuff to make sure all our dependencies are in order, and essentially run the bot as a service of the web application. By having a single shared ServiceProvider, we can ensure proper scoping and sharing of services that are shared across both Web and Discord frontends.
+
+***
+
+We start within the overridden `ExecuteAsync` method, which ASP.NET calls for us on startup. Here, we register event hooks for things like Discord.Net logging. We then do a manual initialization/migration of our database, to ensure that any pending migrations are applied right away (and errors are thrown before anything runs properly).
+```csharp
+scope.ServiceProvider.GetRequiredService<ModixContext>()
+    .Database.Migrate();
+```
+
+We also start all of our internal `IBehavior` implementations, for things like automoderation and logging. If you're writing a feature that will make the most sense as a behavior, simply have it implement IBehavior and register it as explained above - the rest will be handled for you. See the existing implementations for examples.
+```csharp
+_hooks.ServiceProvider = _scope.ServiceProvider;
+
+foreach (var behavior in _scope.ServiceProvider.GetServices<IBehavior>())
+{
+    await behavior.StartAsync();
+    stoppingToken.Register(() => behavior.StopAsync().GetAwaiter().GetResult());
+}
+```
+
+Speaking of commands, we also add all our command modules to the `CommandService` for Discord.Net's command stuff, and handle executing them within the `HandleCommand` method - each command gets its own scope within the context of the DI container, and if it errors, we use our slightly friendly event handler to inform the user. Your frontend code should prefer to provide friendly errors to the user, rather than let exceptions bubble up from the service layer for optimal UX.
+
+Finally, we actually start the client & log in, then `await Task.Delay(-1)` to make sure we aren't killed prematurely. We also add a temporary hook to the Ready event, which is removed after the first time it's executed. This sets the bot's status once at startup, then removes itself so it doesn't fire again in the event of a reconnect.
+
+```csharp
+Log.LogTrace("Discord client is ready. Setting game status.");
+_client.Ready -= OnClientReady;
+await _client.SetGameAsync("https://mod.gg/");
+```

--- a/wiki/Orchestration-(Docker).md
+++ b/wiki/Orchestration-(Docker).md
@@ -1,0 +1,44 @@
+Modix uses Kubernetes to orchestrate its various components and services. You can view the cluster configuration [here](https://github.com/discord-csharp/MODiX/blob/master/modix-kubernetes.yml) - each section has a comment header to help you read through it. 
+
+# What's a Kubernetes?
+Kubernetes is used to compose & orchestrate containers - typically created with Docker. Modix itself is one container, part of the greater cluster along with a database service, CSDiscord, etc.
+
+# How does the Modix pipeline work?
+We utilize [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) for Modix's deployment. It builds the Modix container, uploads it to the Docker hub, and triggers a deployment on our Kubernetes cluster to update any relevant containers. This allows us to have a very simple deployment workflow, where all it takes is a commit on Master to push changes into production right away - for better, [or](https://github.com/discord-csharp/MODiX/commit/b3dd4f2fa1e0e73fe7097b4947904cdce41ba728) [for](https://github.com/discord-csharp/MODiX/commit/dd6fb7c2a4ae1956a23f032825aa0262e586582e) [worse](https://github.com/discord-csharp/MODiX/commit/6489654dd0f02fdd474b6c10ac5da5a54dc0515b).
+
+# What's a container?
+Great question, but, [outside the scope of this documentation](https://www.docker.com/resources/what-container) - regardless, here's a quick rundown of Modix's `Dockerfile`: 
+
+>Basing off the .NET Core 2.1 SDK image (Debian Stretch), copy the repo files into the container & run all our tests
+```
+FROM microsoft/dotnet:2.1-sdk-stretch as dotnet-test
+WORKDIR /src
+COPY . .
+RUN dotnet test Modix.Data.Test
+```
+
+>Basing off the .NET Core 2.1 SDK image (Debian Stretch), copy the repo files into the container
+```
+FROM microsoft/dotnet:2.1-sdk-stretch as dotnet-build
+WORKDIR /src
+COPY . .
+```
+
+>In the same container, install Node 10 to compile the frontend
+```
+RUN apt-get update && apt install curl -y
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get install nodejs -y
+```
+
+>Publish Modix for `linux-x64` - this also builds the frontend (defined as an msbuild task in the csproj)
+```
+RUN dotnet publish Modix.sln -c Release -r linux-x64 -o /app
+```
+>Finally, from the ASP.NET Core runtime image, copy the built application and the built frontend from the previous container into the appropriate locations in the final container
+```
+FROM microsoft/dotnet:2.1-aspnetcore-runtime
+WORKDIR /app
+COPY --from=dotnet-build /app .
+ENTRYPOINT ["dotnet", "Modix.dll"]
+```

--- a/wiki/Project-Overview.md
+++ b/wiki/Project-Overview.md
@@ -1,0 +1,22 @@
+Modix has grown a bit since the initial implementation. It now consists of multiple components, each with their own dependencies - as well as various test projects.
+
+# `~/Modix` - Core application, HTTP API
+This is Modix proper - the startup project. Written in C# and targeting .NET Core, it has cross-project dependencies on `~/Modix.Bot`, `~/Modix.Data`, and `~/Modix.Services` (as defined by `Modix.sln`), and contains the core logic for the HTTP API, which is driven by ASP.NET Core. This includes all the controllers, HTTP-specific authentication logic, web frontend models, and the ASP.NET Core startup class.
+
+## `~/Modix/ClientApp` - Web Frontend
+This is the web frontend for Modix, written in Typescript using Vue.JS and associated tooling (`vue-cli`, `webpack`, `npm`, etc).
+
+## `~/Modix.Bot` - Discord Bot
+This project contains the Discord.Net-specific and core Modix bot stuff, such as command modules and type readers. It's contained within a `BackgroundService` to be hosted within the core application.
+
+## `~/Modix.Services` - Service Layer
+This project contains the majority of our business logic types, and is used by `~/Modix.Bot` (the Discord frontend) and `~/Modix` (core / HTTP). If a command is run from either of these frontends, it will probably be through a service within this project.
+
+## `~/Modix.Data` - Data Layer
+This is our data layer, and contains the majority of the POCO models and database logic, as well as migrations. This includes the database context, driven by Entity Framework Core and using PostgreSQL.
+
+## `~/Modix.Common` - Common Stuff
+This is where we put stuff that is so generic that any other project can / will depend on it.
+
+# CSDiscord
+This is a separate project, [located here](https://github.com/discord-csharp/CSDiscord), which powers our REPL/eval feature. Combined with kubernetes orchestration, we follow a "security by disposability" pattern, where containers are spun up and disposed of as eval requests come in. Communication to the service from Modix itself is over HTTP - see `ReplModule.cs` in the main Modix project.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,1 @@
+Confused? Having trouble? Join our server at https://discord.gg/csharp for help!


### PR DESCRIPTION
Setup wiki files, within the main repository (discord-csharp/MODiX), to be pushed to the GitHub Wiki for the project (discord-csharp/MODiX.wiki).

Setup Wiki Deployment Workflow, to perform automatic deployments of the wiki files.

Setup for new wiki developments, as part of #707.

Do not merge until the WIKI_DEPLOYMENT_ACCESS_TOKEN secret has been setup upon the repository. Otherwise, the workflow will fail.