### PR TITLE
DbSet<TEntity> Usage

### DIFF
--- a/Modix.Data.Test/Repositories/ClaimMappingRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/ClaimMappingRepositoryTests.cs
@@ -25,10 +25,10 @@ namespace Modix.Data.Test.Repositories
         {
             var modixContext = TestDataContextFactory.BuildTestDataContext(x =>
             {
-                x.Users.AddRange(Users.Entities.Clone());
-                x.GuildUsers.AddRange(GuildUsers.Entities.Clone());
-                x.ClaimMappings.AddRange(ClaimMappings.Entities.Clone());
-                x.ConfigurationActions.AddRange(ConfigurationActions.Entities.Where(y => !(y.ClaimMappingId is null)).Clone());
+                x.Set<UserEntity>().AddRange(Users.Entities.Clone());
+                x.Set<GuildUserEntity>().AddRange(GuildUsers.Entities.Clone());
+                x.Set<ClaimMappingEntity>().AddRange(ClaimMappings.Entities.Clone());
+                x.Set<ConfigurationActionEntity>().AddRange(ConfigurationActions.Entities.Where(y => !(y.ClaimMappingId is null)).Clone());
             });
 
             var uut = new ClaimMappingRepository(modixContext);
@@ -183,8 +183,8 @@ namespace Modix.Data.Test.Repositories
 
             var id = await uut.CreateAsync(data);
 
-            modixContext.ClaimMappings.ShouldContain(x => x.Id == id);
-            var claimMapping = modixContext.ClaimMappings.First(x => x.Id == id);
+            modixContext.Set<ClaimMappingEntity>().ShouldContain(x => x.Id == id);
+            var claimMapping = modixContext.Set<ClaimMappingEntity>().First(x => x.Id == id);
 
             claimMapping.GuildId.ShouldBe(data.GuildId);
             claimMapping.Type.ShouldBe(data.Type);
@@ -192,9 +192,9 @@ namespace Modix.Data.Test.Repositories
             claimMapping.UserId.ShouldBe(data.UserId);
             claimMapping.Claim.ShouldBe(data.Claim);
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .ShouldContain(x => x.Id == claimMapping.CreateActionId);
-            var createAction = modixContext.ConfigurationActions
+            var createAction = modixContext.Set<ConfigurationActionEntity>()
                 .First(x => x.Id == claimMapping.CreateActionId);
 
             createAction.GuildId.ShouldBe(data.GuildId);
@@ -325,9 +325,9 @@ namespace Modix.Data.Test.Repositories
 
             result.ShouldBeTrue();
 
-            modixContext.ClaimMappings
+            modixContext.Set<ClaimMappingEntity>()
                 .ShouldContain(x => x.Id == claimMappingId);
-            var claimMapping = modixContext.ClaimMappings
+            var claimMapping = modixContext.Set<ClaimMappingEntity>()
                 .First(x => x.Id == claimMappingId);
 
             var originalClaimMapping = ClaimMappings.Entities
@@ -341,19 +341,19 @@ namespace Modix.Data.Test.Repositories
             claimMapping.CreateActionId.ShouldBe(originalClaimMapping.CreateActionId);
             claimMapping.DeleteActionId.ShouldNotBeNull();
 
-            modixContext.ClaimMappings
+            modixContext.Set<ClaimMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ClaimMappings.Entities
                     .Select(x => x.Id));
 
-            modixContext.ClaimMappings
+            modixContext.Set<ClaimMappingEntity>()
                 .Where(x => x.Id != claimMappingId)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .ShouldContain(x => x.Id == claimMapping.DeleteActionId);
-            var deleteAction = modixContext.ConfigurationActions
+            var deleteAction = modixContext.Set<ConfigurationActionEntity>()
                 .First(x => x.Id == claimMapping.DeleteActionId);
 
             deleteAction.GuildId.ShouldBe(claimMapping.GuildId);
@@ -366,14 +366,14 @@ namespace Modix.Data.Test.Repositories
             deleteAction.DesignatedChannelMappingId.ShouldBeNull();
             deleteAction.DesignatedRoleMappingId.ShouldBeNull();
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .Where(x => x.Id != deleteAction.Id)
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => !(x.ClaimMappingId is null))
                     .Select(x => x.Id));
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .Where(x => x.Id != deleteAction.Id)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -391,24 +391,24 @@ namespace Modix.Data.Test.Repositories
 
             result.ShouldBeFalse();
 
-            modixContext.ClaimMappings
+            modixContext.Set<ClaimMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ClaimMappings.Entities
                     .Select(x => x.Id));
 
-            modixContext.ClaimMappings
+            modixContext.Set<ClaimMappingEntity>()
                 .Where(x => x.Id != claimMappingId)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => !(x.ClaimMappingId is null))
                     .Select(x => x.Id));
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()

--- a/Modix.Data.Test/Repositories/ConfigurationActionRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/ConfigurationActionRepositoryTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 
+using Modix.Data.Models.Core;
 using Modix.Data.Repositories;
 using Modix.Data.Test.TestData;
 
@@ -19,14 +20,14 @@ namespace Modix.Data.Test.Repositories
         {
             var modixContext = TestDataContextFactory.BuildTestDataContext(x =>
             {
-                x.Users.AddRange(Users.Entities.Clone());
-                x.GuildUsers.AddRange(GuildUsers.Entities.Clone());
-                x.GuildRoles.AddRange(GuildRoles.Entities.Clone());
-                x.GuildChannels.AddRange(GuildChannels.Entities.Clone());
-                x.ClaimMappings.AddRange(ClaimMappings.Entities.Clone());
-                x.DesignatedChannelMappings.AddRange(DesignatedChannelMappings.Entities.Clone());
-                x.DesignatedRoleMappings.AddRange(DesignatedRoleMappings.Entities.Clone());
-                x.ConfigurationActions.AddRange(ConfigurationActions.Entities.Clone());
+                x.Set<UserEntity>().AddRange(Users.Entities.Clone());
+                x.Set<GuildUserEntity>().AddRange(GuildUsers.Entities.Clone());
+                x.Set<GuildRoleEntity>().AddRange(GuildRoles.Entities.Clone());
+                x.Set<GuildChannelEntity>().AddRange(GuildChannels.Entities.Clone());
+                x.Set<ClaimMappingEntity>().AddRange(ClaimMappings.Entities.Clone());
+                x.Set<DesignatedChannelMappingEntity>().AddRange(DesignatedChannelMappings.Entities.Clone());
+                x.Set<DesignatedRoleMappingEntity>().AddRange(DesignatedRoleMappings.Entities.Clone());
+                x.Set<ConfigurationActionEntity>().AddRange(ConfigurationActions.Entities.Clone());
             });
 
             var uut = new ConfigurationActionRepository(modixContext);

--- a/Modix.Data.Test/Repositories/DesignatedChannelMappingRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/DesignatedChannelMappingRepositoryTests.cs
@@ -24,11 +24,11 @@ namespace Modix.Data.Test.Repositories
         {
             var modixContext = TestDataContextFactory.BuildTestDataContext(x =>
             {
-                x.Users.AddRange(Users.Entities.Clone());
-                x.GuildUsers.AddRange(GuildUsers.Entities.Clone());
-                x.GuildChannels.AddRange(GuildChannels.Entities.Clone());
-                x.DesignatedChannelMappings.AddRange(DesignatedChannelMappings.Entities.Clone());
-                x.ConfigurationActions.AddRange(ConfigurationActions.Entities.Where(y => !(y.DesignatedChannelMappingId is null)).Clone());
+                x.Set<UserEntity>().AddRange(Users.Entities.Clone());
+                x.Set<GuildUserEntity>().AddRange(GuildUsers.Entities.Clone());
+                x.Set<GuildChannelEntity>().AddRange(GuildChannels.Entities.Clone());
+                x.Set<DesignatedChannelMappingEntity>().AddRange(DesignatedChannelMappings.Entities.Clone());
+                x.Set<ConfigurationActionEntity>().AddRange(ConfigurationActions.Entities.Where(y => !(y.DesignatedChannelMappingId is null)).Clone());
             });
 
             var uut = new DesignatedChannelMappingRepository(modixContext);
@@ -187,12 +187,12 @@ namespace Modix.Data.Test.Repositories
 
             await Should.ThrowAsync<ArgumentNullException>(uut.CreateAsync(null!));
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedChannelMappings.Entities.Select(x => x.Id));
 
-            modixContext.DesignatedChannelMappings.EachShould(x => x.ShouldNotHaveChanged());
+            modixContext.Set<DesignatedChannelMappingEntity>().EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
                 .SaveChangesAsync();
@@ -205,8 +205,8 @@ namespace Modix.Data.Test.Repositories
 
             var id = await uut.CreateAsync(data);
 
-            modixContext.DesignatedChannelMappings.ShouldContain(x => x.Id == id);
-            var designatedChannelMapping = modixContext.DesignatedChannelMappings.First(x => x.Id == id);
+            modixContext.Set<DesignatedChannelMappingEntity>().ShouldContain(x => x.Id == id);
+            var designatedChannelMapping = modixContext.Set<DesignatedChannelMappingEntity>().First(x => x.Id == id);
 
             designatedChannelMapping.GuildId.ShouldBe(data.GuildId);
             designatedChannelMapping.Type.ShouldBe(data.Type);
@@ -214,11 +214,11 @@ namespace Modix.Data.Test.Repositories
             designatedChannelMapping.CreateActionId.ShouldNotBeNull();
             designatedChannelMapping.DeleteActionId.ShouldBeNull();
 
-            modixContext.DesignatedChannelMappings.Where(x => x.Id != designatedChannelMapping.Id).Select(x => x.Id).ShouldBe(DesignatedChannelMappings.Entities.Select(x => x.Id));
-            modixContext.DesignatedChannelMappings.Where(x => x.Id != designatedChannelMapping.Id).EachShould(x => x.ShouldNotHaveChanged());
+            modixContext.Set<DesignatedChannelMappingEntity>().Where(x => x.Id != designatedChannelMapping.Id).Select(x => x.Id).ShouldBe(DesignatedChannelMappings.Entities.Select(x => x.Id));
+            modixContext.Set<DesignatedChannelMappingEntity>().Where(x => x.Id != designatedChannelMapping.Id).EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions.ShouldContain(x => x.Id == designatedChannelMapping.CreateActionId);
-            var createAction = modixContext.ConfigurationActions.First(x => x.Id == designatedChannelMapping.CreateActionId);
+            modixContext.Set<ConfigurationActionEntity>().ShouldContain(x => x.Id == designatedChannelMapping.CreateActionId);
+            var createAction = modixContext.Set<ConfigurationActionEntity>().First(x => x.Id == designatedChannelMapping.CreateActionId);
 
             createAction.GuildId.ShouldBe(data.GuildId);
             createAction.Type.ShouldBe(ConfigurationActionType.DesignatedChannelMappingCreated);
@@ -230,8 +230,8 @@ namespace Modix.Data.Test.Repositories
             createAction.DesignatedChannelMappingId.ShouldBe(designatedChannelMapping.Id);
             createAction.DesignatedRoleMappingId.ShouldBeNull();
 
-            modixContext.ConfigurationActions.Where(x => x.Id != createAction.Id).Select(x => x.Id).ShouldBe(ConfigurationActions.Entities.Where(x => !(x.DesignatedChannelMappingId is null)).Select(x => x.Id));
-            modixContext.ConfigurationActions.Where(x => x.Id != createAction.Id).EachShould(x => x.ShouldNotHaveChanged());
+            modixContext.Set<ConfigurationActionEntity>().Where(x => x.Id != createAction.Id).Select(x => x.Id).ShouldBe(ConfigurationActions.Entities.Where(x => !(x.DesignatedChannelMappingId is null)).Select(x => x.Id));
+            modixContext.Set<ConfigurationActionEntity>().Where(x => x.Id != createAction.Id).EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldHaveReceived(2)
                 .SaveChangesAsync();
@@ -330,12 +330,12 @@ namespace Modix.Data.Test.Repositories
                     .Any(y => (y.Id == x) && (y.DeleteActionId == null)))
                 .Count());
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedChannelMappings.Entities.Select(x => x.Id));
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .Where(x => designatedChannelMappingIds.Contains(x.Id) && (x.DeleteActionId == null))
                 .EachShould(entity =>
                 {
@@ -347,8 +347,8 @@ namespace Modix.Data.Test.Repositories
                     entity.CreateActionId.ShouldBe(originalEntity.CreateActionId);
                     entity.DeleteActionId.ShouldNotBeNull();
 
-                    modixContext.ConfigurationActions.ShouldContain(x => x.Id == entity.DeleteActionId);
-                    var deleteAction = modixContext.ConfigurationActions.First(x => x.Id == entity.DeleteActionId);
+                    modixContext.Set<ConfigurationActionEntity>().ShouldContain(x => x.Id == entity.DeleteActionId);
+                    var deleteAction = modixContext.Set<ConfigurationActionEntity>().First(x => x.Id == entity.DeleteActionId);
 
                     deleteAction.GuildId.ShouldBe(entity.GuildId);
                     deleteAction.Type.ShouldBe(ConfigurationActionType.DesignatedChannelMappingDeleted);
@@ -361,13 +361,13 @@ namespace Modix.Data.Test.Repositories
                     deleteAction.DesignatedRoleMappingId.ShouldBeNull();
                 });
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .AsEnumerable()
                 .Where(x => !designatedChannelMappingIds.Contains(x.Id) || DesignatedChannelMappings.Entities
                     .Any(y => (y.Id == x.Id) && (x.DeleteActionId == null)))
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .AsEnumerable()
                 .Where(x => DesignatedChannelMappings.Entities
                     .Any(y => (y.DeleteActionId == x.Id) && designatedChannelMappingIds.Contains(y.Id)))
