### PR TITLE
Update to .NET 5.0 preview 4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
     <UserSecretsId>5B9ECED8-0E0C-443E-98B1-F1E508AB292B</UserSecretsId>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,13 +24,17 @@
 
     <PackageReference Update="AspNet.Security.OAuth.Discord" Version="3.0.0" />
 
-    <PackageReference Update="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.0-preview.3.20215.14" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0-preview.3.20215.2" />
-    <PackageReference Update="Microsoft.Extensions.Hosting" Version="5.0.0-preview.3.20215.2" />
-    <PackageReference Update="Microsoft.Extensions.Http" Version="5.0.0-preview.3.20215.2" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="5.0.0-preview.3.20215.2" />
-    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="3.1.3" />
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.0-preview.3.20215.14" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.0-preview.4.20257.10" />
+    <PackageReference Update="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.0-preview.4.20257.10" />
+
+    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="5.0.0-preview.4.20251.6" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0-preview.4.20251.6" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="5.0.0-preview.4.20251.6" />
+    <PackageReference Update="Microsoft.Extensions.Hosting" Version="5.0.0-preview.4.20251.6" />
+    <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0-preview.4.20251.6" />
+    <PackageReference Update="Microsoft.Extensions.Http" Version="5.0.0-preview.4.20251.6" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.4.20251.6" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="5.0.0-preview.4.20251.6" />
 
     <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
 
@@ -46,11 +50,11 @@
     <PackageReference Update="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Update="Serilog.Sinks.RollingFile" Version="3.3.0" />
     
-    <PackageReference Update="Humanizer.Core" Version="2.7.9" />
+    <PackageReference Update="Humanizer.Core" Version="2.8.11" />
 
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.7.0-preview-20200428-01" />
 
-    <PackageReference Update="Moq" Version="4.13.1" />
+    <PackageReference Update="Moq" Version="4.14.1" />
     <PackageReference Update="Moq.AutoMock" Version="2.0.0" />
 
     <PackageReference Update="NUnit" Version="3.12.0" />

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 as dotnet-test
+FROM mcr.microsoft.com/dotnet/sdk:5.0 as dotnet-test
 WORKDIR /src
 COPY . .
 RUN sh build/test.sh
 
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 as dotnet-build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 as dotnet-build
 WORKDIR /src
 COPY . .
 
 RUN sh build/build.sh
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:5.0
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
 WORKDIR /app
 COPY --from=dotnet-build /app .
 COPY --from=dotnet-build /src/healthcheck.sh .

--- a/Modix.Common.Test/Modix.Common.Test.csproj
+++ b/Modix.Common.Test/Modix.Common.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NUnit" />

--- a/Modix.Common/Modix.Common.csproj
+++ b/Modix.Common/Modix.Common.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Serilog" />
   </ItemGroup>
 

--- a/Modix.sln
+++ b/Modix.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		build\build.sh = build\build.sh
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		Dockerfile = Dockerfile
 		readme.md = readme.md
 		build\test.sh = build\test.sh


### PR DESCRIPTION
- Sets `LangVersion` to `preview`, as some C# 9 features (pattern matching improvements and target-typed `new`, for example) are now available in preview
- Updates Nuget packages to preview 4
- Changes Docker images to point to the [new repository](https://github.com/dotnet/dotnet-docker/issues/1939)