### PR TITLE
Refactored `UserTrackingBehavior`

### DIFF
--- a/Modix.Common/Extensions/System/SystemClock.cs
+++ b/Modix.Common/Extensions/System/SystemClock.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace System
+{
+    public interface ISystemClock
+    {
+        DateTimeOffset UtcNow { get; }
+    }
+
+    [ServiceBinding(ServiceLifetime.Singleton)]
+    public class SystemClock
+        : ISystemClock
+    {
+        public DateTimeOffset UtcNow
+            => DateTimeOffset.UtcNow;
+    }
+}

--- a/Modix.Data.Test/Repositories/GuildUserRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/GuildUserRepositoryTests.cs
@@ -103,7 +103,7 @@ namespace Modix.Data.Test.Repositories
             (var modixContext, var uut) = BuildTestContext();
 
             await Should.ThrowAsync<ArgumentNullException>(async () => 
-                await uut.CreateAsync(null!));
+                await uut.CreateAsync(null!, default));
 
             modixContext.Set<GuildUserEntity>().AsEnumerable()
                 .Select(x => (x.UserId, x.GuildId))
@@ -131,7 +131,7 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            await uut.CreateAsync(data);
+            await uut.CreateAsync(data, default);
 
             modixContext.Set<UserEntity>().ShouldContain(x => x.Id == data.UserId);
             var user = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
@@ -160,7 +160,7 @@ namespace Modix.Data.Test.Repositories
 
             var userCount = modixContext.Set<UserEntity>().Count();
 
-            await uut.CreateAsync(data);
+            await uut.CreateAsync(data, default);
 
             modixContext.Set<UserEntity>().Count().ShouldBe(userCount);
             var user = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
@@ -192,7 +192,7 @@ namespace Modix.Data.Test.Repositories
             var userCount = modixContext.Set<UserEntity>().Count();
             var previousUser = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
 
-            await uut.CreateAsync(data);
+            await uut.CreateAsync(data, default);
 
             modixContext.Set<UserEntity>().Count().ShouldBe(userCount);
             var user = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
@@ -223,7 +223,7 @@ namespace Modix.Data.Test.Repositories
             var userCount = modixContext.Set<UserEntity>().Count();
             var previousUser = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
 
-            await uut.CreateAsync(data);
+            await uut.CreateAsync(data, default);
 
             modixContext.Set<UserEntity>().Count().ShouldBe(userCount);
             var user = modixContext.Set<UserEntity>().First(x => x.Id == data.UserId);
@@ -249,7 +249,7 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            await uut.CreateAsync(data);
+            await uut.CreateAsync(data, default);
 
             modixContext.Set<GuildUserEntity>()
                 .ShouldContain(x => (x.GuildId == data.GuildId) && (x.UserId == data.UserId));
@@ -280,7 +280,7 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            await Should.ThrowAsync<InvalidOperationException>(uut.CreateAsync(data));
+            await Should.ThrowAsync<InvalidOperationException>(uut.CreateAsync(data, default));
 
             modixContext.Set<GuildUserEntity>().AsEnumerable()
                 .Select(x => (x.UserId, x.GuildId))
@@ -339,7 +339,7 @@ namespace Modix.Data.Test.Repositories
             (var modixContext, var uut) = BuildTestContext();
 
             await Should.ThrowAsync<ArgumentNullException>(async () =>
-                await uut.TryUpdateAsync(1, 1, null!));
+                await uut.TryUpdateAsync(1, 1, null!, default));
 
             modixContext.Set<GuildUserEntity>().AsEnumerable()
                 .Select(x => (x.UserId, x.GuildId))
@@ -389,7 +389,7 @@ namespace Modix.Data.Test.Repositories
                 data.Discriminator = mutatedData.Discriminator;
                 data.Nickname = mutatedData.Nickname;
                 data.LastSeen = mutatedData.LastSeen;
-            });
+            }, default);
 
             result.ShouldBeTrue();
 
@@ -428,7 +428,7 @@ namespace Modix.Data.Test.Repositories
 
             var updateAction = Substitute.For<Action<GuildUserMutationData>>();
 
