### PR TITLE
Logging verbosity adjustments

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -45,6 +45,7 @@
     <PackageReference Update="Serilog" Version="2.9.1-dev-01167" />
     <PackageReference Update="Serilog.AspNetCore" Version="3.3.0-dev-00152" />
     <PackageReference Update="Serilog.Extensions.Logging" Version="3.0.2-dev-10272" />
+    <PackageReference Update="Serilog.Filters.Expressions" Version="2.1.0" />
     <PackageReference Update="Serilog.Sinks.Literate" Version="3.0.0" />
     <PackageReference Update="Serilog.Sinks.Sentry" Version="2.4.1" />
     <PackageReference Update="Serilog.Sinks.Console" Version="3.1.1" />

--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Filters.Expressions"/>
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.RollingFile" />
     <PackageReference Include="Serilog.Sinks.Sentry" />


### PR DESCRIPTION
Adjusted Serilog config to keep Microsoft trace logging (they CALL it `Information` but it's verbose as FUCK) out of the "normal operation" logs.