### PR TITLE
Behavior system adjustments

### DIFF
--- a/Modix.Common.Test/Extensions/Microsoft/Extensions/Hosting/ScopedStartupActionBaseTests.cs
+++ b/Modix.Common.Test/Extensions/Microsoft/Extensions/Hosting/ScopedStartupActionBaseTests.cs
@@ -46,6 +46,7 @@ namespace Modix.Common.Test.Extensions.Microsoft.Extensions.Hosting
 
         #region StartAsync() Tests
 
+        [Test]
         public async Task StartAsync_Always_InvokesOnStartingAsyncAndCompletesWhenDone()
         {
             using var testContext = new TestContext();
@@ -71,6 +72,7 @@ namespace Modix.Common.Test.Extensions.Microsoft.Extensions.Hosting
 
         #region StopAsync() Tests
 
+        [Test]
         public void StopAsync_Always_DoesNothing()
         {
             using var testContext = new TestContext();

--- a/Modix.Common/Extensions/Microsoft/Extensions/Hosting/BehaviorHost.cs
+++ b/Modix.Common/Extensions/Microsoft/Extensions/Hosting/BehaviorHost.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Extensions.Hosting
     public class BehaviorHost
         : IHostedService
     {
-        #region Construction
-
         public BehaviorHost(
             IEnumerable<IBehavior> behaviors,
             ILogger<BehaviorHost> logger)
@@ -19,10 +17,6 @@ namespace Microsoft.Extensions.Hosting
             _behaviors = behaviors;
             _logger = logger;
         }
-
-        #endregion Construction
-
-        #region IHostedService
 
         public async Task StartAsync(
             CancellationToken cancellationToken)
@@ -58,13 +52,7 @@ namespace Microsoft.Extensions.Hosting
             HostingLogMessages.BehaviorsStopped(_logger);
         }
 
-        #endregion IHostedService
-
-        #region State
-
         private readonly IEnumerable<IBehavior> _behaviors;
         private readonly ILogger _logger;
-
-        #endregion State
     }
 }

--- a/Modix.Common/Extensions/Microsoft/Extensions/Hosting/BehaviorHost.cs
+++ b/Modix.Common/Extensions/Microsoft/Extensions/Hosting/BehaviorHost.cs
@@ -32,9 +32,10 @@ namespace Microsoft.Extensions.Hosting
             await Task.WhenAll(_behaviors
                 .Select(async behavior =>
                 {
-                    HostingLogMessages.BehaviorStarting(_logger, behavior);
+                    using var logScope = HostingLogMessages.BeginBehaviorScope(_logger, behavior);
+                    HostingLogMessages.BehaviorStarting(_logger);
                     await behavior.StartAsync(cancellationToken);
-                    HostingLogMessages.BehaviorStarted(_logger, behavior);
+                    HostingLogMessages.BehaviorStarted(_logger);
                 }));
 
             HostingLogMessages.BehaviorsStarted(_logger);
@@ -48,9 +49,10 @@ namespace Microsoft.Extensions.Hosting
             await Task.WhenAll(_behaviors
                 .Select(async behavior =>
                 {
-                    HostingLogMessages.BehaviorStopping(_logger, behavior);
+                    using var logScope = HostingLogMessages.BeginBehaviorScope(_logger, behavior);
+                    HostingLogMessages.BehaviorStopping(_logger);
                     await behavior.StopAsync(cancellationToken);
-                    HostingLogMessages.BehaviorStopped(_logger, behavior);
+                    HostingLogMessages.BehaviorStopped(_logger);
                 }));
 
             HostingLogMessages.BehaviorsStopped(_logger);

