### PR TITLE
Fix NullReferenceException when updating tags

### DIFF
--- a/Modix.Services/Tags/TagService.cs
+++ b/Modix.Services/Tags/TagService.cs
@@ -151,6 +151,8 @@ namespace Modix.Services.Tags
 
             var tag = await _modixContext
                 .Set<TagEntity>()
+                .Include(x => x.OwnerRole)
+                .Include(x => x.OwnerUser)
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.DeleteActionId == null)
                 .Where(x => x.Name == name)
@@ -175,6 +177,8 @@ namespace Modix.Services.Tags
 
             var tag = await _modixContext
                 .Set<TagEntity>()
+                .Include(x => x.OwnerRole)
+                .Include(x => x.OwnerUser)
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.DeleteActionId == null)
                 .Where(x => x.Name == name)
@@ -248,6 +252,8 @@ namespace Modix.Services.Tags
 
             var tag = await _modixContext
                 .Set<TagEntity>()
+                .Include(x => x.OwnerRole)
+                .Include(x => x.OwnerUser)
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.DeleteActionId == null)
                 .Where(x => x.Name == name)
@@ -272,6 +278,8 @@ namespace Modix.Services.Tags
 
             var tag = await _modixContext
                 .Set<TagEntity>()
+                .Include(x => x.OwnerRole)
+                .Include(x => x.OwnerUser)
                 .Where(x => x.GuildId == guildId)
                 .Where(x => x.DeleteActionId == null)
                 .Where(x => x.Name == name)


### PR DESCRIPTION
We weren't pulling the owner user/role, so both the owner user and the owner role were null when checking whether the command user owns the tag or has sufficient rank.

Fixes #757.