### PR TITLE
Followup to #719. Missed a spot.

### DIFF
--- a/Modix.Data/Migrations/20200217042656_MessageStatsSnapshotReconciliation.Designer.cs
+++ b/Modix.Data/Migrations/20200217042656_MessageStatsSnapshotReconciliation.Designer.cs
@@ -310,7 +310,6 @@ namespace Modix.Data.Migrations
             modelBuilder.Entity("Modix.Data.Models.Core.MessageEntity", b =>
                 {
                     b.Property<long>("Id")
-                        .ValueGeneratedOnAdd()
                         .HasColumnType("bigint");
 
                     b.Property<long>("AuthorId")


### PR DESCRIPTION
Having this line in the migration-embedded snapshot means that creating a new migration, then removing it, results in a snapshot that is not the same as it was originally.