@@ -386,23 +386,23 @@ namespace Modix.Data.Test.Repositories
 
             result.ShouldBe(0);
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedChannelMappings.Entities
                     .Select(x => x.Id));
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => x.DesignatedChannelMappingId != null)
                     .Select(x => x.Id));
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldHaveReceived(1)
@@ -422,9 +422,9 @@ namespace Modix.Data.Test.Repositories
 
             result.ShouldBeTrue();
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .ShouldContain(x => x.Id == designatedChannelMappingId);
-            var designatedChannelMapping = modixContext.DesignatedChannelMappings
+            var designatedChannelMapping = modixContext.Set<DesignatedChannelMappingEntity>()
                 .First(x => x.Id == designatedChannelMappingId);
 
             var originalDesignatedChannelMapping = DesignatedChannelMappings.Entities
@@ -436,19 +436,19 @@ namespace Modix.Data.Test.Repositories
             designatedChannelMapping.CreateActionId.ShouldBe(originalDesignatedChannelMapping.CreateActionId);
             designatedChannelMapping.DeleteActionId.ShouldNotBeNull();
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedChannelMappings.Entities
                     .Select(x => x.Id));
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .Where(x => x.Id != designatedChannelMappingId)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .ShouldContain(x => x.Id == designatedChannelMapping.DeleteActionId);
-            var deleteAction = modixContext.ConfigurationActions
+            var deleteAction = modixContext.Set<ConfigurationActionEntity>()
                 .First(x => x.Id == designatedChannelMapping.DeleteActionId);
 
             deleteAction.GuildId.ShouldBe(designatedChannelMapping.GuildId);
@@ -461,14 +461,14 @@ namespace Modix.Data.Test.Repositories
             deleteAction.DesignatedChannelMappingId.ShouldBe(designatedChannelMapping.Id);
             deleteAction.DesignatedRoleMappingId.ShouldBeNull();
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .Where(x => x.Id != deleteAction.Id)
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => !(x.DesignatedChannelMappingId is null))
                     .Select(x => x.Id));
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .Where(x => x.Id != deleteAction.Id)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -486,23 +486,23 @@ namespace Modix.Data.Test.Repositories
 
             result.ShouldBeFalse();
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedChannelMappings.Entities
                     .Select(x => x.Id));
 
-            modixContext.DesignatedChannelMappings
+            modixContext.Set<DesignatedChannelMappingEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => !(x.DesignatedChannelMappingId is null))
                     .Select(x => x.Id));
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()

--- a/Modix.Data.Test/Repositories/DesignatedRoleMappingRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/DesignatedRoleMappingRepositoryTests.cs
@@ -24,11 +24,11 @@ namespace Modix.Data.Test.Repositories
         {
             var modixContext = TestDataContextFactory.BuildTestDataContext(x =>
             {
-                x.Users.AddRange(Users.Entities.Clone());
-                x.GuildUsers.AddRange(GuildUsers.Entities.Clone());
-                x.GuildRoles.AddRange(GuildRoles.Entities.Clone());
-                x.DesignatedRoleMappings.AddRange(DesignatedRoleMappings.Entities.Clone());
-                x.ConfigurationActions.AddRange(ConfigurationActions.Entities.Where(y => !(y.DesignatedRoleMappingId is null)).Clone());
+                x.Set<UserEntity>().AddRange(Users.Entities.Clone());
+                x.Set<GuildUserEntity>().AddRange(GuildUsers.Entities.Clone());
+                x.Set<GuildRoleEntity>().AddRange(GuildRoles.Entities.Clone());
+                x.Set<DesignatedRoleMappingEntity>().AddRange(DesignatedRoleMappings.Entities.Clone());
+                x.Set<ConfigurationActionEntity>().AddRange(ConfigurationActions.Entities.Where(y => !(y.DesignatedRoleMappingId is null)).Clone());
             });
 
             var uut = new DesignatedRoleMappingRepository(modixContext);
@@ -187,9 +187,9 @@ namespace Modix.Data.Test.Repositories
 
             await Should.ThrowAsync<ArgumentNullException>(uut.CreateAsync(null!));
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .AsQueryable().Select(x => x.Id).ShouldBe(DesignatedRoleMappings.Entities.Select(x => x.Id));
-            modixContext.DesignatedRoleMappings.EachShould(x => x.ShouldNotHaveChanged());
+            modixContext.Set<DesignatedRoleMappingEntity>().EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
                 .SaveChangesAsync();
@@ -202,8 +202,8 @@ namespace Modix.Data.Test.Repositories
 
             var id = await uut.CreateAsync(data);
 
-            modixContext.DesignatedRoleMappings.ShouldContain(x => x.Id == id);
-            var designatedRoleMapping = modixContext.DesignatedRoleMappings.First(x => x.Id == id);
+            modixContext.Set<DesignatedRoleMappingEntity>().ShouldContain(x => x.Id == id);
+            var designatedRoleMapping = modixContext.Set<DesignatedRoleMappingEntity>().First(x => x.Id == id);
 
             designatedRoleMapping.GuildId.ShouldBe(data.GuildId);
             designatedRoleMapping.Type.ShouldBe(data.Type);
@@ -211,11 +211,11 @@ namespace Modix.Data.Test.Repositories
             designatedRoleMapping.CreateActionId.ShouldNotBeNull();
             designatedRoleMapping.DeleteActionId.ShouldBeNull();
 
-            modixContext.DesignatedRoleMappings.Where(x => x.Id != designatedRoleMapping.Id).Select(x => x.Id).ShouldBe(DesignatedRoleMappings.Entities.Select(x => x.Id));
-            modixContext.DesignatedRoleMappings.Where(x => x.Id != designatedRoleMapping.Id).EachShould(x => x.ShouldNotHaveChanged());
+            modixContext.Set<DesignatedRoleMappingEntity>().Where(x => x.Id != designatedRoleMapping.Id).Select(x => x.Id).ShouldBe(DesignatedRoleMappings.Entities.Select(x => x.Id));
+            modixContext.Set<DesignatedRoleMappingEntity>().Where(x => x.Id != designatedRoleMapping.Id).EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions.ShouldContain(x => x.Id == designatedRoleMapping.CreateActionId);
-            var createAction = modixContext.ConfigurationActions.First(x => x.Id == designatedRoleMapping.CreateActionId);
+            modixContext.Set<ConfigurationActionEntity>().ShouldContain(x => x.Id == designatedRoleMapping.CreateActionId);
+            var createAction = modixContext.Set<ConfigurationActionEntity>().First(x => x.Id == designatedRoleMapping.CreateActionId);
 
             createAction.GuildId.ShouldBe(data.GuildId);
             createAction.Type.ShouldBe(ConfigurationActionType.DesignatedRoleMappingCreated);
@@ -227,8 +227,8 @@ namespace Modix.Data.Test.Repositories
             createAction.DesignatedRoleMappingId.ShouldNotBeNull();
             createAction.DesignatedRoleMappingId.ShouldBe(designatedRoleMapping.Id);
 
-            modixContext.ConfigurationActions.Where(x => x.Id != createAction.Id).Select(x => x.Id).ShouldBe(ConfigurationActions.Entities.Where(x => !(x.DesignatedRoleMappingId is null)).Select(x => x.Id));
-            modixContext.ConfigurationActions.Where(x => x.Id != createAction.Id).EachShould(x => x.ShouldNotHaveChanged());
+            modixContext.Set<ConfigurationActionEntity>().Where(x => x.Id != createAction.Id).Select(x => x.Id).ShouldBe(ConfigurationActions.Entities.Where(x => !(x.DesignatedRoleMappingId is null)).Select(x => x.Id));
+            modixContext.Set<ConfigurationActionEntity>().Where(x => x.Id != createAction.Id).EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldHaveReceived(2)
                 .SaveChangesAsync();
@@ -301,12 +301,12 @@ namespace Modix.Data.Test.Repositories
                     .Any(y => (y.Id == x) && (y.DeleteActionId == null)))
                 .Count());
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedRoleMappings.Entities.Select(x => x.Id));
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .Where(x => designatedRoleMappingIds.Contains(x.Id) && (x.DeleteActionId == null))
                 .EachShould(entity =>
                 {
@@ -318,8 +318,8 @@ namespace Modix.Data.Test.Repositories
                     entity.CreateActionId.ShouldBe(originalEntity.CreateActionId);
                     entity.DeleteActionId.ShouldNotBeNull();
 
-                    modixContext.ConfigurationActions.ShouldContain(x => x.Id == entity.DeleteActionId);
-                    var deleteAction = modixContext.ConfigurationActions.First(x => x.Id == entity.DeleteActionId);
+                    modixContext.Set<ConfigurationActionEntity>().ShouldContain(x => x.Id == entity.DeleteActionId);
+                    var deleteAction = modixContext.Set<ConfigurationActionEntity>().First(x => x.Id == entity.DeleteActionId);
 
                     deleteAction.GuildId.ShouldBe(entity.GuildId);
                     deleteAction.Type.ShouldBe(ConfigurationActionType.DesignatedRoleMappingDeleted);
@@ -332,13 +332,13 @@ namespace Modix.Data.Test.Repositories
                     deleteAction.DesignatedRoleMappingId.ShouldBeNull();
                 });
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .AsEnumerable()
                 .Where(x => !designatedRoleMappingIds.Contains(x.Id) || DesignatedRoleMappings.Entities
                     .Any(y => (y.Id == x.Id) && (x.DeleteActionId == null)))
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .AsEnumerable()
                 .Where(x => DesignatedRoleMappings.Entities
                     .Any(y => (y.DeleteActionId == x.Id) && designatedRoleMappingIds.Contains(y.Id)))
