### PR TITLE
Do not include images when quoting spoilered messages

### DIFF
--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -75,6 +75,11 @@ namespace Modix.Services.Quote
                     {
                         var channel = DiscordClient.GetChannel(channelId);
 
+                        if (channel is ITextChannel { IsNsfw: true })
+                        {
+                            return;
+                        }
+
                         if (channel is IGuildChannel guildChannel &&
                             channel is ISocketMessageChannel messageChannel)
                         {

--- a/Modix.Services/Quote/QuoteService.cs
+++ b/Modix.Services/Quote/QuoteService.cs
@@ -43,7 +43,12 @@ namespace Modix.Services.Quote
                 return embed;
             }
 
-            if (!TryAddImageAttachment(message, embed))
+            if (message.Attachments.Any(x => x.IsSpoiler())
+                || message.Embeds.Any() && FormatUtilities.ContainsSpoiler(message.Content))
+            {
+                embed.AddField("Spoiler warning", "The quoted message contains spoilered content.");
+            }
+            else if (!TryAddImageAttachment(message, embed))
                 if (!TryAddImageEmbed(message, embed))
                     if (!TryAddThumbnailEmbed(message, embed))
                         TryAddOtherAttachment(message, embed);

--- a/Modix.Services/Utilities/FormatUtilities.cs
+++ b/Modix.Services/Utilities/FormatUtilities.cs
@@ -220,5 +220,11 @@ namespace Modix.Services.Utilities
 
             return $"{humanizedTimeAgo} ago ({ago.UtcDateTime:yyyy-MM-ddTHH:mm:ssK})";
         }
+
+        public static bool ContainsSpoiler(string text)
+            => _containsSpoilerRegex.IsMatch(text);
+
+        private static readonly Regex _containsSpoilerRegex
+            = new Regex(@"\|\|.+\|\|", RegexOptions.Compiled);
     }
 }


### PR DESCRIPTION
Resolves #705.

Uses the following rules:
* If an attachment is spoilered, do not include the attachment in the quote
* If message text contains a spoiler, and the message contains an embed, do not include the embed in the quote
* Never quote anything from a NSFW channel

![image](https://user-images.githubusercontent.com/2829282/80256848-9d6d2100-864d-11ea-9c29-f0f6fb42271d.png)