-            var result = await uut.TryUpdateAsync(userId, guildId, updateAction);
+            var result = await uut.TryUpdateAsync(userId, guildId, updateAction, default);
 
             result.ShouldBeFalse();
 

--- a/Modix.Services.Test/Core/Messages/GuildMemberUpdatedNotificationTests.cs
+++ b/Modix.Services.Test/Core/Messages/GuildMemberUpdatedNotificationTests.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+
+using Moq;
+using NUnit.Framework;
+using Shouldly;
+
+using Discord;
+using Discord.WebSocket;
+
+namespace Modix.Services.Test.Core.Messages
+{
+    [TestFixture]
+    public class GuildMemberUpdatedNotificationTests
+    {
+        #region Constructor Tests
+
+        [Test]
+        public void Constructor_Always_PropertiesAreGiven()
+        {
+            var mockOldMember = new Mock<ISocketGuildUser>();
+            var mockNewMember = new Mock<ISocketGuildUser>();
+
+            var uut = new GuildMemberUpdatedNotification(mockOldMember.Object, mockNewMember.Object);
+
+            uut.OldMember.ShouldBeSameAs(mockOldMember.Object);
+            uut.NewMember.ShouldBeSameAs(mockNewMember.Object);
+        }
+
+        #endregion Constructor Tests
+    }
+}

