### PR TITLE
PingModule Refactoring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,10 +46,10 @@ dotnet_style_require_accessibility_modifiers = always:error
 dotnet_style_readonly_field = true:suggestion
 
 # Parentheses settings
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_other_operators = always_for_clarity:none
 
 # Suggest more modern language features when available
 dotnet_style_object_initializer = true:suggestion
@@ -57,7 +57,7 @@ dotnet_style_collection_initializer = true:suggestion
 dotnet_style_explicit_tuple_names = true:warning
 dotnet_style_prefer_inferred_tuple_names = true:silent
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:silent
-dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_auto_properties = true:none
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 dotnet_style_prefer_conditional_expression_over_assignment = true:silent
 dotnet_style_prefer_conditional_expression_over_return = true:silent

--- a/Modix.Services/Diagnostics/DiscordGatewayLatencyEndpoint.cs
+++ b/Modix.Services/Diagnostics/DiscordGatewayLatencyEndpoint.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Discord.WebSocket;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Modix.Services.Diagnostics
+{
+    [ServiceBinding(ServiceLifetime.Transient)]
+    public class DiscordGatewayLatencyEndpoint
+        : ILatencyEndpoint
+    {
+        public DiscordGatewayLatencyEndpoint(
+            IDiscordSocketClient discordClient)
+        {
+            _discordClient = discordClient;
+        }
+
+        public string DisplayName
+            => "Discord Gateway";
+
+        public Task<long> GetLatencyAsync(
+                CancellationToken cancellationToken)
+            => Task.FromResult(Convert.ToInt64(_discordClient.Latency));
+
+        private readonly IDiscordSocketClient _discordClient;
+    }
+}

--- a/Modix.Services/Diagnostics/DiscordRestAvailabilityEndpoint.cs
+++ b/Modix.Services/Diagnostics/DiscordRestAvailabilityEndpoint.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Discord;
+using Discord.Rest;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Modix.Services.Diagnostics
+{
+    [ServiceBinding(ServiceLifetime.Transient)]
+    public class DiscordRestAvailabilityEndpoint
+        : IAvailabilityEndpoint
+    {
+        public DiscordRestAvailabilityEndpoint(
+            IDiscordRestClient discordClient)
+        {
+            _discordClient = discordClient;
+        }
+
+        public string DisplayName
+            => "Discord REST";
+
+        public async Task<bool> GetAvailabilityAsync(
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var options = RequestOptions.Default.Clone();
+                options.CancelToken = cancellationToken;
+
+                var user = await _discordClient.GetUserAsync(_discordClient.CurrentUser.Id, options);
+
+                return user.Id == _discordClient.CurrentUser.Id;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private readonly IDiscordRestClient _discordClient;
+    }
+}

--- a/Modix.Services/Diagnostics/HttpGetAvailabilityEndpoint.cs
+++ b/Modix.Services/Diagnostics/HttpGetAvailabilityEndpoint.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Modix.Services.Diagnostics
+{
+    public sealed class HttpGetAvailabilityEndpoint
+        : IAvailabilityEndpoint,
+            IDisposable
+    {
+        public HttpGetAvailabilityEndpoint(
+            string displayName,
+            string url,
+            IHttpClientFactory httpClientFactory)
+        {
+            _displayName = displayName;
+            _url = url;
+
+            _httpClient = httpClientFactory.CreateClient();
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "MODiX");
+        }
+
+        public string DisplayName
+            => _displayName;
+
+        public void Dispose()
+            => _httpClient.Dispose();
+
+        public async Task<bool> GetAvailabilityAsync(
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                return (await _httpClient.GetAsync(
+                        _url,
+                        HttpCompletionOption.ResponseHeadersRead,
+                        cancellationToken))
+                    .IsSuccessStatusCode;
+            }
+            catch (HttpRequestException)
+            {
+                return false;
+            }
+        }
+
+        private readonly string _displayName;
+        private readonly HttpClient _httpClient;
+        private readonly string _url;
+    }
+
+    [ServiceConfigurator]
+    public class HttpGetAvailabilityEndpointConfigurator
+        : IServiceConfigurator
+    {
+        public void ConfigureServices(
+                IServiceCollection services,
+                IConfiguration configuration)
+            => services
+                .AddSingleton<IAvailabilityEndpoint>(serviceProvider => new HttpGetAvailabilityEndpoint("Github REST", "https://api.github.com", serviceProvider.GetRequiredService<IHttpClientFactory>()));
+    }
+}

--- a/Modix.Services/Diagnostics/IAvailabilityEndpoint.cs
+++ b/Modix.Services/Diagnostics/IAvailabilityEndpoint.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Modix.Services.Diagnostics
+{
+    public interface IAvailabilityEndpoint
+        : IDiagnosticEndpoint
+    {
+        Task<bool> GetAvailabilityAsync(
+            CancellationToken cancellationToken);
+    }
+}

