### PR TITLE
Refactored `AttachmentBlacklistBehavior`

### DIFF
--- a/Modix.Data.Test/Repositories/DesignatedChannelMappingRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/DesignatedChannelMappingRepositoryTests.cs
@@ -246,7 +246,7 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            var result = await uut.AnyAsync(criteria);
+            var result = await uut.AnyAsync(criteria, default);
 
             result.ShouldBeTrue();
         }
@@ -256,7 +256,7 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            var result = await uut.AnyAsync(criteria);
+            var result = await uut.AnyAsync(criteria, default);
 
             result.ShouldBeFalse();
         }

--- a/Modix.Data.Test/Repositories/GuildUserRepositoryTests.cs
+++ b/Modix.Data.Test/Repositories/GuildUserRepositoryTests.cs
@@ -55,9 +55,9 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            var existingTransaction = await uut.BeginCreateTransactionAsync();
+            var existingTransaction = await uut.BeginCreateTransactionAsync(default);
 
-            var result = uut.BeginCreateTransactionAsync();
+            var result = uut.BeginCreateTransactionAsync(default);
 
             result.IsCompleted.ShouldBeFalse();
 
@@ -71,7 +71,7 @@ namespace Modix.Data.Test.Repositories
         {
             (var modixContext, var uut) = BuildTestContext();
 
-            var result = uut.BeginCreateTransactionAsync();
+            var result = uut.BeginCreateTransactionAsync(default);
 
             result.IsCompleted.ShouldBeTrue();
 
@@ -87,7 +87,7 @@ namespace Modix.Data.Test.Repositories
             var database = Substitute.ForPartsOf<DatabaseFacade>(modixContext);
             modixContext.Database.Returns(database);
 
-            using (var transaction = await uut.BeginCreateTransactionAsync()) { }
+            using (var transaction = await uut.BeginCreateTransactionAsync(default)) { }
 
             await database.ShouldHaveReceived(1)
                 .BeginTransactionAsync();

--- a/Modix.Data/Repositories/DesignatedChannelMappingRepository.cs
+++ b/Modix.Data/Repositories/DesignatedChannelMappingRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.EntityFrameworkCore;
@@ -49,11 +50,14 @@ namespace Modix.Data.Repositories
         /// Checks whether any mappings exist within the repository, according to an arbitrary set of criteria.
         /// </summary>
         /// <param name="criteria">A set of criteria defining the mappings to check for.</param>
+        /// <param name="cancellationToken">A token that may be used to cancel the operation.</param>
         /// <returns>
         /// A <see cref="Task"/> that will complete when the operation has completed,
         /// containing a flag indicating whether any matching mappings were found.
         /// </returns>
-        Task<bool> AnyAsync(DesignatedChannelMappingSearchCriteria criteria);
+        Task<bool> AnyAsync(
+            DesignatedChannelMappingSearchCriteria criteria,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Searches the repository for mapped <see cref="DesignatedChannelMappingEntity.ChannelId"/> values, based on an arbitrary set of criteria
@@ -129,10 +133,12 @@ namespace Modix.Data.Repositories
         }
 
         /// <inheritdoc />
-        public Task<bool> AnyAsync(DesignatedChannelMappingSearchCriteria criteria)
+        public Task<bool> AnyAsync(
+                DesignatedChannelMappingSearchCriteria criteria,
+                CancellationToken cancellationToken)
             => ModixContext.Set<DesignatedChannelMappingEntity>().AsNoTracking()
                 .FilterBy(criteria)
-                .AnyAsync();
+                .AnyAsync(cancellationToken);
 
         /// <inheritdoc />
         public async Task<IReadOnlyCollection<ulong>> SearchChannelIdsAsync(DesignatedChannelMappingSearchCriteria searchCriteria)

--- a/Modix.Services.Test/MessageLogging/MessageLoggingBehaviorTests.cs
+++ b/Modix.Services.Test/MessageLogging/MessageLoggingBehaviorTests.cs
@@ -38,7 +38,11 @@ namespace Modix.Services.Test.MessageLogging
             {
                 MockDesignatedChannelService = new Mock<IDesignatedChannelService>();
                 MockDesignatedChannelService
-                    .Setup(x => x.ChannelHasDesignationAsync(It.IsAny<IGuild>(), It.IsAny<IChannel>(), DesignatedChannelType.Unmoderated))
+                    .Setup(x => x.ChannelHasDesignationAsync(
+                        It.IsAny<IGuild>(),
+                        It.IsAny<IChannel>(),
+                        DesignatedChannelType.Unmoderated,
+                        It.IsAny<CancellationToken>()))
                     .ReturnsAsync(isChannelUnmoderated);
                 MockDesignatedChannelService
                     .Setup(x => x.GetDesignatedChannelsAsync(It.IsAny<IGuild>(), DesignatedChannelType.MessageLog))
@@ -209,7 +213,8 @@ namespace Modix.Services.Test.MessageLogging
                         .ChannelHasDesignationAsync(
                             mockGuild.Object,
                             mockChannel.Object,
-                            DesignatedChannelType.Unmoderated),
+                            DesignatedChannelType.Unmoderated,
+                            testContext.CancellationToken),
                     Times.AtMostOnce());
                 testContext.MockDesignatedChannelService.ShouldHaveReceived(x => x
                         .GetDesignatedChannelsAsync(
@@ -263,7 +268,8 @@ namespace Modix.Services.Test.MessageLogging
                 .ChannelHasDesignationAsync(
                     mockGuild.Object,
                     mockChannel.Object,
-                    DesignatedChannelType.Unmoderated));
+                    DesignatedChannelType.Unmoderated,
+                    testContext.CancellationToken));
             testContext.MockDesignatedChannelService.ShouldHaveReceived(x => x
                 .GetDesignatedChannelsAsync(
                     mockGuild.Object,
@@ -450,7 +456,8 @@ namespace Modix.Services.Test.MessageLogging
                         .ChannelHasDesignationAsync(
                             mockGuild.Object,
                             mockChannel.Object,
-                            DesignatedChannelType.Unmoderated),
+                            DesignatedChannelType.Unmoderated,
+                            testContext.CancellationToken),
                     Times.AtMostOnce());
                 testContext.MockDesignatedChannelService.ShouldHaveReceived(x => x
                         .GetDesignatedChannelsAsync(
@@ -505,7 +512,8 @@ namespace Modix.Services.Test.MessageLogging
                 .ChannelHasDesignationAsync(
                     mockGuild.Object,
                     mockChannel.Object,
-                    DesignatedChannelType.Unmoderated));
+                    DesignatedChannelType.Unmoderated,
+                    testContext.CancellationToken));
             testContext.MockDesignatedChannelService.ShouldHaveReceived(x => x
                 .GetDesignatedChannelsAsync(
                     mockGuild.Object,

--- a/Modix.Services.Test/Moderation/AttachmentBlacklistBehaviorTests.cs
+++ b/Modix.Services.Test/Moderation/AttachmentBlacklistBehaviorTests.cs
@@ -1,0 +1,271 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Discord;
+using Discord.WebSocket;
+
+using Modix.Common.Test;
+using Modix.Data.Models.Core;
+using Modix.Services.Core;
+using Modix.Services.Moderation;
+
+using Moq;
+
+using NUnit.Framework;
+
+using Shouldly;
+
+namespace Modix.Services.Test.Moderation
+{
+    [TestFixture]
+    public class AttachmentBlacklistBehaviorTests
+    {
+        #region Test Context
+
+        public class TestContext
+            : AsyncMethodWithLoggerTestContext
+        {
+            public TestContext(
+                ulong selfUserId,
+                bool channelIsUnmoderated)
+            {
+                MockDesignatedChannelService = new Mock<IDesignatedChannelService>();
+                MockDesignatedChannelService
+                    .Setup(x => x.ChannelHasDesignationAsync(
+                        It.IsAny<IGuild>(),
+                        It.IsAny<IChannel>(),
+                        DesignatedChannelType.Unmoderated,
+                        It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(channelIsUnmoderated);
+
+                MockModerationService = new Mock<IModerationService>();
+
+                MockSelfUser = new Mock<ISocketSelfUser>();
+                MockSelfUser
+                    .Setup(x => x.Id)
+                    .Returns(selfUserId);
+
+                MockSelfUserProvider = new Mock<ISelfUserProvider>();
+                MockSelfUserProvider
+                    .Setup(x => x.GetSelfUserAsync(It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() => MockSelfUser.Object);
+            }
+
+            public AttachmentBlacklistBehavior BuildUut()
+                => new AttachmentBlacklistBehavior(
+                    MockDesignatedChannelService.Object,
+                    LoggerFactory.CreateLogger<AttachmentBlacklistBehavior>(),
+                    MockModerationService.Object,
+                    MockSelfUserProvider.Object);
+
+            public readonly Mock<IDesignatedChannelService> MockDesignatedChannelService;
+            public readonly Mock<IModerationService> MockModerationService;
+            public readonly Mock<ISocketSelfUser> MockSelfUser;
+            public readonly Mock<ISelfUserProvider> MockSelfUserProvider;
+        }
+
+        #endregion Test Context
+
+        #region HandleNotificationAsync() Tests
+
+        public static TestCaseData BuildTestCaseData_HandleNotificationAsync(
+            ulong selfUserId,
+            ulong? guildId,
+            (ulong id, bool isUnmoderated) channel,
+            (ulong id, bool isBot, bool isWebhook) author,
+            ulong messageId,
+            IReadOnlyList<string> attachmentFilenames,
+            IReadOnlyList<string> suspiciousFilenames)
+        {
+            var mockChannel = new Mock<IMessageChannel>();
+            mockChannel
+                .Setup(x => x.Id)
+                .Returns(channel.id);
+
+            var mockAuthor = new Mock<IUser>();
+            mockAuthor
+                .Setup(x => x.Id)
+                .Returns(author.id);
+            mockAuthor
+                .Setup(x => x.IsBot)
+                .Returns(author.isBot);
+            mockAuthor
+                .Setup(x => x.IsWebhook)
+                .Returns(author.isWebhook);
+            mockAuthor
+                .Setup(x => x.Mention)
+                .Returns($"<@{author.id}>");
+
+            if (guildId.HasValue)
+            {
+                var mockGuild = new Mock<ISocketGuild>();
+                mockGuild
+                    .Setup(x => x.Id)
+                    .Returns(guildId.Value);
+
+                mockChannel.As<ISocketGuildChannel>()
+                    .Setup(x => x.Guild)
+                    .Returns(mockGuild.Object);
+
+                mockAuthor.As<IGuildUser>()
+                    .Setup(x => x.Guild)
+                    .Returns(mockGuild.Object);
+            }
+
+            var mockMessage = new Mock<ISocketMessage>();
+            mockMessage
+                .Setup(x => x.Id)
+                .Returns(messageId);
+            mockMessage
+                .Setup(x => x.Channel)
+                .Returns(mockChannel.Object);
+            mockMessage
+                .Setup(x => x.Author)
+                .Returns(mockAuthor.Object);
+            mockMessage
+                .Setup(x => x.Attachments)
+                .Returns(attachmentFilenames
+                    .Select(attachmentFilename =>
+                    {
+                        var mockAttachment = new Mock<IAttachment>();
+                        mockAttachment
+                            .Setup(x => x.Filename)
+                            .Returns(attachmentFilename);
+
+                        return mockAttachment.Object;
+                    })
+                    .ToArray());
+
+            var notification = new MessageReceivedNotification(
+                mockMessage.Object);
+
+            return new TestCaseData(selfUserId, mockChannel, notification, channel.isUnmoderated, suspiciousFilenames);
+        }
+
+        public static readonly ImmutableArray<TestCaseData> HandleNotificationAsync_MessageHasNoSuspiciousAttachments_TestCaseData
+            = ImmutableArray.Create(
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: default,        guildId: default,           channel: (id: default,          isUnmoderated: default),    author: (id: default,           isBot: default, isWebhook: default),    messageId: default,         attachmentFilenames: Array.Empty<string>(),                     suspiciousFilenames: Array.Empty<string>()  ).SetName("{m}(Default Values)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: ulong.MinValue, guildId: ulong.MinValue,    channel: (id: ulong.MinValue,   isUnmoderated: false),      author: (id: ulong.MinValue,    isBot: false,   isWebhook: false),      messageId: ulong.MinValue,  attachmentFilenames: Array.Empty<string>(),                     suspiciousFilenames: Array.Empty<string>()  ).SetName("{m}(Min Values)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: ulong.MaxValue, guildId: ulong.MaxValue,    channel: (id: ulong.MaxValue,   isUnmoderated: true),       author: (id: ulong.MaxValue,    isBot: true,    isWebhook: true),       messageId: ulong.MaxValue,  attachmentFilenames: Array.Empty<string>(),                     suspiciousFilenames: Array.Empty<string>()  ).SetName("{m}(Max Values)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: 1,              guildId: null,              channel: (id: 2,                isUnmoderated: false),      author: (id: 3,                 isBot: false,   isWebhook: false),      messageId: 4,               attachmentFilenames: new[] { "5.exe" },                         suspiciousFilenames: Array.Empty<string>()  ).SetName("{m}(Message is not from guild)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: 6,              guildId: 7,                 channel: (id: 8,                isUnmoderated: true),       author: (id: 9,                 isBot: false,   isWebhook: false),      messageId: 10,              attachmentFilenames: new[] { "11.exe" },                        suspiciousFilenames: Array.Empty<string>()  ).SetName("{m}(Channel is unmoderated)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: 12,             guildId: 13,                channel: (id: 14,               isUnmoderated: false),      author: (id: 15,                isBot: true,    isWebhook: false),      messageId: 16,              attachmentFilenames: new[] { "17.exe" },                        suspiciousFilenames: Array.Empty<string>()  ).SetName("{m}(Author is bot)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: 18,             guildId: 19,                channel: (id: 20,               isUnmoderated: false),      author: (id: 21,                isBot: false,   isWebhook: true),       messageId: 22,              attachmentFilenames: new[] { "23.exe" },                        suspiciousFilenames: Array.Empty<string>()  ).SetName("{m}(Author is webhook)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: 24,             guildId: 25,                channel: (id: 26,               isUnmoderated: false),      author: (id: 27,                isBot: false,   isWebhook: false),      messageId: 28,              attachmentFilenames: Array.Empty<string>(),                     suspiciousFilenames: Array.Empty<string>()  ).SetName("{m}(Message has no attachments)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: 29,             guildId: 30,                channel: (id: 31,               isUnmoderated: false),      author: (id: 32,                isBot: false,   isWebhook: false),      messageId: 33,              attachmentFilenames: new[] { "34.txt" },                        suspiciousFilenames: Array.Empty<string>()  ).SetName("{m}(Attachment is not suspicious)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: 35,             guildId: 36,                channel: (id: 37,               isUnmoderated: false),      author: (id: 38,                isBot: false,   isWebhook: false),      messageId: 39,              attachmentFilenames: new[] { "40.jpg", "41.bpm", "42.png" },    suspiciousFilenames: Array.Empty<string>()  ).SetName("{m}(Attachments are not suspicious)"));
+
+        [TestCaseSource(nameof(HandleNotificationAsync_MessageHasNoSuspiciousAttachments_TestCaseData))]
+        public async Task HandleNotificationAsync_MessageHasNoSuspiciousAttachments_IgnoresMessage(
+            ulong selfUserId,
+            Mock<IMessageChannel> mockChannel,
+            MessageReceivedNotification notification,
+            bool channelIsUnmoderated,
+            IReadOnlyList<string> suspiciousFilenames)
+        {
+            using var testContext = new TestContext(
+                selfUserId,
+                channelIsUnmoderated);
+
+            var uut = testContext.BuildUut();
+
+            await uut.HandleNotificationAsync(
+                notification,
+                testContext.CancellationToken);
+
+            var guild = (notification.Message.Channel as ISocketGuildChannel)?.Guild;
+            if (guild is null)
+                testContext.MockDesignatedChannelService.ShouldNotHaveReceived(x => x
+                    .ChannelHasDesignationAsync(
+                        It.IsAny<IGuild>(),
+                        It.IsAny<IChannel>(),
+                        It.IsAny<DesignatedChannelType>(),
+                        It.IsAny<CancellationToken>()));
+            else
+                testContext.MockDesignatedChannelService.ShouldHaveReceived(x => x
+                        .ChannelHasDesignationAsync(
+                            guild,
+                            mockChannel.Object,
+                            DesignatedChannelType.Unmoderated,
+                            testContext.CancellationToken),
+                    Times.AtMostOnce());
+
+            testContext.MockSelfUserProvider.Invocations.ShouldBeEmpty();
+
+            testContext.MockModerationService.Invocations.ShouldBeEmpty();
+
+            mockChannel.ShouldNotHaveReceived(x => x
+                .SendMessageAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<Embed>(),
+                    It.IsAny<RequestOptions>()));
+        }
+
+        public static readonly ImmutableArray<TestCaseData> HandleNotificationAsync_MessageHasAnySuspiciousAttachments_TestCaseData
+            = ImmutableArray.Create(
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: 1,  guildId: 2,     channel: (id: 3,    isUnmoderated: false),  author: (id: 4,     isBot: false,   isWebhook: false),  messageId: 5,   attachmentFilenames: new[] { "6.exe" },                         suspiciousFilenames: new[] { "6.exe" }                      ).SetName("{m}(Message has suspicious attachment)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: 7,  guildId: 8,     channel: (id: 9,    isUnmoderated: false),  author: (id: 10,    isBot: false,   isWebhook: false),  messageId: 11,  attachmentFilenames: new[] { "12.dll", "13.bat", "14.sh" },     suspiciousFilenames: new[] { "12.dll", "13.bat", "14.sh" }  ).SetName("{m}(Message has suspicious attachments)"),
+                BuildTestCaseData_HandleNotificationAsync(  selfUserId: 15, guildId: 16,    channel: (id: 17,   isUnmoderated: false),  author: (id: 18,    isBot: false,   isWebhook: false),  messageId: 19,  attachmentFilenames: new[] { "20.msc", "21.txt", "22.jar" },    suspiciousFilenames: new[] { "20.msc", "22.jar" }           ).SetName("{m}(Message has suspicious and non-suspicious attachments)"));
+
+        [TestCaseSource(nameof(HandleNotificationAsync_MessageHasAnySuspiciousAttachments_TestCaseData))]
+        public async Task HandleNotificationAsync_MessageHasAnySuspiciousAttachments_DeletesMessageAndReplies(
+            ulong selfUserId,
+            Mock<IMessageChannel> mockChannel,
+            MessageReceivedNotification notification,
+            bool channelIsUnmoderated,
+            IReadOnlyList<string> suspiciousFilenames)
+        {
+            using var testContext = new TestContext(
+                selfUserId,
+                channelIsUnmoderated);
+
+            var uut = testContext.BuildUut();
+
+            await uut.HandleNotificationAsync(
+                notification,
+                testContext.CancellationToken);
+
+            testContext.MockDesignatedChannelService.ShouldHaveReceived(x => x
+                .ChannelHasDesignationAsync(
+                    ((ISocketGuildChannel)notification.Message.Channel).Guild,
+                    mockChannel.Object,
+                    DesignatedChannelType.Unmoderated,
+                    testContext.CancellationToken));
+
+            testContext.MockSelfUserProvider.ShouldHaveReceived(x => x
+                .GetSelfUserAsync(testContext.CancellationToken));
+
+            testContext.MockModerationService.ShouldHaveReceived(x => x
+                .DeleteMessageAsync(
+                    notification.Message,
+                    It.IsNotNull<string>(),
+                    selfUserId,
+                    testContext.CancellationToken));
+
+            var reason = testContext.MockModerationService.Invocations
+                .Where(x => x.Method.Name == nameof(IModerationService.DeleteMessageAsync))
+                .Select(x => (string)x.Arguments[1])
+                .First();
+            reason.ShouldContain("attach");
+            reason.ShouldContain("suspicious");
+            foreach(var suspiciousFilename in suspiciousFilenames)
+                reason.ShouldContain(suspiciousFilename);
+
+            mockChannel.ShouldHaveReceived(x => x
+                .SendMessageAsync(
+                    It.Is<string>(y => (y != null) && y.Contains(notification.Message.Author.Id.ToString())),
+                    It.IsAny<bool>(),
+                    It.IsAny<Embed>(),
+                    It.Is<RequestOptions>(y => (y != null) && (y.CancelToken == testContext.CancellationToken))));
+        }
+
+        #endregion HandleNotificationAsync() Tests
+    }
+}

--- a/Modix.Services.Test/Moderation/InvitePurgingBehaviorTests.cs
+++ b/Modix.Services.Test/Moderation/InvitePurgingBehaviorTests.cs
@@ -284,7 +284,8 @@ namespace Modix.Services.Test.Moderation
                 .Setup(x => x.ChannelHasDesignationAsync(
                     autoMocker.Get<IGuild>(),
                     autoMocker.Get<IMessageChannel>(),
-                    DesignatedChannelType.Unmoderated))
+                    DesignatedChannelType.Unmoderated,
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
 
             await uut.HandleNotificationAsync(notification);
@@ -339,7 +340,8 @@ namespace Modix.Services.Test.Moderation
                     DeleteMessageAsync(
                         notification.Message,
                         It.Is<string>(y => y.Contains("invite", StringComparison.OrdinalIgnoreCase)),
-                        autoMocker.Get<ISocketSelfUser>().Id));
+                        autoMocker.Get<ISocketSelfUser>().Id,
+                        It.IsAny<CancellationToken>()));
         }
 
         [Test]
@@ -490,7 +492,8 @@ namespace Modix.Services.Test.Moderation
                 .Setup(x => x.ChannelHasDesignationAsync(
                     autoMocker.Get<IGuild>(),
                     autoMocker.Get<IMessageChannel>(),
-                    DesignatedChannelType.Unmoderated))
+                    DesignatedChannelType.Unmoderated,
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
 
             await uut.HandleNotificationAsync(notification);
@@ -551,7 +554,8 @@ namespace Modix.Services.Test.Moderation
                     DeleteMessageAsync(
                         notification.NewMessage,
                         It.Is<string>(y => y.Contains("invite", StringComparison.OrdinalIgnoreCase)),
-                        autoMocker.Get<ISocketSelfUser>().Id));
+                        autoMocker.Get<ISocketSelfUser>().Id,
+                        It.IsAny<CancellationToken>()));
         }
 
         [Test]
