### PR TITLE
MessageEntity.Id Snapshot Corruption

### DIFF
--- a/Modix.Data/Migrations/ModixContextModelSnapshot.cs
+++ b/Modix.Data/Migrations/ModixContextModelSnapshot.cs
@@ -282,7 +282,6 @@ namespace Modix.Data.Migrations
             modelBuilder.Entity("Modix.Data.Models.Core.MessageEntity", b =>
                 {
                     b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
                     b.Property<long>("AuthorId")

--- a/Modix.Data/Models/Core/MessageEntity.cs
+++ b/Modix.Data/Models/Core/MessageEntity.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using Modix.Data.Models.Moderation;
-using Modix.Data.Utilities;
 
 namespace Modix.Data.Models.Core
 {
     public class MessageEntity
     {
         [Required]
+        [DatabaseGenerated(DatabaseGeneratedOption.None)]
         public ulong Id { get; set; }
 
         [Required]


### PR DESCRIPTION
Removed bogus value-generation definitions for MessageEntity.

Message ID values come from Discord and should not be generated. It was an oversight that this column was not annotated to have no generation, when this feature was originally added, as the default behavior is, by intention, to have value-generation added for primary key columns.

Since this column has a value conversion defined, Npgsql.EntityFrameworkCore does not actually support value generation, and this causes bogus migrations to be generated. I.E. generating a migration upon Modix.Data, without making any changes, results in a non-empty migration.

Additionally, at some point, the model snapshot got corrupt, with respect to this entity. This might be related to the EF Core 3.0 upgrade, as there were previous bugs associated with value generation for columns with type conversions. In any case, the end result is that the Model Snapshot thinks this column should have an associated ID sequence, when no such sequence in fact exists within the database.

As such, there is no migration needed here. The model simply needs to be updated to reflect the actual state of the database.