### PR TITLE
PromotionCampaignSummary optimization

### DIFF
--- a/Modix.Bot/Modules/PromotionsModule.cs
+++ b/Modix.Bot/Modules/PromotionsModule.cs
@@ -63,9 +63,8 @@ namespace Modix.Modules
             foreach (var campaign in campaigns)
             {
                 var idLabel = $"#{campaign.Id}";
-                var votesLabel = (campaign.GetTotalVotes() == 1) ? "Vote" : "Votes";
 
-                var approvalLabel = $"👍 {campaign.GetNumberOfApprovals()} / 👎 {campaign.GetNumberOfOppositions()}";
+                var approvalLabel = $"👍 {campaign.ApproveCount} / 👎 {campaign.OpposeCount}";
                 var timeRemaining = campaign.GetTimeUntilCampaignCanBeClosed();
                 var timeRemainingLabel = timeRemaining < TimeSpan.FromSeconds(1) ? "Can be closed now" : $"{timeRemaining.Humanize(precision: 2, minUnit: TimeUnit.Minute)} until close";
 

--- a/Modix.Data/Utilities/PromotionCampaignEntityExtensions.cs
+++ b/Modix.Data/Utilities/PromotionCampaignEntityExtensions.cs
@@ -8,30 +8,6 @@ namespace Modix.Data.Utilities
     {
         public static readonly TimeSpan CampaignAcceptCooldown = TimeSpan.FromHours(48);
 
-        /// <summary>
-        /// Get the total count of comments that were not abstaining
-        /// </summary>
-        public static int GetTotalVotes(this PromotionCampaignSummary campaign)
-        {
-            return campaign.CommentCounts
-                .Where(x => x.Key != PromotionSentiment.Abstain)
-                .Sum(x => x.Value);
-        }
-
-        public static int GetNumberOfApprovals(this PromotionCampaignSummary campaign)
-        {
-            return campaign.CommentCounts
-                .Where(x => x.Key == PromotionSentiment.Approve)
-                .Sum(x => x.Value);
-        }
-
-        public static int GetNumberOfOppositions(this PromotionCampaignSummary campaign)
-        {
-            return campaign.CommentCounts
-                .Where(x => x.Key == PromotionSentiment.Oppose)
-                .Sum(x => x.Value);
-        }
-
         public static TimeSpan GetTimeUntilCampaignCanBeClosed(this PromotionCampaignSummary campaign)
         {
             return campaign.CreateAction.Created.Add(CampaignAcceptCooldown) - DateTimeOffset.Now;

--- a/Modix/ClientApp/src/components/Promotions/PromotionListItem.vue
+++ b/Modix/ClientApp/src/components/Promotions/PromotionListItem.vue
@@ -34,10 +34,10 @@
             <div class="column is-narrow-tablet ratings">
                 <div class="columns is-mobile">
                     <div class="column rating" @click.stop="expandWithSentiment('Approve')">
-                        <span v-html="sentimentIcon('Approve')"></span> {{forCurrentUser ? '?' : campaign.votesFor}}
+                        <span v-html="sentimentIcon('Approve')"></span> {{forCurrentUser ? '?' : campaign.approveCount}}
                     </div>
                     <div class="column rating" @click.stop="expandWithSentiment('Oppose')">
-                        <span v-html="sentimentIcon('Oppose')"></span> {{forCurrentUser ? '?' : campaign.votesAgainst}}
+                        <span v-html="sentimentIcon('Oppose')"></span> {{forCurrentUser ? '?' : campaign.opposeCount}}
                     </div>
                 </div>
 

--- a/Modix/ClientApp/src/models/promotions/PromotionCampaign.ts
+++ b/Modix/ClientApp/src/models/promotions/PromotionCampaign.ts
@@ -42,13 +42,9 @@ export default class PromotionCampaign
     createAction?:   PromotionAction;
     outcome:         CampaignOutcome = CampaignOutcome.Failed;
     closeAction?:    PromotionAction;
-
-    commentCounts: {[sentiment in PromotionSentiment]: number} =
-    {
-        "Abstain": 0,
-        "Approve": 0,
-        "Oppose": 0
-    };
+    abstainCount:    number = 5;
+    approveCount:    number = 6;
+    opposeCount:     number = 7;
 
     get isActive(): boolean
     {
@@ -57,22 +53,12 @@ export default class PromotionCampaign
 
     get sentimentRatio(): number
     {
-        if (this.votesFor > 0 || this.votesAgainst > 0)
+        if (this.approveCount > 0 || this.opposeCount > 0)
         {
-            return this.votesFor / (this.votesFor + this.votesAgainst);
+            return this.approveCount / (this.approveCount + this.opposeCount);
         }
 
         return 0;
-    }
-
-    get votesFor(): number
-    {
-        return this.commentCounts[PromotionSentiment.Approve] || 0;
-    }
-
-    get votesAgainst(): number
-    {
-        return this.commentCounts[PromotionSentiment.Oppose] || 0;
     }
 
     get startDate(): Date


### PR DESCRIPTION
Fixed that queries for `PromotionCampaignSummary` were performing aggregations in-memory.