@@ -587,7 +591,8 @@ namespace Modix.Services.Test.Moderation
                     DeleteMessageAsync(
                         It.IsAny<IMessage>(),
                         It.IsAny<string>(),
-                        It.IsAny<ulong>()));
+                        It.IsAny<ulong>(),
+                        It.IsAny<CancellationToken>()));
 
             autoMocker.GetMock<IMessageChannel>()
                 .ShouldNotHaveReceived(x => x.

--- a/Modix.Services.Test/UserMetrics/UserMetricsBehaviorTests.cs
+++ b/Modix.Services.Test/UserMetrics/UserMetricsBehaviorTests.cs
@@ -39,7 +39,8 @@ namespace Modix.Services.Test.UserMetrics
                     .Setup(x => x.ChannelHasDesignationAsync(
                         It.IsAny<IGuild>(),
                         It.IsAny<IChannel>(),
-                        DesignatedChannelType.CountsTowardsParticipation))
+                        DesignatedChannelType.CountsTowardsParticipation,
+                        It.IsAny<CancellationToken>()))
                     .ReturnsAsync(() => IsChannelOnTopic);
 
                 MockDesignatedRoleService = new Mock<IDesignatedRoleService>();
@@ -230,7 +231,8 @@ namespace Modix.Services.Test.UserMetrics
                     .ChannelHasDesignationAsync(
                         guild,
                         notification.Message.Channel,
-                        DesignatedChannelType.CountsTowardsParticipation),
+                        DesignatedChannelType.CountsTowardsParticipation,
+                        testContext.CancellationToken),
                 Times.AtMostOnce());
 
             if (guild is { })