@@ -357,23 +357,23 @@ namespace Modix.Data.Test.Repositories
 
             result.ShouldBe(0);
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedRoleMappings.Entities
                     .Select(x => x.Id));
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => x.DesignatedRoleMappingId != null)
                     .Select(x => x.Id));
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldHaveReceived(1)
@@ -393,9 +393,9 @@ namespace Modix.Data.Test.Repositories
 
             result.ShouldBeTrue();
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .ShouldContain(x => x.Id == designatedRoleMappingId);
-            var designatedRoleMapping = modixContext.DesignatedRoleMappings
+            var designatedRoleMapping = modixContext.Set<DesignatedRoleMappingEntity>()
                 .First(x => x.Id == designatedRoleMappingId);
 
             var originalDesignatedRoleMapping = DesignatedRoleMappings.Entities
@@ -407,19 +407,19 @@ namespace Modix.Data.Test.Repositories
             designatedRoleMapping.CreateActionId.ShouldBe(originalDesignatedRoleMapping.CreateActionId);
             designatedRoleMapping.DeleteActionId.ShouldNotBeNull();
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedRoleMappings.Entities
                     .Select(x => x.Id));
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .Where(x => x.Id != designatedRoleMappingId)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .ShouldContain(x => x.Id == designatedRoleMapping.DeleteActionId);
-            var deleteAction = modixContext.ConfigurationActions
+            var deleteAction = modixContext.Set<ConfigurationActionEntity>()
                 .First(x => x.Id == designatedRoleMapping.DeleteActionId);
 
             deleteAction.GuildId.ShouldBe(designatedRoleMapping.GuildId);
@@ -432,14 +432,14 @@ namespace Modix.Data.Test.Repositories
             deleteAction.DesignatedRoleMappingId.ShouldNotBeNull();
             deleteAction.DesignatedRoleMappingId.ShouldBe(designatedRoleMapping.Id);
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .Where(x => x.Id != deleteAction.Id)
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => !(x.DesignatedRoleMappingId is null))
                     .Select(x => x.Id));
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .Where(x => x.Id != deleteAction.Id)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -457,23 +457,23 @@ namespace Modix.Data.Test.Repositories
 
             result.ShouldBeFalse();
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(DesignatedRoleMappings.Entities
                     .Select(x => x.Id));
 
-            modixContext.DesignatedRoleMappings
+            modixContext.Set<DesignatedRoleMappingEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(ConfigurationActions.Entities
                     .Where(x => !(x.DesignatedRoleMappingId is null))
                     .Select(x => x.Id));
 
-            modixContext.ConfigurationActions
+            modixContext.Set<ConfigurationActionEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()

