### PR TITLE
PingModule refactoring, 2.3.1-alpha

### DIFF
--- a/Modix.Services/Diagnostics/DiscordRestAvailabilityEndpoint.cs
+++ b/Modix.Services/Diagnostics/DiscordRestAvailabilityEndpoint.cs
@@ -6,6 +6,7 @@ using Discord;
 using Discord.Rest;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Modix.Services.Diagnostics
 {
@@ -14,9 +15,11 @@ namespace Modix.Services.Diagnostics
         : IAvailabilityEndpoint
     {
         public DiscordRestAvailabilityEndpoint(
-            IDiscordRestClient discordClient)
+            IDiscordRestClient discordClient,
+            ILogger<DiscordRestAvailabilityEndpoint> logger)
         {
             _discordClient = discordClient;
+            _logger = logger;
         }
 
         public string DisplayName
@@ -30,16 +33,19 @@ namespace Modix.Services.Diagnostics
                 var options = RequestOptions.Default.Clone();
                 options.CancelToken = cancellationToken;
 
-                var user = await _discordClient.GetUserAsync(_discordClient.CurrentUser.Id, options);
+                await _discordClient.GetUserAsync(_discordClient.CurrentUser.Id, options);
 
-                return user.Id == _discordClient.CurrentUser.Id;
+                return true;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _logger.LogWarning(ex, "The Discord REST service appears to be unavailable");
+
                 return false;
             }
         }
 
         private readonly IDiscordRestClient _discordClient;
+        private readonly ILogger _logger;
     }
 }

--- a/Modix.Services/Diagnostics/HttpGetAvailabilityEndpoint.cs
+++ b/Modix.Services/Diagnostics/HttpGetAvailabilityEndpoint.cs
@@ -5,37 +5,37 @@ using System.Threading.Tasks;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Modix.Services.Diagnostics
 {
     public sealed class HttpGetAvailabilityEndpoint
-        : IAvailabilityEndpoint,
-            IDisposable
+        : IAvailabilityEndpoint
     {
         public HttpGetAvailabilityEndpoint(
             string displayName,
             string url,
-            IHttpClientFactory httpClientFactory)
+            IHttpClientFactory httpClientFactory,
+            ILogger<HttpGetAvailabilityEndpoint> logger)
         {
             _displayName = displayName;
             _url = url;
-
-            _httpClient = httpClientFactory.CreateClient();
-            _httpClient.DefaultRequestHeaders.Add("User-Agent", "MODiX");
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
         }
 
         public string DisplayName
             => _displayName;
 
-        public void Dispose()
-            => _httpClient.Dispose();
-
         public async Task<bool> GetAvailabilityAsync(
             CancellationToken cancellationToken)
         {
+            var httpClient = _httpClientFactory.CreateClient();
+            httpClient.DefaultRequestHeaders.Add("User-Agent", "MODiX");
+
             try
             {
-                return (await _httpClient.GetAsync(
+                return (await httpClient.GetAsync(
                         _url,
                         HttpCompletionOption.ResponseHeadersRead,
                         cancellationToken))
@@ -45,12 +45,15 @@ namespace Modix.Services.Diagnostics
                     (ex is HttpRequestException)
                 ||  (ex is TaskCanceledException))
             {
+                _logger.LogWarning(ex, "An HTTP Endpoint ({Url}) appears to be unavailable", _url);
+
                 return false;
             }
         }
 
         private readonly string _displayName;
-        private readonly HttpClient _httpClient;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger _logger;
         private readonly string _url;
     }
 
@@ -62,6 +65,10 @@ namespace Modix.Services.Diagnostics
                 IServiceCollection services,
                 IConfiguration configuration)
             => services
-                .AddSingleton<IAvailabilityEndpoint>(serviceProvider => new HttpGetAvailabilityEndpoint("Github REST", "https://api.github.com", serviceProvider.GetRequiredService<IHttpClientFactory>()));
+                .AddTransient<IAvailabilityEndpoint>(serviceProvider => new HttpGetAvailabilityEndpoint(
+                    "Github REST",
+                    "https://api.github.com",
+                    serviceProvider.GetRequiredService<IHttpClientFactory>(),
+                    serviceProvider.GetRequiredService<ILogger<HttpGetAvailabilityEndpoint>>()));
     }
 }


### PR DESCRIPTION
Fixed that `HttpGetAvailabilityEndpoint` did not correctly manage `HttpClient` instances.

Added logging for ping/availability failure states.