@@ -276,7 +278,8 @@ namespace Modix.Services.Test.UserMetrics
                 .ChannelHasDesignationAsync(
                     guild,
                     notification.Message.Channel,
-                    DesignatedChannelType.CountsTowardsParticipation));
+                    DesignatedChannelType.CountsTowardsParticipation,
+                    testContext.CancellationToken));
 
             testContext.MockDesignatedRoleService.ShouldHaveReceived(x => x
                 .RolesHaveDesignationAsync(
@@ -321,7 +324,8 @@ namespace Modix.Services.Test.UserMetrics
                 .Setup(x => x.ChannelHasDesignationAsync(
                     It.IsAny<IGuild>(),
                     It.IsAny<IChannel>(),
-                    It.IsAny<DesignatedChannelType>()))
+                    It.IsAny<DesignatedChannelType>(),
+                    It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new Exception());
 
             var uut = testContext.BuildUut();
@@ -334,7 +338,8 @@ namespace Modix.Services.Test.UserMetrics
                 .ChannelHasDesignationAsync(
                     guild,
                     notification.Message.Channel,
-                    DesignatedChannelType.CountsTowardsParticipation));
+                    DesignatedChannelType.CountsTowardsParticipation,
+                    testContext.CancellationToken));
 
             testContext.MockDesignatedRoleService.ShouldHaveReceived(x => x
                 .RolesHaveDesignationAsync(
@@ -392,7 +397,8 @@ namespace Modix.Services.Test.UserMetrics
                 .ChannelHasDesignationAsync(
                     guild,
                     notification.Message.Channel,
-                    DesignatedChannelType.CountsTowardsParticipation));
+                    DesignatedChannelType.CountsTowardsParticipation,
+                    testContext.CancellationToken));
 
             testContext.MockDesignatedRoleService.ShouldHaveReceived(x => x
                 .RolesHaveDesignationAsync(

--- a/Modix.Services/Core/UserService.cs
+++ b/Modix.Services/Core/UserService.cs
@@ -202,7 +202,7 @@ namespace Modix.Services.Core
         {
             var now = _systemClock.UtcNow;
 
-            using (var transaction = await GuildUserRepository.BeginCreateTransactionAsync())
+            using (var transaction = await GuildUserRepository.BeginCreateTransactionAsync(cancellationToken))
             {
                 if (!await GuildUserRepository.TryUpdateAsync(user.Id, user.GuildId, data =>
                 {

--- a/Modix.Services/MessageLogging/MessageLoggingBehavior.cs
+++ b/Modix.Services/MessageLogging/MessageLoggingBehavior.cs
@@ -172,7 +172,8 @@ namespace Modix.Services.MessageLogging
             var channelIsUnmoderated = await _designatedChannelService.ChannelHasDesignationAsync(
                 guild,
                 channel,
-                DesignatedChannelType.Unmoderated);
+                DesignatedChannelType.Unmoderated,
+                cancellationToken);
             if (channelIsUnmoderated)
             {
                 MessageLoggingLogMessages.IgnoringUnmoderatedChannel(_logger);

--- a/Modix.Services/Moderation/AttachmentBlacklistBehavior.cs
+++ b/Modix.Services/Moderation/AttachmentBlacklistBehavior.cs
@@ -1,126 +1,172 @@
-﻿using System;
+﻿#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 using Discord;
 using Discord.WebSocket;
-using Serilog;
+
+using Modix.Common.Messaging;
+using Modix.Services.Core;
+using Modix.Data.Models.Core;
 
 namespace Modix.Services.Moderation
 {
-    public class AttachmentBlacklistBehavior : BehaviorBase
+    [ServiceBinding(ServiceLifetime.Scoped)]
+    public class AttachmentBlacklistBehavior
+        : INotificationHandler<MessageReceivedNotification>
     {
         public static readonly IReadOnlyCollection<string> BlacklistedExtensions = new[]
         {
-            ".exe",
-            ".dll",
-            ".application",
-            ".msc",
-            ".bat",
-            ".pdb",
-            ".sh",
-            ".com",
-            ".scr",
-            ".msi",
-            ".cmd",
-            ".vbs",
-            ".js",
-            ".reg",
-            ".pif",
-            ".msp",
-            ".hta",
-            ".cpl",
-            ".jar",
-            ".vbe",
-            ".ws",
-            ".wsf",
-            ".wsc",
-            ".wsh",
-            ".ps1",
-            ".ps1xml",
-            ".ps2",
-            ".ps2xml",
-            ".psc1",
-            ".pasc2",
-            ".msh",
-            ".msh1",
-            ".msh2",
-            ".mshxml",
-            ".msh1xml",
-            ".msh2xml",
-            ".scf",
-            ".lnk",
-            ".inf",
-            ".doc",
-            ".xls",
-            ".ppt",
-            ".docm",
-            ".dotm",
-            ".xlsm",
-            ".xltm",
-            ".xlam",
-            ".pptm",
-            ".potm",
-            ".ppam",
-            ".ppsm",
-            ".sldn"
+                ".exe",
+                ".dll",
+                ".application",
+                ".msc",
+                ".bat",
+                ".pdb",
+                ".sh",
+                ".com",
+                ".scr",
+                ".msi",
+                ".cmd",
+                ".vbs",
+                ".js",
+                ".reg",
+                ".pif",
+                ".msp",
+                ".hta",
+                ".cpl",
+                ".jar",
+                ".vbe",
+                ".ws",
+                ".wsf",
+                ".wsc",
+                ".wsh",
+                ".ps1",
+                ".ps1xml",
+                ".ps2",
+                ".ps2xml",
+                ".psc1",
+                ".pasc2",
+                ".msh",
+                ".msh1",
+                ".msh2",
+                ".mshxml",
+                ".msh1xml",
+                ".msh2xml",
+                ".scf",
+                ".lnk",
+                ".inf",
+                ".doc",
+                ".xls",
+                ".ppt",
+                ".docm",
+                ".dotm",
+                ".xlsm",
+                ".xltm",
+                ".xlam",
+                ".pptm",
+                ".potm",
+                ".ppam",
+                ".ppsm",
+                ".sldn"
         };
 
-        private DiscordSocketClient DiscordClient { get; }
-
-        public AttachmentBlacklistBehavior(DiscordSocketClient discordClient, IServiceProvider serviceProvider) : base(serviceProvider)
+        public AttachmentBlacklistBehavior(
+            IDesignatedChannelService designatedChannelService,
+            ILogger<AttachmentBlacklistBehavior> logger,
+            IModerationService moderationService,
+            ISelfUserProvider selfUserProvider)
         {
-            DiscordClient = discordClient;
+            _designatedChannelService = designatedChannelService;
+            _logger = logger;
+            _moderationService = moderationService;
+            _selfUserProvider = selfUserProvider;
         }
 
-        private async Task Handle(IMessage message)
+        public async Task HandleNotificationAsync(
+            MessageReceivedNotification notification,
+            CancellationToken cancellationToken)
         {
+            var message = notification.Message;
+            var channel = notification.Message.Channel;
+            var guild = (channel as ISocketGuildChannel)?.Guild;
+            var author = notification.Message.Author;
+
+            using var logScope = AttachmentBlacklistLogMessages.BeginMessageScope(_logger, guild?.Id, channel.Id, author.Id, message.Id);
+
             if (!message.Attachments.Any())
-                return;
-
-            if (!(message is IUserMessage userMessage) || !(userMessage.Author is IGuildUser || userMessage.Author.IsBot))
-                return;
-
-            // Check if the attachment's file name ends in anything suspicious first
-            if (!BlacklistedExtensions.Any(ext => message.Attachments.Any(m => m.Filename.ToLower().EndsWith(ext))))
-                return;
-
-            await TryDeleteAndReplyToUser(message);
-        }
-
-        private async Task TryDeleteAndReplyToUser(IMessage message)
-        {
-            try
             {
-                var attachments = string.Join(", ", message.Attachments.Select(x => x.Filename));
-
-                await SelfExecuteRequest<IModerationService>(async moderationService =>
-                {
-                    await moderationService.DeleteMessageAsync(message, $"Message had suspicious files attached: {attachments}", DiscordClient.CurrentUser.Id);
-                });
-
-                var reply = GetReplyToUser(message);
-                await message.Channel.SendMessageAsync(reply);
+                AttachmentBlacklistLogMessages.IgnoringMessageWithNoAttachments(_logger);
+                return;
             }
-            catch (Exception e)
+
+            if (guild is null)
             {
-                Log.Warning(e, "Failed to remove message {messageId} with suspicious file(s) attached in {channelName}", message.Id, message.Channel.Name);
+                AttachmentBlacklistLogMessages.IngoringNonGuildMessage(_logger);
+                return;
             }
+
+            if (author.IsBot || author.IsWebhook)
+            {
+                AttachmentBlacklistLogMessages.IngoringNonHumanMessage(_logger);
+                return;
+            }
+
+            AttachmentBlacklistLogMessages.ChannelModerationStatusFetching(_logger);
+            var channelIsUnmoderated = await _designatedChannelService.ChannelHasDesignationAsync(
+                guild,
+                channel,
+                DesignatedChannelType.Unmoderated,
+                cancellationToken);
+            AttachmentBlacklistLogMessages.ChannelModerationStatusFetched(_logger);
+            if (channelIsUnmoderated)
+            {
+                AttachmentBlacklistLogMessages.IgnoringUnmoderatedChannel(_logger);
+                return;
+            }
+
+            AttachmentBlacklistLogMessages.SuspiciousAttachmentsSearching(_logger);
+            var blacklistedFilenames = message.Attachments
+                .Select(attachment => attachment.Filename.ToLower())
+                .Where(filename => BlacklistedExtensions
+                    .Any(extension => filename.EndsWith(extension)))
+                .ToArray();
+
+            if(!blacklistedFilenames.Any())
+            {
+                AttachmentBlacklistLogMessages.SuspiciousAttachmentsNotFound(_logger);
+                return;
+            }
+            AttachmentBlacklistLogMessages.SuspiciousAttachmentsFound(_logger, blacklistedFilenames.Length);
+
+            AttachmentBlacklistLogMessages.SelfUserFetching(_logger);
+            var selfUser = await _selfUserProvider.GetSelfUserAsync(cancellationToken);
+            AttachmentBlacklistLogMessages.SelfUserFetched(_logger);
+
+            AttachmentBlacklistLogMessages.SuspiciousMessageDeleting(_logger);
+            await _moderationService.DeleteMessageAsync(
+                message,
+                $"Message had suspicious files attached: {string.Join(", ", blacklistedFilenames)}",
+                selfUser.Id,
+                cancellationToken);
+            AttachmentBlacklistLogMessages.SuspiciousMessageDeleted(_logger);
+
+            AttachmentBlacklistLogMessages.ReplySending(_logger);
+            await message.Channel.SendMessageAsync(
+                $"Please don't upload any potentially harmful files {author.Mention}, your message has been removed",
+                options: new RequestOptions() { CancelToken = cancellationToken });
+            AttachmentBlacklistLogMessages.ReplySent(_logger);
         }
 
-        private static string GetReplyToUser(IMessage message)
-            => $"Please don't upload any potentially harmful files {message.Author.Mention}, your message has been removed";
-
-        internal protected override Task OnStartingAsync()
-        {
-            DiscordClient.MessageReceived += Handle;
-            return Task.CompletedTask;
-        }
-
-        internal protected override Task OnStoppedAsync()
-        {
-            DiscordClient.MessageReceived -= Handle;
-            return Task.CompletedTask;
-        }
+        private readonly IDesignatedChannelService _designatedChannelService;
+        private readonly ILogger _logger;
+        private readonly IModerationService _moderationService;
+        private readonly ISelfUserProvider _selfUserProvider;
     }
 }

--- a/Modix.Services/Moderation/AttachmentBlacklistLogMessages.cs
+++ b/Modix.Services/Moderation/AttachmentBlacklistLogMessages.cs
@@ -1,0 +1,215 @@
+﻿#nullable enable
+
+using System;
+
+using Discord;
+
+using Microsoft.Extensions.Logging;
+
+namespace Modix.Services.Moderation
+{
+    public static class AttachmentBlacklistLogMessages
+    {
+        public enum EventType
+        {
+            IgnoringMessageWithNoAttachments    = ModerationLogEventType.AttachmentBlacklist + 0x01,
+            IngoringNonGuildMessage             = ModerationLogEventType.AttachmentBlacklist + 0x02,
+            IngoringNonHumanMessage             = ModerationLogEventType.AttachmentBlacklist + 0x03,
+            IgnoringUnmoderatedChannel          = ModerationLogEventType.AttachmentBlacklist + 0x04,
+            SuspiciousAttachmentsSearching      = ModerationLogEventType.AttachmentBlacklist + 0x05,
+            SuspiciousAttachmentsNotFound       = ModerationLogEventType.AttachmentBlacklist + 0x06,
+            SuspiciousAttachmentsFound          = ModerationLogEventType.AttachmentBlacklist + 0x07,
+            ChannelModerationStatusFetching     = ModerationLogEventType.AttachmentBlacklist + 0x08,
+            ChannelModerationStatusFetched      = ModerationLogEventType.AttachmentBlacklist + 0x09,
+            SelfUserFetching                    = ModerationLogEventType.AttachmentBlacklist + 0x0A,
+            SelfUserFetched                     = ModerationLogEventType.AttachmentBlacklist + 0x0B,
+            SuspiciousMessageDeleting           = ModerationLogEventType.AttachmentBlacklist + 0x0C,
+            SuspiciousMessageDeleted            = ModerationLogEventType.AttachmentBlacklist + 0x0D,
+            ReplySending                        = ModerationLogEventType.AttachmentBlacklist + 0x0E,
+            ReplySent                           = ModerationLogEventType.AttachmentBlacklist + 0x0F
+        }
+
+        public static IDisposable BeginMessageScope(
+                ILogger logger,
+                ulong? guildId,
+                ulong channelId,
+                ulong authorId,
+                ulong messageId)
+            => _beginMessageScope.Invoke(
+                logger,
+                guildId,
+                channelId,
+                authorId,
+                messageId);
+        private readonly static Func<ILogger, ulong?, ulong, ulong, ulong, IDisposable> _beginMessageScope
+            = LoggerMessageEx.DefineScope<ulong?, ulong, ulong, ulong>(
+                "GuildId: {GuildId}\r\n\tChannelId: {ChannelId}\r\n\tAuthorId: {AuthorId}\r\n\tMessageId: {MessageId}");
+
+        public static void ChannelModerationStatusFetched(
+                ILogger logger)
+            => _channelModerationStatusFetched.Invoke(
+                logger);
+        private static readonly Action<ILogger> _channelModerationStatusFetched
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.ChannelModerationStatusFetched.ToEventId(),
+                    "Channel moderation status fetched")
+                .WithoutException();
+
+        public static void ChannelModerationStatusFetching(
+                ILogger logger)
+            => _channelModerationStatusFetching.Invoke(
+                logger);
+        private static readonly Action<ILogger> _channelModerationStatusFetching
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.ChannelModerationStatusFetching.ToEventId(),
+                    "Fetching channel moderation status")
+                .WithoutException();
+
+        public static void IgnoringMessageWithNoAttachments(
+                ILogger logger)
+            => _ignoringMessageWithNoAttachments.Invoke(
+                logger);
+        private static readonly Action<ILogger> _ignoringMessageWithNoAttachments
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.IgnoringMessageWithNoAttachments.ToEventId(),
+                    "Ignoring message with no attachments")
+                .WithoutException();
+
+        public static void IngoringNonGuildMessage(
+                ILogger logger)
+            => _ingoringNonGuildMessage.Invoke(
+                logger);
+        private static readonly Action<ILogger> _ingoringNonGuildMessage
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.IngoringNonGuildMessage.ToEventId(),
+                    "Ignoring non-guild message")
+                .WithoutException();
+
+        public static void IngoringNonHumanMessage(
+                ILogger logger)
+            => _ingoringNonHumanMessage.Invoke(
+                logger);
+        private static readonly Action<ILogger> _ingoringNonHumanMessage
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.IngoringNonHumanMessage.ToEventId(),
+                    "Ignoring non-human message")
+                .WithoutException();
+
+        public static void IgnoringUnmoderatedChannel(
+                ILogger logger)
+            => _ignoringUnmoderatedChannel.Invoke(
+                logger);
+        private static readonly Action<ILogger> _ignoringUnmoderatedChannel
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.IgnoringUnmoderatedChannel.ToEventId(),
+                    "Ignoring message from unmoderated channel")
+                .WithoutException();
+
+        public static void ReplySending(
+                ILogger logger)
+            => _replySending.Invoke(
+                logger);
+        private static readonly Action<ILogger> _replySending
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.ReplySending.ToEventId(),
+                    "Sending reply")
+                .WithoutException();
+
+        public static void ReplySent(
+                ILogger logger)
+            => _replySent.Invoke(
+                logger);
+        private static readonly Action<ILogger> _replySent
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.ReplySent.ToEventId(),
+                    "Reply sent")
+                .WithoutException();
+
+        public static void SelfUserFetched(
+                ILogger logger)
+            => _selfUserFetched.Invoke(
+                logger);
+        private static readonly Action<ILogger> _selfUserFetched
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.SelfUserFetched.ToEventId(),
+                    $"{nameof(ISelfUser)} fetched")
+                .WithoutException();
+
+        public static void SelfUserFetching(
+                ILogger logger)
+            => _selfUserFetching.Invoke(
+                logger);
+        private static readonly Action<ILogger> _selfUserFetching
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.SelfUserFetching.ToEventId(),
+                    $"Fetching {nameof(ISelfUser)}")
+                .WithoutException();
+
+        public static void SuspiciousAttachmentsFound(
+                ILogger logger,
+                int suspiciousAttachmentCount)
+            => _suspiciousAttachmentsFound.Invoke(
+                logger,
+                suspiciousAttachmentCount);
+        private static readonly Action<ILogger, int> _suspiciousAttachmentsFound
+            = LoggerMessage.Define<int>(
+                    LogLevel.Debug,
+                    EventType.SuspiciousAttachmentsFound.ToEventId(),
+                    "Suspicious attachments found: {SuspiciousAttachmentCount}")
+                .WithoutException();
+
+        public static void SuspiciousAttachmentsNotFound(
+                ILogger logger)
+            => _suspiciousAttachmentsNotFound.Invoke(
+                logger);
+        private static readonly Action<ILogger> _suspiciousAttachmentsNotFound
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.SuspiciousAttachmentsNotFound.ToEventId(),
+                    "No suspicious attachments found")
+                .WithoutException();
+
+        public static void SuspiciousAttachmentsSearching(
+                ILogger logger)
+            => _suspiciousAttachmentsSearching.Invoke(
+                logger);
+        private static readonly Action<ILogger> _suspiciousAttachmentsSearching
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.SuspiciousAttachmentsSearching.ToEventId(),
+                    "Searching for suspicious attachments")
+                .WithoutException();
+
+        public static void SuspiciousMessageDeleted(
+                ILogger logger)
+            => _suspiciousMessageDeleted.Invoke(
+                logger);
+        private static readonly Action<ILogger> _suspiciousMessageDeleted
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.SuspiciousMessageDeleted.ToEventId(),
+                    "Suspicious message deleted")
+                .WithoutException();
+
+        public static void SuspiciousMessageDeleting(
+                ILogger logger)
+            => _suspiciousMessageDeleting.Invoke(
+                logger);
+        private static readonly Action<ILogger> _suspiciousMessageDeleting
+            = LoggerMessage.Define(
+                    LogLevel.Debug,
+                    EventType.SuspiciousMessageDeleting.ToEventId(),
+                    "Deleting suspicious message")
+                .WithoutException();
+    }
+}