--- a/Modix.Services.Test/Core/UserTrackingBehaviorTests.cs
+++ b/Modix.Services.Test/Core/UserTrackingBehaviorTests.cs
@@ -1,0 +1,223 @@
+﻿#nullable enable
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Discord;
+using Discord.WebSocket;
+
+using Moq;
+using NUnit.Framework;
+using Shouldly;
+
+using Modix.Services.Core;
+
+using Modix.Common.Test;
+
+namespace Modix.Services.Test.Core
+{
+    [TestFixture]
+    public class UserTrackingBehaviorTests
+    {
+        #region Test Context
+
+        public class TestContext
+            : AsyncMethodTestContext
+        {
+            public TestContext()
+            {
+                MockSelfUser = new Mock<ISocketSelfUser>();
+                MockSelfUser
+                    .Setup(x => x.Id)
+                    .Returns(() => SelfUserId);
+
+                MockSelfUserProvider = new Mock<ISelfUserProvider>();
+                MockSelfUserProvider
+                    .Setup(x => x.GetSelfUserAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() => MockSelfUser.Object);
+
+                MockUserService = new Mock<IUserService>();
+            }
+
+            public UserTrackingBehavior BuildUut()
+                => new UserTrackingBehavior(
+                    MockSelfUserProvider.Object,
+                    MockUserService.Object);
+
+            public readonly Mock<ISocketSelfUser> MockSelfUser;
+            public readonly Mock<ISelfUserProvider> MockSelfUserProvider;
+            public readonly Mock<IUserService> MockUserService;
+
+            public ulong SelfUserId;
+        }
+
+        #endregion Test Context
+
+        #region HandleNotificationAsync(GuildAvailableNotification) Tests
+
+        public static TestCaseData BuildTestCaseData_HandleNotificationAsync_GuildAvailableNotification(
+            ulong selfUserId)
+        {
+            var mockGuildUser = new Mock<ISocketGuildUser>();
+
+            var mockGuild = new Mock<ISocketGuild>();
+            mockGuild
+                .Setup(x => x.GetUser(It.IsAny<ulong>()))
+                .Returns(mockGuildUser.Object);
+
+            var notification = new GuildAvailableNotification(
+                mockGuild.Object);
+
+            return new TestCaseData(selfUserId, mockGuild, mockGuildUser, notification);
+        }
+
+        public static readonly ImmutableArray<TestCaseData> HandleNotificationAsync_GuildAvailableNotification_TestCaseData
+            = ImmutableArray.Create(
+                BuildTestCaseData_HandleNotificationAsync_GuildAvailableNotification(   selfUserId: default         ).SetName("{m}(Default Values)"),
+                BuildTestCaseData_HandleNotificationAsync_GuildAvailableNotification(   selfUserId: ulong.MinValue  ).SetName("{m}(Min Values)"),
+                BuildTestCaseData_HandleNotificationAsync_GuildAvailableNotification(   selfUserId: ulong.MaxValue  ).SetName("{m}(Max Values)"),
+                BuildTestCaseData_HandleNotificationAsync_GuildAvailableNotification(   selfUserId: 1               ).SetName("{m}(Unique Values 1)"),
+                BuildTestCaseData_HandleNotificationAsync_GuildAvailableNotification(   selfUserId: 2               ).SetName("{m}(Unique Values 2)"),
+                BuildTestCaseData_HandleNotificationAsync_GuildAvailableNotification(   selfUserId: 3               ).SetName("{m}(Unique Values 3)"));
+
+        [TestCaseSource(nameof(HandleNotificationAsync_GuildAvailableNotification_TestCaseData))]
+        public async Task HandleNotificationAsync_GuildAvailableNotification_Always_TracksSelfUser(
+            ulong selfUserId,
+            Mock<ISocketGuild> mockGuild,
+            Mock<ISocketGuildUser> mockGuildUser,
+            GuildAvailableNotification notification)
+        {
+            var testContext = new TestContext()
+            {
+                SelfUserId = selfUserId
+            };
+
+            var uut = testContext.BuildUut();
+
+            await uut.HandleNotificationAsync(
+                notification,
+                testContext.CancellationToken);
+
+            mockGuild.ShouldHaveReceived(x => x
+                .GetUser(selfUserId));
+
+            testContext.MockUserService.ShouldHaveReceived(x => x
+                .TrackUserAsync(mockGuildUser.Object, testContext.CancellationToken));
+        }
+
+        #endregion HandleNotificationAsync(GuildAvailableNotification) Tests
+
+        #region HandleNotificationAsync(GuildMemberUpdatedNotification) Tests
+
+        [Test]
+        public async Task HandleNotificationAsync_GuildMemberUpdatedNotification_Always_TracksNewMember()
+        {
+            var testContext = new TestContext();
+
+            var uut = testContext.BuildUut();
+
+            var notification = new GuildMemberUpdatedNotification(
+                new Mock<ISocketGuildUser>().Object,
+                new Mock<ISocketGuildUser>().Object);
+
+            await uut.HandleNotificationAsync(
+                notification,
+                testContext.CancellationToken);
+
+            testContext.MockUserService.ShouldHaveReceived(x => x
+                .TrackUserAsync(notification.NewMember, testContext.CancellationToken));
+        }
+
+        #endregion HandleNotificationAsync(GuildMemberUpdatedNotification) Tests
+
+        #region HandleNotificationAsync(MessageReceivedNotification) Tests
+
+        public static TestCaseData BuildTestCaseData_HandleNotificationAsync_MessageReceivedNotification(
+            bool authorIsGuildMember,
+            bool authorGuildIsNull)
+        {
+            var mockAuthor = new Mock<IUser>();
+            if (authorIsGuildMember)
+                mockAuthor.As<IGuildUser>()
+                    .Setup(x => x.Guild)
+                    .Returns(authorGuildIsNull
+                        ? null!
+                        : new Mock<IGuild>().Object);
+
+            var mockMessage = new Mock<ISocketMessage>();
+            mockMessage
+                .Setup(x => x.Author)
+                .Returns(mockAuthor.Object);
+
+            var notification = new MessageReceivedNotification(
+                mockMessage.Object);
+
+            return new TestCaseData(notification);
+        }
+
+        public static readonly ImmutableArray<TestCaseData> HandleNotificationAsync_MessageReceivedNotification_AuthorIsNotTrackable_TestCaseData
+            = ImmutableArray.Create(
+                BuildTestCaseData_HandleNotificationAsync_MessageReceivedNotification(  authorIsGuildMember: false, authorGuildIsNull: false).SetName("{m}(Author is not guild member)"),
+                BuildTestCaseData_HandleNotificationAsync_MessageReceivedNotification(  authorIsGuildMember: true,  authorGuildIsNull: true ).SetName("{m}(Author guild is null)"));
+
+        public static readonly ImmutableArray<TestCaseData> HandleNotificationAsync_MessageReceivedNotification_AuthorIsTrackable_TestCaseData
+            = ImmutableArray.Create(
+                BuildTestCaseData_HandleNotificationAsync_MessageReceivedNotification(  authorIsGuildMember: true,  authorGuildIsNull: false).SetName("{m}(Author is guild member)"));
+
+        [TestCaseSource(nameof(HandleNotificationAsync_MessageReceivedNotification_AuthorIsNotTrackable_TestCaseData))]
+        public async Task HandleNotificationAsync_MessageReceivedNotification_AuthorIsNotTrackable_DoesNothing(
+            MessageReceivedNotification notification)
+        {
+            var testContext = new TestContext();
+
+            var uut = testContext.BuildUut();
+
+            await uut.HandleNotificationAsync(
+                notification,
+                testContext.CancellationToken);
+
+            testContext.MockUserService.Invocations.ShouldBeEmpty();
+        }
+
+        [TestCaseSource(nameof(HandleNotificationAsync_MessageReceivedNotification_AuthorIsTrackable_TestCaseData))]
+        public async Task HandleNotificationAsync_MessageReceivedNotification_AuthorIsTrackable_TracksAuthor(
+            MessageReceivedNotification notification)
+        {
+            var testContext = new TestContext();
+
+            var uut = testContext.BuildUut();
+
+            await uut.HandleNotificationAsync(
+                notification,
+                testContext.CancellationToken);
+
+            testContext.MockUserService.ShouldHaveReceived(x => x
+                .TrackUserAsync((IGuildUser)notification.Message.Author, testContext.CancellationToken));
+        }
+
+        #endregion HandleNotificationAsync(MessageReceivedNotification) Tests
+
+        #region HandleNotificationAsync(UserJoinedNotification) Tests
+
+        [Test]
+        public async Task HandleNotificationAsync_UserJoinedNotification_Tests()
+        {
+            var testContext = new TestContext();
+
+            var uut = testContext.BuildUut();
+
+            var notification = new UserJoinedNotification(
+                new Mock<ISocketGuildUser>().Object);
+
+            await uut.HandleNotificationAsync(
+                notification,
+                testContext.CancellationToken);
+
+            testContext.MockUserService.ShouldHaveReceived(x => x
+                .TrackUserAsync(notification.GuildUser, testContext.CancellationToken));
+        }
+
+        #endregion HandleNotificationAsync(UserJoinedNotification) Tests
+    }
+}

