### PR TITLE
Fix Message Link Security Issue 

### DIFF
--- a/Modix.Bot/Modules/QuoteModule.cs
+++ b/Modix.Bot/Modules/QuoteModule.cs
@@ -15,6 +15,7 @@ namespace Modix.Modules
     [Name("Quoting")]
     [Summary("Quote a message from the guild with its ID.")]
     [HelpTags("quotes")]
+    [RequireContext(ContextType.Guild)]
     public class QuoteModule : ModuleBase
     {
         private readonly IQuoteService _quoteService;
@@ -47,7 +48,7 @@ namespace Modix.Modules
                 var permissions = user.GetPermissions(channel);
 
                 if (!permissions.ViewChannel)
-                    return;
+                    await ReplyFailure(messageId);
 
             }
             catch (Exception e)
@@ -76,7 +77,7 @@ namespace Modix.Modules
                 var permissions = user.GetPermissions(channel);
 
                 if (!permissions.ViewChannel)
-                    return;
+                    await ReplyFailure(messageId);
             }
             catch (Exception e)
             {
@@ -154,5 +155,7 @@ namespace Modix.Modules
             => channel.GetMessageAsync(messageId);
 
         private Task ReplyFailure() => ReplyAsync($"I couldn't find the message you're referring to {Context.User.Mention}");
+
+        private Task ReplyFailure(ulong id) => ReplyAsync($"Sorry, you don't have permission to view this message (`{id}`) {Context.User.Mention}");
     }
 }

--- a/Modix.Bot/Modules/QuoteModule.cs
+++ b/Modix.Bot/Modules/QuoteModule.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 using Discord;
 using Discord.Commands;
-
+using Discord.WebSocket;
 using Modix.Data.Repositories;
 using Modix.Services.CommandHelp;
 using Modix.Services.Quote;
@@ -41,6 +41,14 @@ namespace Modix.Modules
 
                 if (message == null)
                     message = await FindMessageInUnknownChannelAsync(messageId);
+
+                var user = Context.User as IGuildUser;
+                var channel = message.Channel as ITextChannel;
+                var permissions = user.GetPermissions(channel);
+
+                if (!permissions.ViewChannel)
+                    return;
+
             }
             catch (Exception e)
             {
@@ -63,6 +71,12 @@ namespace Modix.Modules
             try
             {
                 message = await GetMessage(messageId, channel);
+
+                var user = Context.User as IGuildUser;
+                var permissions = user.GetPermissions(channel);
+
+                if (!permissions.ViewChannel)
+                    return;
             }
             catch (Exception e)
             {

--- a/Modix.Bot/Modules/QuoteModule.cs
+++ b/Modix.Bot/Modules/QuoteModule.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 using Discord;
 using Discord.Commands;
-using Discord.WebSocket;
+
 using Modix.Data.Repositories;
 using Modix.Services.CommandHelp;
 using Modix.Services.Quote;

--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -84,14 +84,15 @@ namespace Modix.Services.Quote
                             channel is ISocketMessageChannel messageChannel)
                         {
                             var currentUser = await guildChannel.Guild.GetCurrentUserAsync();
-                            var channelPermissions = currentUser.GetPermissions(guildChannel);
+                            var botChannelPermissions = currentUser.GetPermissions(guildChannel);
+                            var userChannelPermissions = guildUser.GetPermissions(guildChannel);
 
-                            if (!channelPermissions.ViewChannel)
+                            if (!botChannelPermissions.ViewChannel || !userChannelPermissions.ViewChannel)
                             {
                                 return;
                             }
 
-                            var cacheMode = channelPermissions.ReadMessageHistory
+                            var cacheMode = botChannelPermissions.ReadMessageHistory
                                 ? CacheMode.AllowDownload
                                 : CacheMode.CacheOnly;
 


### PR DESCRIPTION
The Discord API exposes all channel Ids and their last message Ids regardless of whether or not a user has permission to view the channel. This essentially allows people to view any future conversations in private channels via two ways.

1. By creating a make-shift link message and letting `MessageLinkBehavior` quote the message. 
2. Using the `!quote` command 

The behaviour should now check if the source user has permissions to view the channel and fix this vulnerability and the quote commands will respond appropriately. 