--- a/Modix.Services/Moderation/InvitePurgingBehavior.cs
+++ b/Modix.Services/Moderation/InvitePurgingBehavior.cs
@@ -91,7 +91,7 @@ namespace Modix.Services.Moderation
             if (!matches.Any())
                 return;
 
-            if (await DesignatedChannelService.ChannelHasDesignationAsync(channel.Guild, channel, DesignatedChannelType.Unmoderated))
+            if (await DesignatedChannelService.ChannelHasDesignationAsync(channel.Guild, channel, DesignatedChannelType.Unmoderated, default))
                 return;
 
             if (await AuthorizationService.HasClaimsAsync(author, AuthorizationClaim.PostInviteLink))
@@ -118,7 +118,7 @@ namespace Modix.Services.Moderation
 
             Log.Debug("Message {MessageId} is going to be deleted", message.Id);
 
-            await ModerationService.DeleteMessageAsync(message, "Unauthorized Invite Link", selfUser.Id);
+            await ModerationService.DeleteMessageAsync(message, "Unauthorized Invite Link", selfUser.Id, default);
 
             Log.Debug("Message {MessageId} was deleted because it contains an invite link", message.Id);
 

--- a/Modix.Services/Moderation/ModerationLogEventType.cs
+++ b/Modix.Services/Moderation/ModerationLogEventType.cs
@@ -1,0 +1,9 @@
+﻿#nullable enable
+
+namespace Modix.Services.Moderation
+{
+    public enum ModerationLogEventType
+    {
+        AttachmentBlacklist = ServicesLogEventType.Moderation + 0x0100
+    }
+}