--- a/Modix.Services/Core/CoreSetup.cs
+++ b/Modix.Services/Core/CoreSetup.cs
@@ -20,7 +20,6 @@ namespace Modix.Services.Core
         /// <returns><paramref name="services"/></returns>
         public static IServiceCollection AddModixCore(this IServiceCollection services)
             => services
-                .AddSingleton<IBehavior, UserTrackingBehavior>()
                 .AddSingleton<IBehavior, DiscordSocketListeningBehavior>()
                 .AddSingleton<ReadySynchronizationProvider>()
                 .AddSingleton<IReadySynchronizationProvider>(x => x.GetService<ReadySynchronizationProvider>())

--- a/Modix.Services/Core/DiscordSocketListeningBehavior.cs
+++ b/Modix.Services/Core/DiscordSocketListeningBehavior.cs
@@ -34,6 +34,7 @@ namespace Modix.Services.Core
             DiscordSocketClient.ChannelCreated += OnChannelCreatedAsync;
             DiscordSocketClient.ChannelUpdated += OnChannelUpdatedAsync;
             DiscordSocketClient.GuildAvailable += OnGuildAvailableAsync;
+            DiscordSocketClient.GuildMemberUpdated += OnGuildMemberUpdatedAsync;
             DiscordSocketClient.JoinedGuild += OnJoinedGuildAsync;
             DiscordSocketClient.MessageDeleted += OnMessageDeletedAsync;
             DiscordSocketClient.MessageReceived += OnMessageReceivedAsync;
