### PR TITLE
Fix NullReferenceException in !infraction update

### DIFF
--- a/Modix.Bot/Modules/InfractionModule.cs
+++ b/Modix.Bot/Modules/InfractionModule.cs
@@ -127,11 +127,15 @@ namespace Modix.Modules
             [Summary("The ID value of the infraction to be update.")] long infractionId,
                 [Summary("New reason for the infraction"), Remainder] string reason)
         {
-            var success = await ModerationService.UpdateInfractionAsync(infractionId, reason, Context.User.Id);
+            var (success, errorMessage) = await ModerationService.UpdateInfractionAsync(infractionId, reason, Context.User.Id);
 
             if (!success)
             {
-                await ReplyAsync("Failed updating infraction");
+                var replyMessage = string.IsNullOrWhiteSpace(errorMessage)
+                    ? "Failed updating infraction."
+                    : $"Failed updating infraction. {errorMessage}";
+
+                await ReplyAsync(replyMessage);
                 return;
             }
 

--- a/Modix.Data/Repositories/InfractionRepository.cs
+++ b/Modix.Data/Repositories/InfractionRepository.cs
@@ -45,7 +45,7 @@ namespace Modix.Data.Repositories
         /// A <see cref="Task"/> which will complete when the operation is complete,
         /// containing the requested infraction, or null if no such infraction exists.
         /// </returns>
-        Task<InfractionSummary> ReadSummaryAsync(long infractionId);
+        Task<InfractionSummary?> ReadSummaryAsync(long infractionId);
 
         /// <summary>
         /// Checks whether the repository contains any infractions matching the given search criteria.
@@ -160,12 +160,12 @@ namespace Modix.Data.Repositories
         }
 
         /// <inheritdoc />
-        public Task<InfractionSummary> ReadSummaryAsync(long infractionId)
+        public Task<InfractionSummary?> ReadSummaryAsync(long infractionId)
             => ModixContext.Set<InfractionEntity>().AsNoTracking()
                 .Where(x => x.Id == infractionId)
                 .AsExpandable()
                 .Select(InfractionSummary.FromEntityProjection)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync<InfractionSummary?>();
 
         /// <inheritdoc />
         public Task<bool> AnyAsync(InfractionSearchCriteria criteria)


### PR DESCRIPTION
Checks whether the infraction returned when searching the database is null. Also adds some nullable annotations and descriptive error messages.

![image](https://user-images.githubusercontent.com/2829282/87876346-9718e780-c9a5-11ea-847f-0a425edee2c4.png)