--- a/Modix.Services/ServicesLogEventType.cs
+++ b/Modix.Services/ServicesLogEventType.cs
@@ -9,6 +9,7 @@ namespace Modix.Services
         Roles           = ApplicationLogEventType.Services + 0x010000,
         MessageTracking = ApplicationLogEventType.Services + 0x020000,
         MessageLogging  = ApplicationLogEventType.Services + 0x030000,
-        UserMetrics     = ApplicationLogEventType.Services + 0x040000
+        UserMetrics     = ApplicationLogEventType.Services + 0x040000,
+        Moderation      = ApplicationLogEventType.Services + 0x050000
     }
 }

--- a/Modix.Services/Starboard/StarboardHandler.cs
+++ b/Modix.Services/Starboard/StarboardHandler.cs
@@ -48,7 +48,7 @@ namespace Modix.Services.Starboard
             }
 
             var isIgnoredFromStarboard = await _designatedChannelService
-                .ChannelHasDesignationAsync(channel.Guild, channel, DesignatedChannelType.IgnoredFromStarboard);
+                .ChannelHasDesignationAsync(channel.Guild, channel, DesignatedChannelType.IgnoredFromStarboard, default);
 
             var starboardExists = await _designatedChannelService
                 .AnyDesignatedChannelAsync(channel.GuildId, DesignatedChannelType.Starboard);