@@ -57,6 +58,7 @@ namespace Modix.Services.Core
             DiscordSocketClient.ChannelCreated -= OnChannelCreatedAsync;
             DiscordSocketClient.ChannelUpdated -= OnChannelUpdatedAsync;
             DiscordSocketClient.GuildAvailable -= OnGuildAvailableAsync;
+            DiscordSocketClient.GuildMemberUpdated -= OnGuildMemberUpdatedAsync;
             DiscordSocketClient.JoinedGuild -= OnJoinedGuildAsync;
             DiscordSocketClient.MessageDeleted -= OnMessageDeletedAsync;
             DiscordSocketClient.MessageReceived -= OnMessageReceivedAsync;
@@ -98,6 +100,13 @@ namespace Modix.Services.Core
         private Task OnGuildAvailableAsync(ISocketGuild guild)
         {
             MessageDispatcher.Dispatch(new GuildAvailableNotification(guild));
+
+            return Task.CompletedTask;
+        }
+
+        private Task OnGuildMemberUpdatedAsync(ISocketGuildUser oldMember, ISocketGuildUser newMember)
+        {
+            MessageDispatcher.Dispatch(new GuildMemberUpdatedNotification(oldMember, newMember));
 
             return Task.CompletedTask;
         }

--- a/Modix.Services/Core/Messages/GuildMemberUpdatedNotification.cs
+++ b/Modix.Services/Core/Messages/GuildMemberUpdatedNotification.cs
@@ -1,0 +1,38 @@
+﻿#nullable enable
+
+using Discord.WebSocket;
+
+using Modix.Common.Messaging;
+
+namespace Discord
+{
+    /// <summary>
+    /// Describes an application-wide notification that occurs when <see cref="IBaseSocketClient.GuildMemberUpdated"/> is raised.
+    /// </summary>
+    public class GuildMemberUpdatedNotification
+        : INotification
+    {
+        /// <summary>
+        /// Constructs a new <see cref="GuildMemberUpdatedNotification"/> from the given values.
+        /// </summary>
+        /// <param name="oldMember">The value to use for <see cref="OldMember"/>.</param>
+        /// <param name="newMember">The value to use for <see cref="NewMember"/>.</param>
+        public GuildMemberUpdatedNotification(
+            ISocketGuildUser oldMember,
+            ISocketGuildUser newMember)
+        {
+            OldMember = oldMember;
+            NewMember = newMember;
+        }
+
+        /// <summary>
+        /// A model of the Guild Member that was updated, from before the update.
+        /// </summary>
+        public ISocketGuildUser OldMember { get; }
+
+        /// <summary>
+        /// A model of the Guild Member that was updated, from after the update.
+        /// </summary>
+        public ISocketGuildUser NewMember { get; }
+    }
+}

--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -446,7 +446,7 @@ namespace Modix.Services.Moderation
                 if (subject == null)
                     throw new InvalidOperationException($"The given subject was not valid, ID: {subjectId}");
 
-                await UserService.TrackUserAsync(subject);
+                await UserService.TrackUserAsync(subject, default);
             }
             else
             {
@@ -613,7 +613,7 @@ namespace Modix.Services.Moderation
                 throw new InvalidOperationException(
                     $"Cannot delete message {message.Id} because it is not a guild message");
 
-            await UserService.TrackUserAsync(message.Author as IGuildUser);
+            await UserService.TrackUserAsync(message.Author as IGuildUser, default);
             await ChannelService.TrackChannelAsync(guildChannel);
 
             using (var transaction = await DeletedMessageRepository.BeginCreateTransactionAsync())


### PR DESCRIPTION
Replaced implementation based on deprecated `BehaviorBase` with implementation base on `Modix.Common.Messaging`.

Added tests.

Added support for Nullable Reference Type checking

Added support for CancellationToken, all the way to the database.

Added Messaging plumbing for IDiscordSocketClient.GuildMemberUpdated.