### PR TITLE
Update Wiki deployment to new rsync for SwiftDocOrg

### DIFF
--- a/.github/workflows/wiki-deployment.yml
+++ b/.github/workflows/wiki-deployment.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout /wiki
         uses: actions/checkout@master
       - name: Merge to .wiki
-        uses: SwiftDocOrg/github-wiki-publish-action@1.0.0
+        uses: SwiftDocOrg/github-wiki-publish-action@rsync
         with:
           path: wiki
         env:


### PR DESCRIPTION
Allows for adding/editing/deleting of all files, not just readmes

See SwiftDocOrg/github-wiki-publish-action#3