--- a/Modix.Services/UserMetrics/UserMetricsBehavior.cs
+++ b/Modix.Services/UserMetrics/UserMetricsBehavior.cs
@@ -97,7 +97,8 @@ namespace Modix.Services.UserMetrics
                 isOnTopic = await _designatedChannelService.ChannelHasDesignationAsync(
                     guild,
                     channel,
-                    DesignatedChannelType.CountsTowardsParticipation);
+                    DesignatedChannelType.CountsTowardsParticipation,
+                    cancellationToken);
                 UserMetricsLogMessages.ChannelParticipationFetched(_logger, isOnTopic);
             }
             catch (Exception ex)

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -138,7 +138,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddScoped<IQuoteService, QuoteService>();
             services.AddSingleton<IBehavior, MessageLinkBehavior>();
-            services.AddSingleton<IBehavior, AttachmentBlacklistBehavior>();
             services.AddScoped<DocsMasterRetrievalService>();
             services.AddMemoryCache();
 


### PR DESCRIPTION
Re-implemented through `Modix.Common.Messaging` rather than deprecated `BehaviorBase`.

Added CancellationToken support to various APIs involved, all the way down the stack.

Added tests.

Optimized DesignatedChannelService.ChannelHasDesignationAsync() to not be stupidly wasteful of network traffic.