### PR TITLE
emojistats - Remove 30 day limit for counting average emoji usage

### DIFF
--- a/Modix.Bot/Modules/EmojiStatsModule.cs
+++ b/Modix.Bot/Modules/EmojiStatsModule.cs
@@ -128,7 +128,8 @@ namespace Modix.Modules
             if (double.IsNaN(percentUsage))
                 percentUsage = 0;
 
-            var numberOfDays = Math.Clamp((DateTime.Now - guildStats.OldestTimestamp).Days, 1, 30);
+            var emojiCreated = ephemeralEmoji.CreatedAt ?? guildStats.OldestTimestamp;
+            var numberOfDays = Math.Max((DateTimeOffset.Now - emojiCreated).Days, 1);
             var perDay = (double)emojiStats.Uses / numberOfDays;
 
             var sb = new StringBuilder(emojiFormatted);
@@ -167,7 +168,8 @@ namespace Modix.Modules
 
             BuildEmojiStatString(sb, guildStats.TotalUses, emojiStats, (emoji) =>
             {
-                var numberOfDays = Math.Clamp((DateTime.Now - guildStats.OldestTimestamp).Days, 1, 30);
+                var emojiCreated = emoji.Emoji.CreatedAt ?? guildStats.OldestTimestamp;
+                var numberOfDays = Math.Max((DateTimeOffset.Now - emojiCreated).Days, 1);
                 return (double)emoji.Uses / numberOfDays;
             });
 

--- a/Modix.Bot/Modules/EmojiStatsModule.cs
+++ b/Modix.Bot/Modules/EmojiStatsModule.cs
@@ -107,7 +107,7 @@ namespace Modix.Modules
 
             var emojiStats = await _emojiRepository.GetEmojiStatsAsync(guildId, ephemeralEmoji);
 
-            if (emojiStats == default || emojiStats.Uses == 0)
+            if (emojiStats.Uses == 0)
             {
                 await ReplyAsync(embed: new EmbedBuilder()
                     .WithTitle("Unknown Emoji")
@@ -118,7 +118,6 @@ namespace Modix.Modules
                 return;
             }
 
-            var emojiStats30 = await _emojiRepository.GetEmojiStatsAsync(guildId, ephemeralEmoji, TimeSpan.FromDays(30));
             var guildStats = await _emojiRepository.GetGuildStatsAsync(guildId);
 
             var emojiFormatted = ((SocketSelfUser)Context.Client.CurrentUser).CanAccessEmoji(ephemeralEmoji)
@@ -130,7 +129,7 @@ namespace Modix.Modules
                 percentUsage = 0;
 
             var numberOfDays = Math.Clamp((DateTime.Now - guildStats.OldestTimestamp).Days, 1, 30);
-            var perDay = (double)emojiStats30.Uses / numberOfDays;
+            var perDay = (double)emojiStats.Uses / numberOfDays;
 
             var sb = new StringBuilder(emojiFormatted);
 

--- a/Modix.Bot/Modules/EmojiStatsModule.cs
+++ b/Modix.Bot/Modules/EmojiStatsModule.cs
@@ -162,7 +162,6 @@ namespace Modix.Modules
                 : Enumerable.Empty<ulong>();
 
             var emojiStats = await _emojiRepository.GetEmojiStatsAsync(guildId, sortDirection, 10, emojiIds: emojiFilter);
-            var emojiStats30 = await _emojiRepository.GetEmojiStatsAsync(guildId, sortDirection, 10, TimeSpan.FromDays(30), emojiIds: emojiFilter);
             var guildStats = await _emojiRepository.GetGuildStatsAsync(guildId, emojiIds: emojiFilter);
 
             var sb = new StringBuilder();
@@ -170,8 +169,7 @@ namespace Modix.Modules
             BuildEmojiStatString(sb, guildStats.TotalUses, emojiStats, (emoji) =>
             {
                 var numberOfDays = Math.Clamp((DateTime.Now - guildStats.OldestTimestamp).Days, 1, 30);
-                var uses30 = emojiStats30.FirstOrDefault(x => x.Emoji.Equals(emoji.Emoji))?.Uses ?? 0;
-                return (double)uses30 / numberOfDays;
+                return (double)emoji.Uses / numberOfDays;
             });
 
             var daysSinceOldestEmojiUse = Math.Max((DateTime.Now - guildStats.OldestTimestamp).Days, 1);


### PR DESCRIPTION
emojistats - Remove 30 day limit for counting average emoji usage

`!emojistats`
-  it was confusing since there was no mention of those 30 days in embed and I dont think last 30 days is a meaningful period
- it was calculated incorrectly (if some emoji of top10emojis collection isnt found in top10emojisFor30days one)

`!emojistats :emoji:`
- it was confusing since there was no mention of those 30 days in embed and I dont think last 30 days is a meaningful period
- fix consistency with `!emojistats`