### PR TITLE
EF ModelSnapshot Validation

### DIFF
--- a/Modix.Data.Test/ModixContextTests.cs
+++ b/Modix.Data.Test/ModixContextTests.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+using NUnit.Framework;
+using Shouldly;
+
+namespace Modix.Data.Test
+{
+    [TestFixture]
+    public class ModixContextTests
+    {
+        [Test]
+        public void ModixContext_Always_ModelMatchesMigrationsSnapshot()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<ModixContext>()
+                .UseNpgsql("Bogus connection string: we don't actually need to connect to the DB, just build ourselves a model.");
+
+            var context = new ModixContext(optionsBuilder.Options);
+
+            var differences = context.GetService<IMigrationsModelDiffer>().GetDifferences(
+                    context.GetService<IMigrationsAssembly>().ModelSnapshot.Model,
+                    context.Model);
+
+            differences.ShouldBeEmpty();
+        }
+    }
+}


### PR DESCRIPTION
Added a test to ensure that the current `Modix.Data.ModixContext.Model` matches the current `Modix.Data.Migrations.ModixContextModelSnapshot.Model`, to ensure that developers don't accidentally make model changes without creating a migration.