--- a/Modix.Common/Extensions/Microsoft/Extensions/Hosting/HostingLogMessages.cs
+++ b/Modix.Common/Extensions/Microsoft/Extensions/Hosting/HostingLogMessages.cs
@@ -6,6 +6,26 @@ namespace Microsoft.Extensions.Hosting
 {
     public static class HostingLogMessages
     {
+        public static IDisposable BeginBehaviorScope(
+                ILogger logger,
+                IBehavior behavior)
+            => _beginBehaviorScope.Invoke(
+                logger,
+                behavior);
+        private static readonly Func<ILogger, IBehavior, IDisposable> _beginBehaviorScope
+            = LoggerMessage.DefineScope<IBehavior>(
+                "Behavior: {Behavior}");
+
+        public static IDisposable BeginStartupActionScope(
+                ILogger logger,
+                IScopedStartupAction startupAction)
+            => _beginStartupActionScope.Invoke(
+                logger,
+                startupAction);
+        private static readonly Func<ILogger, IScopedStartupAction, IDisposable> _beginStartupActionScope
+            = LoggerMessage.DefineScope<IScopedStartupAction>(
+                "StartupAction: {StartupAction}");
+
         public static void BehaviorsStarting(
                 ILogger logger)
             => _behaviorsStarting.Invoke(
@@ -73,55 +93,47 @@ namespace Microsoft.Extensions.Hosting
                 .WithoutException();
 
         public static void BehaviorStarting(
-                ILogger logger,
-                IBehavior behavior)
+                ILogger logger)
             => _behaviorStarting.Invoke(
-                logger,
-                behavior);
-        private static readonly Action<ILogger, IBehavior> _behaviorStarting
-            = LoggerMessage.Define<IBehavior>(
+                logger);
+        private static readonly Action<ILogger> _behaviorStarting
+            = LoggerMessage.Define(
                     LogLevel.Debug,
-                    new EventId(4001, nameof(BehaviorsStarting)),
-                    $"Starting {nameof(IBehavior)}: {{Behavior}}")
+                    new EventId(4001, nameof(BehaviorStarting)),
+                    $"Starting {nameof(IBehavior)}")
                 .WithoutException();
 
         public static void BehaviorStarted(
-                ILogger logger,
-                IBehavior behavior)
+                ILogger logger)
             => _behaviorStarted.Invoke(
-                logger,
-                behavior);
-        private static readonly Action<ILogger, IBehavior> _behaviorStarted
-            = LoggerMessage.Define<IBehavior>(
+                logger);
+        private static readonly Action<ILogger> _behaviorStarted
+            = LoggerMessage.Define(
                     LogLevel.Debug,
                     new EventId(4002, nameof(BehaviorStarted)),
-                    $"{nameof(IBehavior)} started: {{Behavior}}")
+                    $"{nameof(IBehavior)} started")
                 .WithoutException();
 
         public static void BehaviorStopping(
-                ILogger logger,
-                IBehavior behavior)
+                ILogger logger)
             => _behaviorStoping.Invoke(
-                logger,
-                behavior);
-        private static readonly Action<ILogger, IBehavior> _behaviorStoping
-            = LoggerMessage.Define<IBehavior>(
+                logger);
+        private static readonly Action<ILogger> _behaviorStoping
+            = LoggerMessage.Define(
                     LogLevel.Debug,
-                    new EventId(4003, nameof(BehaviorsStopping)),
-                    $"Stoping {nameof(IBehavior)}: {{Behavior}}")
+                    new EventId(4003, nameof(BehaviorStopping)),
+                    $"Stoping {nameof(IBehavior)}")
                 .WithoutException();
 
         public static void BehaviorStopped(
-                ILogger logger,
-                IBehavior behavior)
+                ILogger logger)
             => _behaviorStoped.Invoke(
-                logger,
-                behavior);
-        private static readonly Action<ILogger, IBehavior> _behaviorStoped
-            = LoggerMessage.Define<IBehavior>(
+                logger);
+        private static readonly Action<ILogger> _behaviorStoped
+            = LoggerMessage.Define(
                     LogLevel.Debug,
                     new EventId(4004, nameof(BehaviorStopped)),
-                    $"{nameof(IBehavior)} stoped: {{Behavior}}")
+                    $"{nameof(IBehavior)} stoped")
                 .WithoutException();
     }
 }

--- a/Modix.Common/Extensions/Microsoft/Extensions/Hosting/ScopedStartupActionBase.cs
+++ b/Modix.Common/Extensions/Microsoft/Extensions/Hosting/ScopedStartupActionBase.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Extensions.Hosting
         public async Task StartAsync(
             CancellationToken cancellationToken)
         {
+            using var logScope = HostingLogMessages.BeginStartupActionScope(_logger, this);
             HostingLogMessages.StartupActionExecuting(_logger);
 
             using var serviceScope = _serviceScopeFactory.CreateScope();

--- a/Modix.Common/Extensions/Microsoft/Extensions/Hosting/ScopedStartupActionBase.cs
+++ b/Modix.Common/Extensions/Microsoft/Extensions/Hosting/ScopedStartupActionBase.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Extensions.Hosting
     public abstract class ScopedStartupActionBase
         : IScopedStartupAction
     {
-        #region Construction
-
         protected ScopedStartupActionBase(
             ILogger logger,
             IServiceScopeFactory serviceScopeFactory)
@@ -26,16 +24,8 @@ namespace Microsoft.Extensions.Hosting
             _serviceScopeFactory = serviceScopeFactory;
         }
 
-        #endregion Construction
-
-        #region Public Properties
-
         public Task WhenDone
             => _whenDone.Task;
-
-        #endregion Public Properties
-
-        #region IBehavior
 
         public async Task StartAsync(
             CancellationToken cancellationToken)
@@ -58,24 +48,14 @@ namespace Microsoft.Extensions.Hosting
                 CancellationToken cancellationToken)
             => Task.CompletedTask;
 
-        #endregion IBehavior
-
-        #region Protected Members
-
         internal protected abstract Task OnStartingAsync(
             IServiceProvider serviceProvider,
             CancellationToken cancellationToken);
-
-        #endregion Protected Members
-
-        #region State
 
         internal protected readonly ILogger _logger;
         private readonly IServiceScopeFactory _serviceScopeFactory;
 
         private readonly TaskCompletionSource<object?> _whenDone
             = new TaskCompletionSource<object?>();
-
-        #endregion State
     }
 }


### PR DESCRIPTION
Adjusted logging a bit within BehaviorHost and ScopedStartupActionBase, to properly take advantage of log scoping (now that I better understand how it actually works).

Removed #region copy-pasta.

Added missing `[Test]` annotations.