--- a/Modix.Services/Diagnostics/IDiagnosticEndpoint.cs
+++ b/Modix.Services/Diagnostics/IDiagnosticEndpoint.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Modix.Services.Diagnostics
+{
+    public interface IDiagnosticEndpoint
+    {
+        string DisplayName { get; }
+    }
+}

--- a/Modix.Services/Diagnostics/ILatencyEndpoint.cs
+++ b/Modix.Services/Diagnostics/ILatencyEndpoint.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Modix.Services.Diagnostics
+{
+    public interface ILatencyEndpoint
+        : IDiagnosticEndpoint
+    {
+        Task<long> GetLatencyAsync(
+            CancellationToken cancellationToken);
+    }
+}

--- a/Modix.Services/Diagnostics/PingLatencyEndpoint.cs
+++ b/Modix.Services/Diagnostics/PingLatencyEndpoint.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Net.NetworkInformation;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Modix.Services.Diagnostics
+{
+    public sealed class PingLatencyEndpoint
+        : ILatencyEndpoint,
+            IDisposable
+    {
+        public PingLatencyEndpoint(
+            string displayName,
+            string url)
+        {
+            _displayName = displayName;
+            _url = url;
+
+            _ping = new Ping();
+        }
+
+        public string DisplayName
+            => _displayName;
+
+        public void Dispose()
+            => _ping.Dispose();
+
+        public async Task<long> GetLatencyAsync(
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.Register(_ping.SendAsyncCancel);
+
+            var reply = await _ping.SendPingAsync(_url);
+
+            return reply.RoundtripTime;
+        }
+
+        private readonly string _displayName;
+        private readonly Ping _ping;
+        private readonly string _url;
+    }
+
+    [ServiceConfigurator]
+    public class PingLatencyEndpointServiceConfigurator
+        : IServiceConfigurator
+    {
+        public void ConfigureServices(
+                IServiceCollection services,
+                IConfiguration configuration)
+            => services
+                .AddSingleton<ILatencyEndpoint>(serviceProvider => new PingLatencyEndpoint("Google",     "8.8.8.8"))
+                .AddSingleton<ILatencyEndpoint>(serviceProvider => new PingLatencyEndpoint("Cloudflare", "1.1.1.1"));
+    }
+}

--- a/Modix.Services/ServicesSetup.cs
+++ b/Modix.Services/ServicesSetup.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Modix.Services
+{
+    public static class ServicesSetup
+    {
+        public static IServiceCollection AddModixServices(
+                this IServiceCollection services,
+                IConfiguration configuration)
+            => services
+                .AddServices(Assembly.GetExecutingAssembly(), configuration);
+    }
+}

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -74,25 +74,27 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             IConfiguration configuration)
         {
-            services.AddSingleton(
-                provider => new DiscordSocketClient(config: new DiscordSocketConfig
-                {
-                    AlwaysDownloadUsers = true,
-                    LogLevel = LogSeverity.Debug,
-                    MessageCacheSize = provider
-                        .GetRequiredService<IOptions<ModixConfig>>()
-                        .Value
-                        .MessageCacheSize //needed to log deletions
-                }));
+            services
+                .AddSingleton(
+                    provider => new DiscordSocketClient(config: new DiscordSocketConfig
+                    {
+                        AlwaysDownloadUsers = true,
+                        LogLevel = LogSeverity.Debug,
+                        MessageCacheSize = provider
+                            .GetRequiredService<IOptions<ModixConfig>>()
+                            .Value
+                            .MessageCacheSize //needed to log deletions
+                    }))
+                .AddSingleton<IDiscordClient>(provider => provider.GetRequiredService<DiscordSocketClient>())
+                .AddSingleton(provider => provider.GetRequiredService<DiscordSocketClient>().Abstract());
 
-            services.AddSingleton<IDiscordSocketClient>(provider => provider.GetRequiredService<DiscordSocketClient>().Abstract());
-            services.AddSingleton<IDiscordClient>(provider => provider.GetRequiredService<DiscordSocketClient>());
-
-            services.AddSingleton(
-                provider => new DiscordRestClient(config: new DiscordRestConfig
-                {
-                    LogLevel = LogSeverity.Debug,
-                }));
+            services
+                .AddSingleton(
+                    provider => new DiscordRestClient(config: new DiscordRestConfig
+                    {
+                        LogLevel = LogSeverity.Debug,
+                    }))
+                .AddSingleton(provider => provider.GetRequiredService<DiscordRestClient>().Abstract());
 
             services.AddSingleton(_ =>
                 {
@@ -119,6 +121,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services
                 .AddModixCommon(configuration)
+                .AddModixServices(configuration)
                 .AddModixCore()
                 .AddModixModeration()
                 .AddModixPromotions()


### PR DESCRIPTION
Refactored `PingModule` to use `IDiscordSocketClient` instead of `DiscordSocketClient`, and eliminated reference to `DiscordRestClient`.