--- a/Modix.Data.Test/Repositories/GuildChannelRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/GuildChannelRepositoryTests.cs
@@ -25,7 +25,7 @@ namespace Modix.Data.Test.Repositories
         {
             var modixContext = TestDataContextFactory.BuildTestDataContext(x =>
             {
-                x.GuildChannels.AddRange(GuildChannels.Entities.Clone());
+                x.Set<GuildChannelEntity>().AddRange(GuildChannels.Entities.Clone());
             });
 
             var uut = new GuildChannelRepository(modixContext);
@@ -120,13 +120,13 @@ namespace Modix.Data.Test.Repositories
 
             await Should.ThrowAsync<ArgumentNullException>(uut.CreateAsync(null!));
 
-            modixContext.GuildChannels
+            modixContext.Set<GuildChannelEntity>()
                 .AsQueryable()
                 .Select(x => x.ChannelId)
                 .ShouldBe(GuildChannels.Entities
                     .Select(x => x.ChannelId));
 
-            modixContext.GuildChannels
+            modixContext.Set<GuildChannelEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -142,21 +142,21 @@ namespace Modix.Data.Test.Repositories
             {
                 await uut.CreateAsync(data, cancellationTokenSource.Token);
 
-                modixContext.GuildChannels
+                modixContext.Set<GuildChannelEntity>()
                     .ShouldContain(x => x.ChannelId == data.ChannelId);
-                var channel = modixContext.GuildChannels
+                var channel = modixContext.Set<GuildChannelEntity>()
                     .First(x => x.ChannelId == data.ChannelId);
 
                 channel.GuildId.ShouldBe(data.GuildId);
                 channel.Name.ShouldBe(data.Name);
 
-                modixContext.GuildChannels
+                modixContext.Set<GuildChannelEntity>()
                     .Where(x => x.ChannelId != channel.ChannelId)
                     .Select(x => x.ChannelId)
                     .ShouldBe(GuildChannels.Entities
                         .Select(x => x.ChannelId));
 
-                modixContext.GuildChannels
+                modixContext.Set<GuildChannelEntity>()
                     .Where(x => x.ChannelId != channel.ChannelId)
                     .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -172,13 +172,13 @@ namespace Modix.Data.Test.Repositories
 
             await Should.ThrowAsync<InvalidOperationException>(uut.CreateAsync(data));
 
-            modixContext.GuildChannels
+            modixContext.Set<GuildChannelEntity>()
                 .AsQueryable()
                 .Select(x => x.ChannelId)
                 .ShouldBe(GuildChannels.Entities
                     .Select(x => x.ChannelId));
 
-            modixContext.GuildChannels
+            modixContext.Set<GuildChannelEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -197,13 +197,13 @@ namespace Modix.Data.Test.Repositories
             await Should.ThrowAsync<ArgumentNullException>(async () =>
                 await uut.TryUpdateAsync(1, null!));
 
-            modixContext.GuildChannels
+            modixContext.Set<GuildChannelEntity>()
                 .AsQueryable()
                 .Select(x => x.ChannelId)
                 .ShouldBe(GuildChannels.Entities
                     .Select(x => x.ChannelId));
 
-            modixContext.GuildChannels
+            modixContext.Set<GuildChannelEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -215,7 +215,7 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            var guildChannel = modixContext.GuildChannels.Single(x => x.ChannelId == channelId);
+            var guildChannel = modixContext.Set<GuildChannelEntity>().Single(x => x.ChannelId == channelId);
 
             var mutatedData = new GuildChannelMutationData()
             {
@@ -235,13 +235,13 @@ namespace Modix.Data.Test.Repositories
 
                 guildChannel.Name.ShouldBe(mutatedData.Name);
 
-                modixContext.GuildChannels
+                modixContext.Set<GuildChannelEntity>()
                 .AsQueryable()
                     .Select(x => x.ChannelId)
                     .ShouldBe(GuildChannels.Entities
                         .Select(x => x.ChannelId));
 
-                modixContext.GuildChannels
+                modixContext.Set<GuildChannelEntity>()
                     .Where(x => x.ChannelId != channelId)
                     .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -264,13 +264,13 @@ namespace Modix.Data.Test.Repositories
             updateAction.ShouldNotHaveReceived()
                 .Invoke(Arg.Any<GuildChannelMutationData>());
 
-            modixContext.GuildChannels
+            modixContext.Set<GuildChannelEntity>()
                 .AsQueryable()
                 .Select(x => x.ChannelId)
                 .ShouldBe(GuildChannels.Entities
                     .Select(x => x.ChannelId));
 
-            modixContext.GuildChannels
+            modixContext.Set<GuildChannelEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()

--- a/Modix.Data.Test/Repositories/GuildRoleRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/GuildRoleRepositoryTests.cs
@@ -24,7 +24,7 @@ namespace Modix.Data.Test.Repositories
         {
             var modixContext = TestDataContextFactory.BuildTestDataContext(x =>
             {
-                x.GuildRoles.AddRange(GuildRoles.Entities.Clone());
+                x.Set<GuildRoleEntity>().AddRange(GuildRoles.Entities.Clone());
             });
 
             var uut = new GuildRoleRepository(modixContext);
@@ -103,13 +103,13 @@ namespace Modix.Data.Test.Repositories
 
             await Should.ThrowAsync<ArgumentNullException>(uut.CreateAsync(null!));
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .AsQueryable()
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -123,20 +123,20 @@ namespace Modix.Data.Test.Repositories
 
             await uut.CreateAsync(data);
 
-            modixContext.GuildRoles.ShouldContain(x => x.RoleId == data.RoleId);
-            var role = modixContext.GuildRoles.First(x => x.RoleId == data.RoleId);
+            modixContext.Set<GuildRoleEntity>().ShouldContain(x => x.RoleId == data.RoleId);
+            var role = modixContext.Set<GuildRoleEntity>().First(x => x.RoleId == data.RoleId);
 
             role.GuildId.ShouldBe(data.GuildId);
             role.Name.ShouldBe(data.Name);
             role.Position.ShouldBe(data.Position);
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .Where(x => x.RoleId != role.RoleId)
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .Where(x => x.RoleId != role.RoleId)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -151,13 +151,13 @@ namespace Modix.Data.Test.Repositories
 
             await Should.ThrowAsync<InvalidOperationException>(uut.CreateAsync(data));
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .AsQueryable()
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -176,13 +176,13 @@ namespace Modix.Data.Test.Repositories
             await Should.ThrowAsync<ArgumentNullException>(async () =>
                 await uut.TryUpdateAsync(1, null!));
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .AsQueryable()
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -194,7 +194,7 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            var guildRole = modixContext.GuildRoles.Single(x => x.RoleId == roleId);
+            var guildRole = modixContext.Set<GuildRoleEntity>().Single(x => x.RoleId == roleId);
 
             var mutatedData = new GuildRoleMutationData()
             {
@@ -216,13 +216,13 @@ namespace Modix.Data.Test.Repositories
             guildRole.Name.ShouldBe(mutatedData.Name);
             guildRole.Position.ShouldBe(mutatedData.Position);
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .AsQueryable()
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .Where(x => x.RoleId != roleId)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -244,13 +244,13 @@ namespace Modix.Data.Test.Repositories
             updateAction.ShouldNotHaveReceived()
                 .Invoke(Arg.Any<GuildRoleMutationData>());
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .AsQueryable()
                 .Select(x => x.RoleId)
                 .ShouldBe(GuildRoles.Entities
                     .Select(x => x.RoleId));
 
-            modixContext.GuildRoles
+            modixContext.Set<GuildRoleEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()

--- a/Modix.Data.Test/Repositories/GuildUserRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/GuildUserRepositoryTests.cs
@@ -24,8 +24,8 @@ namespace Modix.Data.Test.Repositories
         {
             var modixContext = TestDataContextFactory.BuildTestDataContext(x =>
             {
-                x.Users.AddRange(Users.Entities.Clone());
-                x.GuildUsers.AddRange(GuildUsers.Entities.Clone());
+                x.Set<UserEntity>().AddRange(Users.Entities.Clone());
+                x.Set<GuildUserEntity>().AddRange(GuildUsers.Entities.Clone());
             });
 
             var uut = new GuildUserRepository(modixContext);
@@ -105,21 +105,21 @@ namespace Modix.Data.Test.Repositories
             await Should.ThrowAsync<ArgumentNullException>(async () => 
                 await uut.CreateAsync(null!));
 
-            modixContext.GuildUsers.AsEnumerable()
+            modixContext.Set<GuildUserEntity>().AsEnumerable()
                 .Select(x => (x.UserId, x.GuildId))
                 .ShouldBe(GuildUsers.Entities
                     .Select(x => (x.UserId, x.GuildId)));
 
-            modixContext.GuildUsers
+            modixContext.Set<GuildUserEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -133,19 +133,19 @@ namespace Modix.Data.Test.Repositories
 
             await uut.CreateAsync(data);
 
-            modixContext.Users.ShouldContain(x => x.Id == data.UserId);
-            var user = modixContext.Users.First(x => x.Id == data.UserId);
+            modixContext.Set<UserEntity>().ShouldContain(x => x.Id == data.UserId);
+            var user = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
 
             user.Username.ShouldBe(data.Username);
             user.Discriminator.ShouldBe(data.Discriminator);
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .Where(x => x.Id != user.Id)
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .Where(x => x.Id != user.Id)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -158,23 +158,23 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            var userCount = modixContext.Users.Count();
+            var userCount = modixContext.Set<UserEntity>().Count();
 
             await uut.CreateAsync(data);
 
-            modixContext.Users.Count().ShouldBe(userCount);
-            var user = modixContext.Users.First(x => x.Id == data.UserId);
+            modixContext.Set<UserEntity>().Count().ShouldBe(userCount);
+            var user = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
 
             user.Username.ShouldBe(data.Username);
             user.Discriminator.ShouldBe(data.Discriminator);
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .Where(x => x.Id != user.Id)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -189,23 +189,23 @@ namespace Modix.Data.Test.Repositories
 
             data.Username = null!;
 
-            var userCount = modixContext.Users.Count();
-            var previousUser = modixContext.Users.First(x => x.Id == data.UserId);
+            var userCount = modixContext.Set<UserEntity>().Count();
+            var previousUser = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
 
             await uut.CreateAsync(data);
 
-            modixContext.Users.Count().ShouldBe(userCount);
-            var user = modixContext.Users.First(x => x.Id == data.UserId);
+            modixContext.Set<UserEntity>().Count().ShouldBe(userCount);
+            var user = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
 
             user.Username.ShouldBe(previousUser.Username);
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .Where(x => x.Id != user.Id)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -220,23 +220,23 @@ namespace Modix.Data.Test.Repositories
 
             data.Discriminator = null!;
 
-            var userCount = modixContext.Users.Count();
-            var previousUser = modixContext.Users.First(x => x.Id == data.UserId);
+            var userCount = modixContext.Set<UserEntity>().Count();
+            var previousUser = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
 
             await uut.CreateAsync(data);
 
-            modixContext.Users.Count().ShouldBe(userCount);
-            var user = modixContext.Users.First(x => x.Id == data.UserId);
+            modixContext.Set<UserEntity>().Count().ShouldBe(userCount);
+            var user = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
 
             user.Discriminator.ShouldBe(previousUser.Discriminator);
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .Where(x => x.Id != user.Id)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -251,20 +251,23 @@ namespace Modix.Data.Test.Repositories
 
             await uut.CreateAsync(data);
 
-            modixContext.GuildUsers.ShouldContain(x => (x.GuildId == data.GuildId) && (x.UserId == data.UserId));
-            var guildUser = modixContext.GuildUsers.First(x => (x.GuildId == data.GuildId) && (x.UserId == data.UserId));
+            modixContext.Set<GuildUserEntity>()
+                .ShouldContain(x => (x.GuildId == data.GuildId) && (x.UserId == data.UserId));
+            var guildUser = modixContext.Set<GuildUserEntity>()
+                .First(x => (x.GuildId == data.GuildId) && (x.UserId == data.UserId));
 
             guildUser.Nickname.ShouldBe(data.Nickname);
             guildUser.FirstSeen.ShouldBe(data.FirstSeen);
             guildUser.LastSeen.ShouldBe(data.LastSeen);
 
-            modixContext.GuildUsers.AsEnumerable()
+            modixContext.Set<GuildUserEntity>()
+                .AsEnumerable()
                 .Where(x => (x.GuildId != guildUser.GuildId) || (x.UserId != guildUser.UserId))
                 .Select(x => (x.UserId, x.GuildId))
                 .ShouldBe(GuildUsers.Entities
                     .Select(x => (x.UserId, x.GuildId)));
 
-            modixContext.GuildUsers
+            modixContext.Set<GuildUserEntity>()
                 .Where(x => (x.UserId != guildUser.UserId) || (x.GuildId != guildUser.GuildId))
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -279,21 +282,21 @@ namespace Modix.Data.Test.Repositories
 
             await Should.ThrowAsync<InvalidOperationException>(uut.CreateAsync(data));
 
-            modixContext.GuildUsers.AsEnumerable()
+            modixContext.Set<GuildUserEntity>().AsEnumerable()
                 .Select(x => (x.UserId, x.GuildId))
                 .ShouldBe(GuildUsers.Entities
                     .Select(x => (x.UserId, x.GuildId)));
 
-            modixContext.GuildUsers
+            modixContext.Set<GuildUserEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -338,21 +341,21 @@ namespace Modix.Data.Test.Repositories
             await Should.ThrowAsync<ArgumentNullException>(async () =>
                 await uut.TryUpdateAsync(1, 1, null!));
 
-            modixContext.GuildUsers.AsEnumerable()
+            modixContext.Set<GuildUserEntity>().AsEnumerable()
                 .Select(x => (x.UserId, x.GuildId))
                 .ShouldBe(GuildUsers.Entities
                     .Select(x => (x.UserId, x.GuildId)));
 
-            modixContext.GuildUsers
+            modixContext.Set<GuildUserEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()
@@ -364,8 +367,8 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            var user = modixContext.Users.Single(x => x.Id == userId);
-            var guildUser = modixContext.GuildUsers.Single(x => (x.UserId == userId) && (x.GuildId == guildId));
+            var user = modixContext.Set<UserEntity>().Single(x => x.Id == userId);
+            var guildUser = modixContext.Set<GuildUserEntity>().Single(x => (x.UserId == userId) && (x.GuildId == guildId));
 
             var mutatedData = new GuildUserMutationData()
             {
@@ -395,22 +398,22 @@ namespace Modix.Data.Test.Repositories
             guildUser.Nickname.ShouldBe(mutatedData.Nickname);
             guildUser.LastSeen.ShouldBe(mutatedData.LastSeen);
 
-            modixContext.GuildUsers.AsEnumerable()
+            modixContext.Set<GuildUserEntity>().AsEnumerable()
                 .Select(x => (x.UserId, x.GuildId))
                 .ShouldBe(GuildUsers.Entities
                     .Select(x => (x.UserId, x.GuildId)));
 
-            modixContext.GuildUsers
+            modixContext.Set<GuildUserEntity>()
                 .Where(x => (x.UserId != userId) || (x.GuildId != guildId))
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .Where(x => x.Id != userId)
                 .EachShould(x => x.ShouldNotHaveChanged());
 
@@ -432,21 +435,21 @@ namespace Modix.Data.Test.Repositories
             updateAction.ShouldNotHaveReceived()
                 .Invoke(Arg.Any<GuildUserMutationData>());
 
-            modixContext.GuildUsers.AsEnumerable()
+            modixContext.Set<GuildUserEntity>().AsEnumerable()
                 .Select(x => (x.UserId, x.GuildId))
                 .ShouldBe(GuildUsers.Entities
                     .Select(x => (x.UserId, x.GuildId)));
 
-            modixContext.GuildUsers
+            modixContext.Set<GuildUserEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .AsQueryable()
                 .Select(x => x.Id)
                 .ShouldBe(Users.Entities
                     .Select(x => x.Id));
 
-            modixContext.Users
+            modixContext.Set<UserEntity>()
                 .EachShould(x => x.ShouldNotHaveChanged());
 
             await modixContext.ShouldNotHaveReceived()

--- a/Modix.Data.Test/TestDataContextFactory.cs
+++ b/Modix.Data.Test/TestDataContextFactory.cs
@@ -1,8 +1,12 @@
 ﻿using System;
+
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 using NSubstitute;
+
+using Modix.Data.Models.Core;
+using Modix.Data.Models.Tags;
 
 namespace Modix.Data.Test
 {
@@ -23,27 +27,27 @@ namespace Modix.Data.Test
                 initializeAction.Invoke(modixContext);
 
                 modixContext.ResetSequenceToMaxValue(
-                    x => x.ClaimMappings,
+                    x => x.Set<ClaimMappingEntity>(),
                     x => x.Id);
 
                 modixContext.ResetSequenceToMaxValue(
-                    x => x.DesignatedChannelMappings,
+                    x => x.Set<DesignatedChannelMappingEntity>(),
                     x => x.Id);
 
                 modixContext.ResetSequenceToMaxValue(
-                    x => x.DesignatedRoleMappings,
+                    x => x.Set<DesignatedRoleMappingEntity>(),
                     x => x.Id);
 
                 modixContext.ResetSequenceToMaxValue(
-                    x => x.ConfigurationActions,
+                    x => x.Set<ConfigurationActionEntity>(),
                     x => x.Id);
 
                 modixContext.ResetSequenceToMaxValue(
-                    x => x.Tags,
+                    x => x.Set<TagEntity>(),
                     x => x.Id);
 
                 modixContext.ResetSequenceToMaxValue(
-                    x => x.TagActions,
+                    x => x.Set<TagActionEntity>(),
                     x => x.Id);
 
                 modixContext.SaveChanges();

--- a/Modix.Data/Models/BehaviourConfiguration.cs
+++ b/Modix.Data/Models/BehaviourConfiguration.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Modix.Data.Models
 {
+    [Table("BehaviourConfigurations")]
     public class BehaviourConfiguration
     {
         [Key, Required, DatabaseGenerated(DatabaseGeneratedOption.Identity)]

--- a/Modix.Data/Models/Core/ClaimMappingEntity.cs
+++ b/Modix.Data/Models/Core/ClaimMappingEntity.cs
@@ -9,6 +9,7 @@ namespace Modix.Data.Models.Core
     /// <summary>
     /// Describes a permission mapping that assigns a claim to a particular role or user within a guild, for use in application authorization.
     /// </summary>
+    [Table("ClaimMappings")]
     public class ClaimMappingEntity
     {
         /// <summary>

--- a/Modix.Data/Models/Core/ConfigurationActionEntity.cs
+++ b/Modix.Data/Models/Core/ConfigurationActionEntity.cs
@@ -10,6 +10,7 @@ namespace Modix.Data.Models.Core
     /// <summary>
     /// Describes an action that was performed, that somehow changed the application's configuration.
     /// </summary>
+    [Table("ConfigurationActions")]
     public class ConfigurationActionEntity
     {
         /// <summary>

--- a/Modix.Data/Models/Core/DesignatedChannelMappingEntity.cs
+++ b/Modix.Data/Models/Core/DesignatedChannelMappingEntity.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Modix.Data.Models.Core
 {
+    [Table("DesignatedChannelMappings")]
     public class DesignatedChannelMappingEntity
     {
         [Required, Key, DatabaseGenerated(DatabaseGeneratedOption.Identity)]

--- a/Modix.Data/Models/Core/DesignatedRoleMappingEntity.cs
+++ b/Modix.Data/Models/Core/DesignatedRoleMappingEntity.cs
@@ -9,6 +9,7 @@ namespace Modix.Data.Models.Core
     /// <summary>
     /// Describes a mapping that assigns an arbitrary designation to a particular role within a guild.
     /// </summary>
+    [Table("DesignatedRoleMappings")]
     public class DesignatedRoleMappingEntity
     {
         /// <summary>

--- a/Modix.Data/Models/Core/GuildChannelEntity.cs
+++ b/Modix.Data/Models/Core/GuildChannelEntity.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Modix.Data.Models.Core
 {
+    [Table("GuildChannels")]
     public class GuildChannelEntity
     {
         [Key]

--- a/Modix.Data/Models/Core/GuildRoleEntity.cs
+++ b/Modix.Data/Models/Core/GuildRoleEntity.cs
@@ -11,6 +11,7 @@ namespace Modix.Data.Models.Core
     /// Tracking this information locally, helps us avoid calls to the Discord API,
     /// and to keep a history for roles that have been deleted from the Discord API.
     /// </summary>
+    [Table("GuildRoles")]
     public class GuildRoleEntity
     {
         /// <summary>

--- a/Modix.Data/Models/Core/GuildUserEntity.cs
+++ b/Modix.Data/Models/Core/GuildUserEntity.cs
@@ -13,6 +13,7 @@ namespace Modix.Data.Models.Core
     /// <summary>
     /// Describes information about a user, that is tracked on a per-guild basis within the application.
     /// </summary>
+    [Table("GuildUsers")]
     public class GuildUserEntity
     {
         [ForeignKey(nameof(User))]

--- a/Modix.Data/Models/Core/MessageEntity.cs
+++ b/Modix.Data/Models/Core/MessageEntity.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Modix.Data.Models.Core
 {
+    [Table("Messages")]
     public class MessageEntity
     {
         [Required]

--- a/Modix.Data/Models/Core/UserEntity.cs
+++ b/Modix.Data/Models/Core/UserEntity.cs
@@ -9,6 +9,7 @@ namespace Modix.Data.Models.Core
     /// <summary>
     /// Describes a user of the application, that has previously joined a Discord guild managed by MODiX.
     /// </summary>
+    [Table("Users")]
     public class UserEntity
     {
         /// <summary>

--- a/Modix.Data/Models/Moderation/DeletedMessageEntity.cs
+++ b/Modix.Data/Models/Moderation/DeletedMessageEntity.cs
@@ -11,6 +11,7 @@ namespace Modix.Data.Models.Moderation
     /// <summary>
     /// Describes a message that was automatically deleted by the application.
     /// </summary>
+    [Table("DeletedMessages")]
     public class DeletedMessageEntity
     {
         /// <summary>

--- a/Modix.Data/Models/Moderation/InfractionEntity.cs
+++ b/Modix.Data/Models/Moderation/InfractionEntity.cs
@@ -9,6 +9,7 @@ using Modix.Data.Models.Core;
 
 namespace Modix.Data.Models.Moderation
 {
+    [Table("Infractions")]
     public class InfractionEntity
     {
         [Key, Required, DatabaseGenerated(DatabaseGeneratedOption.Identity)]

--- a/Modix.Data/Models/Moderation/ModerationActionEntity.cs
+++ b/Modix.Data/Models/Moderation/ModerationActionEntity.cs
@@ -12,6 +12,7 @@ namespace Modix.Data.Models.Moderation
     /// <summary>
     /// Describes a moderation action performed by an authorized staff member.
     /// </summary>
+    [Table("ModerationActions")]
     public class ModerationActionEntity
     {
         /// <summary>

--- a/Modix.Data/Models/Promotions/PromotionActionEntity.cs
+++ b/Modix.Data/Models/Promotions/PromotionActionEntity.cs
@@ -12,6 +12,7 @@ namespace Modix.Data.Models.Promotions
     /// <summary>
     /// Describes an action performed within the promotions system.
     /// </summary>
+    [Table("PromotionActions")]
     public class PromotionActionEntity
     {
         /// <summary>

--- a/Modix.Data/Models/Promotions/PromotionCampaignEntity.cs
+++ b/Modix.Data/Models/Promotions/PromotionCampaignEntity.cs
@@ -9,6 +9,7 @@ using Modix.Data.Models.Core;
 
 namespace Modix.Data.Models.Promotions
 {
+    [Table("PromotionCampaigns")]
     public class PromotionCampaignEntity
     {
         [Key]

--- a/Modix.Data/Models/Promotions/PromotionCommentEntity.cs
+++ b/Modix.Data/Models/Promotions/PromotionCommentEntity.cs
@@ -10,6 +10,7 @@ namespace Modix.Data.Models.Promotions
     /// Describes a comment made in reference to a <see cref="PromotionCampaignEntity"/>,
     /// regarding whether or not the proposed promotion should be accepted or rejected.
     /// </summary>
+    [Table("PromotionComments")]
     public class PromotionCommentEntity
     {
         /// <summary>

--- a/Modix.Data/ModixContext.cs
+++ b/Modix.Data/ModixContext.cs
@@ -1,13 +1,5 @@
-﻿using System.Linq;
-using System.Reflection;
-
-using Modix.Data.Models;
-using Modix.Data.Models.Core;
+﻿using Modix.Data.Models.Core;
 using Modix.Data.Models.Emoji;
-using Modix.Data.Models.Moderation;
-using Modix.Data.Models.Promotions;
-using Modix.Data.Models.Tags;
-using Modix.Data.Utilities;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -16,54 +8,12 @@ namespace Modix.Data
 
     public class ModixContext : DbContext
     {
-        public ModixContext(DbContextOptions<ModixContext> options) : base(options)
-        {
-        }
+        public ModixContext(
+                DbContextOptions<ModixContext> options)
+            : base(options) { }
 
         // For building fakes during testing
-        public ModixContext()
-        {
-        }
-
-        public DbSet<ConfigurationActionEntity> ConfigurationActions { get; set; } = null!;
-
-        public DbSet<BehaviourConfiguration> BehaviourConfigurations { get; set; } = null!;
-
-        public DbSet<UserEntity> Users { get; set; } = null!;
-
-        public DbSet<GuildChannelEntity> GuildChannels { get; set; } = null!;
-
-        public DbSet<GuildRoleEntity> GuildRoles { get; set; } = null!;
-
-        public DbSet<GuildUserEntity> GuildUsers { get; set; } = null!;
-
-        public DbSet<ClaimMappingEntity> ClaimMappings { get; set; } = null!;
-
-        public DbSet<DesignatedChannelMappingEntity> DesignatedChannelMappings { get; set; } = null!;
-
-        public DbSet<DesignatedRoleMappingEntity> DesignatedRoleMappings { get; set; } = null!;
-
-        public DbSet<MessageEntity> Messages { get; set; } = null!;
-
-        public DbSet<ModerationActionEntity> ModerationActions { get; set; } = null!;
-
-        public DbSet<InfractionEntity> Infractions { get; set; } = null!;
-
-        public DbSet<DeletedMessageEntity> DeletedMessages { get; set; } = null!;
-
-        public DbSet<DeletedMessageBatchEntity> DeletedMessageBatches { get; set; } = null!;
-
-        public DbSet<PromotionCampaignEntity> PromotionCampaigns { get; set; } = null!;
-
-        public DbSet<PromotionCommentEntity> PromotionComments { get; set; } = null!;
-
-        public DbSet<PromotionActionEntity> PromotionActions { get; set; } = null!;
-
-        public DbSet<TagEntity> Tags { get; set; } = null!;
-
-        public DbSet<TagActionEntity> TagActions { get; set; } = null!;
-
-        public DbSet<EmojiEntity> Emoji { get; set; } = null!;
+        public ModixContext() { }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Modix.Data/Repositories/BehaviourConfigurationRepository.cs
+++ b/Modix.Data/Repositories/BehaviourConfigurationRepository.cs
@@ -21,7 +21,7 @@ namespace Modix.Data.Repositories
 
         public async Task<IEnumerable<BehaviourConfiguration>> GetBehaviours()
         {
-            return await _modixContext.BehaviourConfigurations.ToListAsync();
+            return await _modixContext.Set<BehaviourConfiguration>().ToListAsync();
         }
     }
 }

--- a/Modix.Data/Repositories/ClaimMappingRepository.cs
+++ b/Modix.Data/Repositories/ClaimMappingRepository.cs
@@ -115,7 +115,7 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.ClaimMappings.AddAsync(entity);
+            await ModixContext.Set<ClaimMappingEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
 
             entity.CreateAction.ClaimMappingId = entity.Id;
@@ -126,27 +126,27 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<ClaimMappingSummary> ReadAsync(long claimMappingId)
-            => ModixContext.ClaimMappings.AsNoTracking()
+            => ModixContext.Set<ClaimMappingEntity>().AsNoTracking()
                 .AsExpandable()
                 .Select(ClaimMappingSummary.FromEntityProjection)
                 .FirstOrDefaultAsync(x => x.Id == claimMappingId);
 
         /// <inheritdoc />
         public Task<bool> AnyAsync(ClaimMappingSearchCriteria criteria)
-            => ModixContext.ClaimMappings.AsNoTracking()
+            => ModixContext.Set<ClaimMappingEntity>().AsNoTracking()
                 .FilterBy(criteria)
                 .AnyAsync();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<long>> SearchIdsAsync(ClaimMappingSearchCriteria criteria)
-            => await ModixContext.ClaimMappings.AsNoTracking()
+            => await ModixContext.Set<ClaimMappingEntity>().AsNoTracking()
                 .FilterBy(criteria)
                 .Select(x => x.Id)
                 .ToArrayAsync();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<ClaimMappingBrief>> SearchBriefsAsync(ClaimMappingSearchCriteria criteria)
-            => await ModixContext.ClaimMappings.AsNoTracking()
+            => await ModixContext.Set<ClaimMappingEntity>().AsNoTracking()
                 .FilterBy(criteria)
                 .AsExpandable()
                 .Select(ClaimMappingBrief.FromEntityProjection)
@@ -155,7 +155,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<bool> TryDeleteAsync(long claimMappingId, ulong rescindedById)
         {
-            var entity = await ModixContext.ClaimMappings
+            var entity = await ModixContext.Set<ClaimMappingEntity>()
                 .Where(x => x.Id == claimMappingId)
                 .FirstOrDefaultAsync();
 

--- a/Modix.Data/Repositories/ConfigurationActionRepository.cs
+++ b/Modix.Data/Repositories/ConfigurationActionRepository.cs
@@ -36,7 +36,7 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<ConfigurationActionSummary> ReadAsync(long actionId)
-            => ModixContext.ConfigurationActions.AsNoTracking()
+            => ModixContext.Set<ConfigurationActionEntity>().AsNoTracking()
                 .AsExpandable()
                 .Select(ConfigurationActionSummary.FromEntityProjection)
                 .FirstOrDefaultAsync(x => x.Id == actionId);

--- a/Modix.Data/Repositories/DeletedMessageBatchRepository.cs
+++ b/Modix.Data/Repositories/DeletedMessageBatchRepository.cs
@@ -52,7 +52,7 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.DeletedMessageBatches.AddAsync(entity);
+            await ModixContext.Set<DeletedMessageBatchEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
 
             entity.CreateAction.DeletedMessageBatchId = entity.Id;
@@ -64,7 +64,7 @@ namespace Modix.Data.Repositories
                 return x.ToBatchEntity();
             });
 
-            await ModixContext.DeletedMessages.AddRangeAsync(deletedMessageEntities);
+            await ModixContext.Set<DeletedMessageEntity>().AddRangeAsync(deletedMessageEntities);
             await ModixContext.SaveChangesAsync();
 
             await RaiseModerationActionCreatedAsync(entity.CreateAction);

--- a/Modix.Data/Repositories/DeletedMessageRepository.cs
+++ b/Modix.Data/Repositories/DeletedMessageRepository.cs
@@ -69,7 +69,7 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.DeletedMessages.AddAsync(entity);
+            await ModixContext.Set<DeletedMessageEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
 
             entity.CreateAction.DeletedMessageId = entity.MessageId;
@@ -82,7 +82,7 @@ namespace Modix.Data.Repositories
         public async Task<RecordsPage<DeletedMessageSummary>> SearchSummariesPagedAsync(
             DeletedMessageSearchCriteria searchCriteria, IEnumerable<SortingCriteria> sortingCriteria, PagingCriteria pagingCriteria)
         {
-            var sourceQuery = ModixContext.DeletedMessages.AsNoTracking();
+            var sourceQuery = ModixContext.Set<DeletedMessageEntity>().AsNoTracking();
 
             var filteredQuery = sourceQuery
                 .FilterBy(searchCriteria);

--- a/Modix.Data/Repositories/DesignatedChannelMappingRepository.cs
+++ b/Modix.Data/Repositories/DesignatedChannelMappingRepository.cs
@@ -119,7 +119,7 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.DesignatedChannelMappings.AddAsync(entity);
+            await ModixContext.Set<DesignatedChannelMappingEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
 
             entity.CreateAction.DesignatedChannelMappingId = entity.Id;
@@ -130,20 +130,20 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<bool> AnyAsync(DesignatedChannelMappingSearchCriteria criteria)
-            => ModixContext.DesignatedChannelMappings.AsNoTracking()
+            => ModixContext.Set<DesignatedChannelMappingEntity>().AsNoTracking()
                 .FilterBy(criteria)
                 .AnyAsync();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<ulong>> SearchChannelIdsAsync(DesignatedChannelMappingSearchCriteria searchCriteria)
-            => await ModixContext.DesignatedChannelMappings.AsNoTracking()
+            => await ModixContext.Set<DesignatedChannelMappingEntity>().AsNoTracking()
                 .FilterBy(searchCriteria)
                 .Select(x => x.ChannelId)
                 .ToArrayAsync();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<DesignatedChannelMappingBrief>> SearchBriefsAsync(DesignatedChannelMappingSearchCriteria searchCriteria)
-            => await ModixContext.DesignatedChannelMappings.AsNoTracking()
+            => await ModixContext.Set<DesignatedChannelMappingEntity>().AsNoTracking()
                 .FilterBy(searchCriteria)
                 .AsExpandable()
                 .Select(DesignatedChannelMappingBrief.FromEntityProjection)
@@ -152,7 +152,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<int> DeleteAsync(DesignatedChannelMappingSearchCriteria criteria, ulong deletedById)
         {
-            var entities = await ModixContext.DesignatedChannelMappings
+            var entities = await ModixContext.Set<DesignatedChannelMappingEntity>()
                 .Where(x => x.DeleteActionId == null)
                 .FilterBy(criteria)
                 .ToArrayAsync();
@@ -168,7 +168,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<bool> TryDeleteAsync(long mappingId, ulong deletedById)
         {
-            var entity = await ModixContext.DesignatedChannelMappings
+            var entity = await ModixContext.Set<DesignatedChannelMappingEntity>()
                 .Where(x => x.Id == mappingId)
                 .FirstOrDefaultAsync();
 

--- a/Modix.Data/Repositories/DesignatedRoleMappingRepository.cs
+++ b/Modix.Data/Repositories/DesignatedRoleMappingRepository.cs
@@ -112,7 +112,7 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.DesignatedRoleMappings.AddAsync(entity);
+            await ModixContext.Set<DesignatedRoleMappingEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
 
             entity.CreateAction.DesignatedRoleMappingId = entity.Id;
@@ -123,13 +123,13 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<bool> AnyAsync(DesignatedRoleMappingSearchCriteria criteria)
-            => ModixContext.DesignatedRoleMappings.AsNoTracking()
+            => ModixContext.Set<DesignatedRoleMappingEntity>().AsNoTracking()
                 .FilterBy(criteria)
                 .AnyAsync();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<DesignatedRoleMappingBrief>> SearchBriefsAsync(DesignatedRoleMappingSearchCriteria criteria)
-            => await ModixContext.DesignatedRoleMappings.AsNoTracking()
+            => await ModixContext.Set<DesignatedRoleMappingEntity>().AsNoTracking()
                 .FilterBy(criteria)
                 .AsExpandable()
                 .Select(DesignatedRoleMappingBrief.FromEntityProjection)
@@ -138,7 +138,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<int> DeleteAsync(DesignatedRoleMappingSearchCriteria criteria, ulong deletedById)
         {
-            var entities = await ModixContext.DesignatedRoleMappings
+            var entities = await ModixContext.Set<DesignatedRoleMappingEntity>()
                 .Where(x => x.DeleteActionId == null)
                 .FilterBy(criteria)
                 .ToArrayAsync();
@@ -154,7 +154,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<bool> TryDeleteAsync(long mappingId, ulong deletedById)
         {
-            var entity = await ModixContext.DesignatedRoleMappings
+            var entity = await ModixContext.Set<DesignatedRoleMappingEntity>()
                 .Where(x => x.Id == mappingId)
                 .FirstOrDefaultAsync();
 

--- a/Modix.Data/Repositories/EmojiRepository.cs
+++ b/Modix.Data/Repositories/EmojiRepository.cs
@@ -141,7 +141,7 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.Emoji.AddAsync(entity);
+            await ModixContext.Set<EmojiEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
 
             return entity.Id;
@@ -159,7 +159,7 @@ namespace Modix.Data.Repositories
             var now = DateTimeOffset.Now;
             var entities = Enumerable.Range(0, count).Select(_ => data.ToEntity(now));
 
-            await ModixContext.Emoji.AddRangeAsync(entities);
+            await ModixContext.Set<EmojiEntity>().AddRangeAsync(entities);
             await ModixContext.SaveChangesAsync();
         }
 
@@ -169,7 +169,7 @@ namespace Modix.Data.Repositories
             if (criteria is null)
                 throw new ArgumentNullException(nameof(criteria));
 
-            var entities = ModixContext.Emoji.FilterBy(criteria);
+            var entities = ModixContext.Set<EmojiEntity>().FilterBy(criteria);
 
             ModixContext.RemoveRange(entities);
             await ModixContext.SaveChangesAsync();
@@ -181,7 +181,7 @@ namespace Modix.Data.Repositories
             if (criteria is null)
                 throw new ArgumentNullException(nameof(criteria));
 
-            var emoji = await ModixContext.Emoji.AsNoTracking()
+            var emoji = await ModixContext.Set<EmojiEntity>().AsNoTracking()
                 .FilterBy(criteria)
                 .GroupBy(x => new
                 {
@@ -210,7 +210,7 @@ namespace Modix.Data.Repositories
             if (criteria is null)
                 throw new ArgumentNullException(nameof(criteria));
 
-            var emoji = await ModixContext.Emoji.AsNoTracking()
+            var emoji = await ModixContext.Set<EmojiEntity>().AsNoTracking()
                 .FilterBy(criteria)
                 .AsExpandable()
                 .Select(EmojiSummary.FromEntityProjection)

--- a/Modix.Data/Repositories/GuildChannelRepository.cs
+++ b/Modix.Data/Repositories/GuildChannelRepository.cs
@@ -70,7 +70,7 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.GuildChannels.AddAsync(entity, cancellationToken);
+            await ModixContext.Set<GuildChannelEntity>().AddAsync(entity, cancellationToken);
             await ModixContext.SaveChangesAsync(cancellationToken);
         }
 
@@ -80,7 +80,7 @@ namespace Modix.Data.Repositories
             if (updateAction == null)
                 throw new ArgumentNullException(nameof(updateAction));
 
-            var entity = await ModixContext.GuildChannels
+            var entity = await ModixContext.Set<GuildChannelEntity>()
                 .Where(x => x.ChannelId == channelId)
                 .FirstOrDefaultAsync(cancellationToken);
 

--- a/Modix.Data/Repositories/GuildRoleRepository.cs
+++ b/Modix.Data/Repositories/GuildRoleRepository.cs
@@ -66,7 +66,7 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.GuildRoles.AddAsync(entity);
+            await ModixContext.Set<GuildRoleEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
         }
 
@@ -76,7 +76,7 @@ namespace Modix.Data.Repositories
             if (updateAction == null)
                 throw new ArgumentNullException(nameof(updateAction));
 
-            var entity = await ModixContext.GuildRoles
+            var entity = await ModixContext.Set<GuildRoleEntity>()
                 .Where(x => x.RoleId == roleId)
                 .FirstOrDefaultAsync();
 

--- a/Modix.Data/Repositories/GuildUserRepository.cs
+++ b/Modix.Data/Repositories/GuildUserRepository.cs
@@ -80,11 +80,11 @@ namespace Modix.Data.Repositories
             var guildDataEntity = data.ToGuildDataEntity();
 
             guildDataEntity.User = await ModixContext
-                .Users
+                .Set<UserEntity>()
                 .FirstOrDefaultAsync(x => x.Id == data.UserId)
                 ?? data.ToUserEntity();
 
-            await ModixContext.GuildUsers.AddAsync(guildDataEntity);
+            await ModixContext.Set<GuildUserEntity>().AddAsync(guildDataEntity);
 
             if ((guildDataEntity.User.Username != data.Username) && !(data.Username is null))
                 guildDataEntity.User.Username = data.Username;
@@ -98,7 +98,8 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public Task<GuildUserSummary> ReadSummaryAsync(ulong userId, ulong guildId)
         {
-            return ModixContext.GuildUsers.AsNoTracking()
+            return ModixContext.Set<GuildUserEntity>()
+                .AsNoTracking()
                 .Where(x => x.UserId == userId)
                 .Where(x => x.GuildId == guildId)
                 .AsExpandable()
@@ -112,7 +113,7 @@ namespace Modix.Data.Repositories
             if (updateAction == null)
                 throw new ArgumentNullException(nameof(updateAction));
 
-            var entity = await ModixContext.GuildUsers
+            var entity = await ModixContext.Set<GuildUserEntity>()
                 .Where(x => x.UserId == userId)
                 .Where(x => x.GuildId == guildId)
                 .Include(x => x.User)

--- a/Modix.Data/Repositories/InfractionRepository.cs
+++ b/Modix.Data/Repositories/InfractionRepository.cs
@@ -146,7 +146,7 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.Infractions.AddAsync(entity);
+            await ModixContext.Set<InfractionEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
 
             entity.CreateAction.InfractionId = entity.Id;
@@ -161,7 +161,7 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<InfractionSummary> ReadSummaryAsync(long infractionId)
-            => ModixContext.Infractions.AsNoTracking()
+            => ModixContext.Set<InfractionEntity>().AsNoTracking()
                 .Where(x => x.Id == infractionId)
                 .AsExpandable()
                 .Select(InfractionSummary.FromEntityProjection)
@@ -169,13 +169,13 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<bool> AnyAsync(InfractionSearchCriteria criteria)
-            => ModixContext.Infractions.AsNoTracking()
+            => ModixContext.Set<InfractionEntity>().AsNoTracking()
                 .FilterBy(criteria)
                 .AnyAsync();
 
         /// <inheritdoc />
         public Task<DateTimeOffset?> ReadExpiresFirstOrDefaultAsync(InfractionSearchCriteria searchCriteria, IEnumerable<SortingCriteria>? sortingCriteria = null)
-            => ModixContext.Infractions.AsNoTracking()
+            => ModixContext.Set<InfractionEntity>().AsNoTracking()
                 .FilterBy(searchCriteria)
                 .AsExpandable()
                 .Select(InfractionSummary.FromEntityProjection)
@@ -185,14 +185,14 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<long>> SearchIdsAsync(InfractionSearchCriteria searchCriteria)
-            => await ModixContext.Infractions.AsNoTracking()
+            => await ModixContext.Set<InfractionEntity>().AsNoTracking()
                 .FilterBy(searchCriteria)
                 .Select(x => x.Id)
                 .ToArrayAsync();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<InfractionSummary>> SearchSummariesAsync(InfractionSearchCriteria searchCriteria, IEnumerable<SortingCriteria>? sortingCriteria = null)
-            => await ModixContext.Infractions.AsNoTracking()
+            => await ModixContext.Set<InfractionEntity>().AsNoTracking()
                 .FilterBy(searchCriteria)
                 .AsExpandable()
                 .Select(InfractionSummary.FromEntityProjection)
@@ -203,7 +203,7 @@ namespace Modix.Data.Repositories
         public async Task<IDictionary<InfractionType, int>> GetInfractionCountsAsync(InfractionSearchCriteria searchCriteria)
         {
             // TODO: Group by here is not supported server side right now, should be refactored
-            var infractions = await ModixContext.Infractions
+            var infractions = await ModixContext.Set<InfractionEntity>()
                 .AsNoTracking()
                 .FilterBy(searchCriteria)
                 .ToArrayAsync();
@@ -226,7 +226,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<RecordsPage<InfractionSummary>> SearchSummariesPagedAsync(InfractionSearchCriteria searchCriteria, IEnumerable<SortingCriteria> sortingCriteria, PagingCriteria pagingCriteria)
         {
-            var sourceQuery = ModixContext.Infractions.AsNoTracking().AsExpandable();
+            var sourceQuery = ModixContext.Set<InfractionEntity>().AsNoTracking().AsExpandable();
 
             var filteredQuery = sourceQuery
                 .FilterBy(searchCriteria);
@@ -249,7 +249,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<bool> TryRescindAsync(long infractionId, ulong rescindedById, string? rescindReason = null)
         {
-            var entity = await ModixContext.Infractions
+            var entity = await ModixContext.Set<InfractionEntity>()
                 .Where(x => x.Id == infractionId)
                 .FirstOrDefaultAsync();
 
@@ -276,7 +276,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<bool> TryDeleteAsync(long infractionId, ulong deletedById)
         {
-            var entity = await ModixContext.Infractions
+            var entity = await ModixContext.Set<InfractionEntity>()
                 .Where(x => x.Id == infractionId)
                 .FirstOrDefaultAsync();
 
@@ -300,7 +300,7 @@ namespace Modix.Data.Repositories
 
         public async Task<bool> TryUpdateAync(long infractionId, string newReason, ulong updatedById)
         {
-            var entity = await ModixContext.Infractions
+            var entity = await ModixContext.Set<InfractionEntity>()
                 .Where(x => x.Id == infractionId)
                 .FirstOrDefaultAsync();
 

--- a/Modix.Data/Repositories/MessageRepository.cs
+++ b/Modix.Data/Repositories/MessageRepository.cs
@@ -144,20 +144,20 @@ namespace Modix.Data.Repositories
         public async Task CreateAsync(MessageCreationData data)
         {
             var entity = data.ToEntity();
-            await ModixContext.Messages.AddAsync(entity);
+            await ModixContext.Set<MessageEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
         }
 
         /// <inheritdoc />
         public async Task DeleteAsync(ulong messageId)
         {
-            var entity = await ModixContext.Messages
+            var entity = await ModixContext.Set<MessageEntity>()
                 .Where(x => x.Id == messageId)
                 .FirstOrDefaultAsync();
 
             if (entity is MessageEntity)
             {
-                ModixContext.Messages.Remove(entity);
+                ModixContext.Set<MessageEntity>().Remove(entity);
                 await ModixContext.SaveChangesAsync();
             }
         }
@@ -167,7 +167,7 @@ namespace Modix.Data.Repositories
         {
             var earliestDateTime = DateTimeOffset.UtcNow - timespan;
 
-            return await ModixContext.Messages
+            return await ModixContext.Set<MessageEntity>()
                 .AsNoTracking()
                 .Where(x => x.GuildId == guildId && x.AuthorId == userId && x.Timestamp >= earliestDateTime)
                 .CountAsync();
@@ -333,7 +333,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<MessageBrief> GetMessage(ulong messageId)
         {
-            return await ModixContext.Messages
+            return await ModixContext.Set<MessageEntity>()
                 .AsNoTracking()
                 .Where(x => x.Id == messageId)
                 .Select(MessageBrief.FromEntityProjection)
@@ -343,13 +343,13 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task UpdateStarboardColumn(ulong messageId, ulong? starboardEntryId)
         {
-            var entity = await ModixContext.Messages
+            var entity = await ModixContext.Set<MessageEntity>()
                 .Where(x => x.Id == messageId)
                 .FirstOrDefaultAsync();
 
             entity.StarboardEntryId = starboardEntryId;
 
-            ModixContext.Messages.Update(entity);
+            ModixContext.Set<MessageEntity>().Update(entity);
             await ModixContext.SaveChangesAsync();
         }
 
@@ -358,7 +358,7 @@ namespace Modix.Data.Repositories
         {
             var earliestDateTime = DateTimeOffset.UtcNow - timespan;
 
-            return await ModixContext.Messages.AsNoTracking()
+            return await ModixContext.Set<MessageEntity>().AsNoTracking()
                 .Where(x => x.GuildId == guildId
                     && x.Timestamp >= earliestDateTime)
                 .CountAsync();
@@ -369,7 +369,7 @@ namespace Modix.Data.Repositories
         {
             var earliestDateTime = DateTimeOffset.UtcNow - timespan;
 
-            var messages = await ModixContext.Messages
+            var messages = await ModixContext.Set<MessageEntity>()
                 .AsNoTracking()
                 .Where(x => x.GuildId == guildId && x.Timestamp >= earliestDateTime)
                 .Select(x => x.ChannelId)

--- a/Modix.Data/Repositories/ModerationActionRepository.cs
+++ b/Modix.Data/Repositories/ModerationActionRepository.cs
@@ -47,7 +47,7 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<ModerationActionSummary> ReadSummaryAsync(long moderationActionId)
-            => ModixContext.ModerationActions.AsNoTracking()
+            => ModixContext.Set<ModerationActionEntity>().AsNoTracking()
                 .Where(x => x.Id == moderationActionId)
                 .AsExpandable()
                 .Select(ModerationActionSummary.FromEntityProjection)
@@ -56,7 +56,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<ModerationActionSummary>> SearchSummariesAsync(ModerationActionSearchCriteria searchCriteria)
         {
-            return await ModixContext.ModerationActions.AsNoTracking()
+            return await ModixContext.Set<ModerationActionEntity>().AsNoTracking()
                 .FilterBy(searchCriteria)
                 .AsExpandable()
                 .Select(ModerationActionSummary.FromEntityProjection)

--- a/Modix.Data/Repositories/PromotionActionRepository.cs
+++ b/Modix.Data/Repositories/PromotionActionRepository.cs
@@ -32,7 +32,7 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<PromotionActionSummary> ReadSummaryAsync(long promotionActionId)
-            => ModixContext.PromotionActions.AsNoTracking()
+            => ModixContext.Set<PromotionActionEntity>().AsNoTracking()
                 .Where(x => x.Id == promotionActionId)
                 .AsExpandable()
                 .Select(PromotionActionSummary.FromEntityProjection)

--- a/Modix.Data/Repositories/PromotionCampaignRepository.cs
+++ b/Modix.Data/Repositories/PromotionCampaignRepository.cs
@@ -119,13 +119,13 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.PromotionCampaigns.AddAsync(entity);
+            await ModixContext.Set<PromotionCampaignEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
 
             entity.CreateAction.CampaignId = entity.Id;
             await ModixContext.SaveChangesAsync();
 
-            var action = await ModixContext.PromotionActions.AsNoTracking()
+            var action = await ModixContext.Set<PromotionActionEntity>().AsNoTracking()
                 .Where(x => x.Id == entity.CreateActionId)
                 .AsExpandable()
                 .Select(PromotionActionSummary.FromEntityProjection)
@@ -136,13 +136,13 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<bool> AnyAsync(PromotionCampaignSearchCriteria searchCriteria)
-            => ModixContext.PromotionCampaigns.AsNoTracking()
+            => ModixContext.Set<PromotionCampaignEntity>().AsNoTracking()
                 .FilterBy(searchCriteria)
                 .AnyAsync();
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<PromotionCampaignSummary>> SearchSummariesAsync(PromotionCampaignSearchCriteria searchCriteria)
-            => await ModixContext.PromotionCampaigns.AsNoTracking()
+            => await ModixContext.Set<PromotionCampaignEntity>().AsNoTracking()
                 .FilterBy(searchCriteria)
                 .AsExpandable()
                 .Select(PromotionCampaignSummary.FromEntityProjection)
@@ -150,7 +150,7 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<PromotionCampaignDetails> ReadDetailsAsync(long campaignId)
-            => ModixContext.PromotionCampaigns.AsNoTracking()
+            => ModixContext.Set<PromotionCampaignEntity>().AsNoTracking()
                 .Where(x => x.Id == campaignId)
                 .AsExpandable()
                 .Select(PromotionCampaignDetails.FromEntityProjection)
@@ -159,7 +159,7 @@ namespace Modix.Data.Repositories
         /// <inheritdoc />
         public async Task<PromotionActionSummary?> TryCloseAsync(long campaignId, ulong closedById, PromotionCampaignOutcome outcome)
         {
-            var entity = await ModixContext.PromotionCampaigns
+            var entity = await ModixContext.Set<PromotionCampaignEntity>()
                 .Where(x => x.Id == campaignId)
                 .FirstOrDefaultAsync();
 
@@ -177,7 +177,7 @@ namespace Modix.Data.Repositories
             };
             await ModixContext.SaveChangesAsync();
 
-            var action = await ModixContext.PromotionActions.AsNoTracking()
+            var action = await ModixContext.Set<PromotionActionEntity>().AsNoTracking()
                 .Where(x => x.Id == entity.CloseActionId)
                 .AsExpandable()
                 .Select(PromotionActionSummary.FromEntityProjection)
@@ -188,7 +188,7 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<PromotionCampaignSummary>> GetPromotionsForUserAsync(ulong guildId, ulong userId)
-            => await ModixContext.PromotionCampaigns.AsNoTracking()
+            => await ModixContext.Set<PromotionCampaignEntity>().AsNoTracking()
                 .Where(x => x.GuildId == guildId
                     && x.SubjectId == userId
                     && x.Outcome == PromotionCampaignOutcome.Accepted)

--- a/Modix.Data/Repositories/PromotionCommentRepository.cs
+++ b/Modix.Data/Repositories/PromotionCommentRepository.cs
@@ -100,13 +100,13 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.PromotionComments.AddAsync(entity);
+            await ModixContext.Set<PromotionCommentEntity>().AddAsync(entity);
             await ModixContext.SaveChangesAsync();
 
             entity.CreateAction.NewCommentId = entity.Id;
             await ModixContext.SaveChangesAsync();
 
-            var action = await ModixContext.PromotionActions.AsNoTracking()
+            var action = await ModixContext.Set<PromotionActionEntity>().AsNoTracking()
                 .Where(x => x.Id == entity.CreateActionId)
                 .AsExpandable()
                 .Select(PromotionActionSummary.FromEntityProjection)
@@ -121,7 +121,7 @@ namespace Modix.Data.Repositories
             if (updateAction is null)
                 throw new ArgumentNullException(nameof(updateAction));
 
-            var oldComment = await ModixContext.PromotionComments
+            var oldComment = await ModixContext.Set<PromotionCommentEntity>()
                                                .Include(x => x.Campaign)
                                                .SingleAsync(x => x.Id == commentId);
 
@@ -134,7 +134,7 @@ namespace Modix.Data.Repositories
                 Type = PromotionActionType.CommentModified,
             };
 
-            await ModixContext.PromotionActions.AddAsync(modifyAction);
+            await ModixContext.Set<PromotionActionEntity>().AddAsync(modifyAction);
             await ModixContext.SaveChangesAsync();
 
             var data = PromotionCommentMutationData.FromEntity(oldComment);
@@ -143,7 +143,7 @@ namespace Modix.Data.Repositories
             var newComment = data.ToEntity();
             newComment.CreateActionId = modifyAction.Id;
 
-            await ModixContext.PromotionComments.AddAsync(newComment);
+            await ModixContext.Set<PromotionCommentEntity>().AddAsync(newComment);
             await ModixContext.SaveChangesAsync();
 
             modifyAction.OldCommentId = oldComment.Id;
@@ -152,7 +152,7 @@ namespace Modix.Data.Repositories
             newComment.CreateActionId = modifyAction.Id;
             await ModixContext.SaveChangesAsync();
 
-            var actionSummary = await ModixContext.PromotionActions.AsNoTracking()
+            var actionSummary = await ModixContext.Set<PromotionActionEntity>().AsNoTracking()
                 .Where(x => x.Id == modifyAction.Id)
                 .AsExpandable()
                 .Select(PromotionActionSummary.FromEntityProjection)
@@ -163,7 +163,7 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public async Task<PromotionCommentSummary> ReadSummaryAsync(long commentId)
-            => await ModixContext.PromotionComments.AsNoTracking()
+            => await ModixContext.Set<PromotionCommentEntity>().AsNoTracking()
                 .Where(x => x.Id == commentId)
                 .AsExpandable()
                 .Select(PromotionCommentSummary.FromEntityProjection)
@@ -171,7 +171,7 @@ namespace Modix.Data.Repositories
 
         /// <inheritdoc />
         public Task<bool> AnyAsync(PromotionCommentSearchCriteria searchCriteria)
-            => ModixContext.PromotionComments.AsNoTracking()
+            => ModixContext.Set<PromotionCommentEntity>().AsNoTracking()
                 .FilterBy(searchCriteria)
                 .AnyAsync();
 

--- a/Modix.Services.Test/Tags/CreateTagTests.cs
+++ b/Modix.Services.Test/Tags/CreateTagTests.cs
@@ -56,7 +56,7 @@ namespace Modix.Services.Test.Tags
         {
             (var autoMocker, var sut, var db) = GetSut();
 
-            db.Tags.Add(new Data.Models.Tags.TagEntity
+            db.Set<TagEntity>().Add(new Data.Models.Tags.TagEntity
             {
                 Name = "modix"
             });
@@ -71,7 +71,7 @@ namespace Modix.Services.Test.Tags
         {
             (var autoMocker, var sut, var db) = GetSut();
 
-            db.Tags.Add(new Data.Models.Tags.TagEntity
+            db.Set<TagEntity>().Add(new Data.Models.Tags.TagEntity
             {
                 Name = "modix"
             });
@@ -88,9 +88,9 @@ namespace Modix.Services.Test.Tags
 
             await sut.CreateTagAsync(1, 1, "MODiX", "Content");
 
-            db.Tags.Count().ShouldBe(1);
+            db.Set<TagEntity>().Count().ShouldBe(1);
 
-            var tag = db.Tags.Single();
+            var tag = db.Set<TagEntity>().Single();
 
             tag.GuildId.ShouldBe((ulong)1);
             tag.OwnerUserId.ShouldBe((ulong)1);
@@ -105,9 +105,9 @@ namespace Modix.Services.Test.Tags
 
             await sut.CreateTagAsync(1, 1, "MODiX", "Content");
 
-            db.TagActions.Count().ShouldBe(1);
+            db.Set<TagActionEntity>().Count().ShouldBe(1);
 
-            var action = db.TagActions.Single();
+            var action = db.Set<TagActionEntity>().Single();
 
             action.GuildId.ShouldBe((ulong)1);
             action.CreatedById.ShouldBe((ulong)1);
@@ -121,7 +121,7 @@ namespace Modix.Services.Test.Tags
 
             await sut.CreateTagAsync(1, 1, "MODiX", "Content");
 
-            var tag = db.Tags.Single();
+            var tag = db.Set<TagEntity>().Single();
 
             tag.CreateAction.ShouldNotBeNull();
         }

--- a/Modix.Services/Tags/TagService.cs
+++ b/Modix.Services/Tags/TagService.cs
@@ -80,7 +80,7 @@ namespace Modix.Services.Tags
 
             name = name.Trim().ToLower();
 
-            if (await _modixContext.Tags.Where(x => x.GuildId == guildId).Where(x => x.DeleteActionId == null).AnyAsync(x => x.Name == name))
+            if (await _modixContext.Set<TagEntity>().Where(x => x.GuildId == guildId).Where(x => x.DeleteActionId == null).AnyAsync(x => x.Name == name))
                 throw new InvalidOperationException($"A tag with the name '{name}' already exists.");
 
             var tag = new TagEntity
@@ -101,7 +101,7 @@ namespace Modix.Services.Tags
 
             tag.CreateAction = createAction;
 
-            _modixContext.Tags.Add(tag);
+            _modixContext.Set<TagEntity>().Add(tag);
 
             await _modixContext.SaveChangesAsync();
         }
@@ -121,7 +121,7 @@ namespace Modix.Services.Tags
                 throw new InvalidOperationException($"The channel '{channel.Name}' is not a message channel.");
 
             var tag = await _modixContext
-                .Tags
+                .Set<TagEntity>()
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.DeleteActionId == null)
                 .Where(x => x.Name == name)
@@ -150,7 +150,7 @@ namespace Modix.Services.Tags
             name = name.Trim().ToLower();
 
             var tag = await _modixContext
-                .Tags
+                .Set<TagEntity>()
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.DeleteActionId == null)
                 .Where(x => x.Name == name)
@@ -174,7 +174,7 @@ namespace Modix.Services.Tags
             name = name.Trim().ToLower();
 
             var tag = await _modixContext
-                .Tags
+                .Set<TagEntity>()
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.DeleteActionId == null)
                 .Where(x => x.Name == name)
@@ -198,7 +198,7 @@ namespace Modix.Services.Tags
             name = name.Trim().ToLower();
 
             return await _modixContext
-                .Tags
+                .Set<TagEntity>()
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.DeleteActionId == null)
                 .Where(x => x.Name == name)
@@ -212,7 +212,7 @@ namespace Modix.Services.Tags
             if (criteria is null)
                 throw new ArgumentNullException(nameof(criteria));
 
-            return await _modixContext.Tags
+            return await _modixContext.Set<TagEntity>()
                 .Where(x => x.DeleteActionId == null)
                 .FilterTagsBy(criteria)
                 .OrderBy(x => x.Name)
@@ -247,7 +247,7 @@ namespace Modix.Services.Tags
             name = name.Trim().ToLower();
 
             var tag = await _modixContext
-                .Tags
+                .Set<TagEntity>()
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.DeleteActionId == null)
                 .Where(x => x.Name == name)
@@ -271,7 +271,7 @@ namespace Modix.Services.Tags
             name = name.Trim().ToLower();
 
             var tag = await _modixContext
-                .Tags
+                .Set<TagEntity>()
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.DeleteActionId == null)
                 .Where(x => x.Name == name)
@@ -383,7 +383,7 @@ namespace Modix.Services.Tags
             name = name.Trim().ToLower();
 
             return await _modixContext
-                .Tags
+                .Set<TagEntity>()
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.Name == name)
                 .Where(x => x.DeleteActionId == null)

--- a/Modix.Services/UserInfo/UserInfoCommand.cs
+++ b/Modix.Services/UserInfo/UserInfoCommand.cs
@@ -226,7 +226,7 @@ namespace Modix.Services.UserInfo
         private async Task<UserInfoUserDto?> GetUserAsync(ulong userId, ulong guildId, CancellationToken cancellationToken)
         {
             return await _modixContext
-                .GuildUsers
+                .Set<GuildUserEntity>()
                 .WhereUserInGuild(userId, guildId)
                 .Select(x => new UserInfoUserDto
                 {
@@ -262,7 +262,7 @@ namespace Modix.Services.UserInfo
             var weekThreshold = now.AddDays(-7);
 
             var messages = await _modixContext
-                .Messages
+                .Set<MessageEntity>()
                 .WhereIsUserInGuild(userId, guild.Id)
                 .WhereCountsTowardsParticipation()
                 .Where(x => x.Timestamp > startingThreshold)


### PR DESCRIPTION
Replaced usage of `DbSet<TEntity>` properties on `ModixContext` with calls to `DbContext.Set<TEntity>()` to allow for lazy instantiation of `DbSet<TEntity>` objects.