### PR TITLE
Specify gateway intents

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -12,7 +12,7 @@
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="Discord.Net" Version="2.3.0-dev-20200425.1" />
+    <PackageReference Update="Discord.Net" Version="2.3.0-dev-20200710.2" />
 
     <PackageReference Update="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="3.1.3"/>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -12,7 +12,7 @@
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="Discord.Net" Version="2.3.0-dev-20200710.2" />
+    <PackageReference Update="Discord.Net" Version="2.3.0-dev-20200801.4" />
 
     <PackageReference Update="Microsoft.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="3.1.3"/>

--- a/Discord.Net.Abstractions/Rest/IIRestMessageChannel.cs
+++ b/Discord.Net.Abstractions/Rest/IIRestMessageChannel.cs
@@ -23,14 +23,14 @@ namespace Discord.Rest
         /// <inheritdoc cref="IRestMessageChannel.GetPinnedMessagesAsync(RequestOptions)" />
         new Task<IReadOnlyCollection<IRestMessage>> GetPinnedMessagesAsync(RequestOptions options = null);
 
-        /// <inheritdoc cref="IRestMessageChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="IRestMessageChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="IRestMessageChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="IRestMessageChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="IRestMessageChannel.SendMessageAsync(string, bool, Embed, RequestOptions)" />
-        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
+        /// <inheritdoc cref="IRestMessageChannel.SendMessageAsync(string, bool, Embed, RequestOptions, AllowedMentions)" />
+        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null);
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestDMChannel.cs
+++ b/Discord.Net.Abstractions/Rest/IRestDMChannel.cs
@@ -39,14 +39,14 @@ namespace Discord.Rest
         /// <inheritdoc cref="RestDMChannel.GetUser(ulong)" />
         IRestUser GetUser(ulong id);
 
-        /// <inheritdoc cref="RestDMChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="RestDMChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="RestDMChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="RestDMChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="RestDMChannel.SendMessageAsync(string, bool, Embed, RequestOptions)" />
-        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
+        /// <inheritdoc cref="RestDMChannel.SendMessageAsync(string, bool, Embed, RequestOptions, AllowedMentions)" />
+        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null);
     }
 
     /// <summary>
@@ -180,33 +180,33 @@ namespace Discord.Rest
                 ?.Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
-            => (await RestDMChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler))
+        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
+            => (await RestDMChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (RestDMChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (RestDMChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
-            => (await RestDMChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler))
+        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
+            => (await RestDMChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (RestDMChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (RestDMChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
-            => (await RestDMChannel.SendMessageAsync(text, isTTS, embed, options))
+        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
+            => (await RestDMChannel.SendMessageAsync(text, isTTS, embed, options, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => (await (RestDMChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options))
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
+            => (await (RestDMChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />

--- a/Discord.Net.Abstractions/Rest/IRestGroupChannel.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGroupChannel.cs
@@ -35,14 +35,14 @@ namespace Discord.Rest
         /// <inheritdoc cref="RestGroupChannel.GetUser(ulong)" />
         IRestUser GetUser(ulong id);
 
-        /// <inheritdoc cref="RestGroupChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="RestGroupChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="RestGroupChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="RestGroupChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="RestGroupChannel.SendMessageAsync(string, bool, Embed, RequestOptions)" />
-        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
+        /// <inheritdoc cref="RestGroupChannel.SendMessageAsync(string, bool, Embed, RequestOptions, AllowedMentions)" />
+        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null);
     }
 
     /// <summary>
@@ -176,33 +176,33 @@ namespace Discord.Rest
             => RestGroupChannel.LeaveAsync(options);
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
-            => (await RestGroupChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler))
+        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
+            => (await RestGroupChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (RestGroupChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (RestGroupChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
-            => (await RestGroupChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler))
+        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
+            => (await RestGroupChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (RestGroupChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (RestGroupChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
-            => (await RestGroupChannel.SendMessageAsync(text, isTTS, embed, options))
+        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
+            => (await RestGroupChannel.SendMessageAsync(text, isTTS, embed, options, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => (await (RestGroupChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options))
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
+            => (await (RestGroupChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />

--- a/Discord.Net.Abstractions/Rest/IRestGuild.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGuild.cs
@@ -680,6 +680,14 @@ namespace Discord.Rest
             => RestGuild.ReorderRolesAsync(args, options);
 
         /// <inheritdoc />
+        public Task<IReadOnlyCollection<RestGuildUser>> SearchUsersAsync(string query, int limit = 1000, RequestOptions options = null)
+            => RestGuild.SearchUsersAsync(query, limit, options);
+
+        /// <inheritdoc />
+        Task<IReadOnlyCollection<IGuildUser>> IGuild.SearchUsersAsync(string query, int limit, CacheMode mode, RequestOptions options)
+            => ((IGuild)RestGuild).SearchUsersAsync(query, limit, mode, options);
+
+        /// <inheritdoc />
         public Task UpdateAsync(RequestOptions options = null)
             => RestGuild.UpdateAsync(options);
 

--- a/Discord.Net.Abstractions/Rest/IRestMessage.cs
+++ b/Discord.Net.Abstractions/Rest/IRestMessage.cs
@@ -151,6 +151,9 @@ namespace Discord.Rest
         public Task AddReactionAsync(IEmote emote, RequestOptions options = null)
             => RestMessage.AddReactionAsync(emote, options);
 
+        public Task RemoveAllReactionsForEmoteAsync(IEmote emote, RequestOptions options = null)
+            => RestMessage.RemoveAllReactionsForEmoteAsync(emote, options);
+
         public Task RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options = null)
             => RestMessage.RemoveReactionAsync(emote, user, options);
 

--- a/Discord.Net.Abstractions/Rest/IRestTextChannel.cs
+++ b/Discord.Net.Abstractions/Rest/IRestTextChannel.cs
@@ -42,14 +42,14 @@ namespace Discord.Rest
         /// <inheritdoc cref="RestTextChannel.GetWebhooksAsync(RequestOptions)" />
         new Task<IReadOnlyCollection<IRestWebhook>> GetWebhooksAsync(RequestOptions options = null);
 
-        /// <inheritdoc cref="RestTextChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="RestTextChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="RestTextChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="RestTextChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="RestTextChannel.SendMessageAsync(string, bool, Embed, RequestOptions)" />
-        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
+        /// <inheritdoc cref="RestTextChannel.SendMessageAsync(string, bool, Embed, RequestOptions, AllowedMentions)" />
+        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null);
     }
 
     /// <summary>
@@ -239,23 +239,23 @@ namespace Discord.Rest
             => RestTextChannel.ModifyAsync(func, options);
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
-            => (await RestTextChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler))
+        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
+            => (await RestTextChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (RestTextChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (RestTextChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
-            => (await RestTextChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler))
+        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
+            => (await RestTextChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
-            => (await RestTextChannel.SendMessageAsync(text, isTTS, embed, options))
+        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
+            => (await RestTextChannel.SendMessageAsync(text, isTTS, embed, options, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
@@ -263,8 +263,8 @@ namespace Discord.Rest
             => RestTextChannel.SyncPermissionsAsync(options);
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (RestTextChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (RestTextChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
@@ -272,8 +272,8 @@ namespace Discord.Rest
             => (RestTextChannel as ITextChannel).TriggerTypingAsync(options);
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => (await (RestTextChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options))
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
+            => (await (RestTextChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options, allowedMentions))
                 .Abstract();
 
         /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestUser.cs
+++ b/Discord.Net.Abstractions/Rest/IRestUser.cs
@@ -102,6 +102,8 @@ namespace Discord.Rest
         protected RestUser RestUser { get; }
 
         public IImmutableSet<ClientType> ActiveClients => RestUser.ActiveClients;
+
+        public IImmutableList<IActivity> Activities => RestUser.Activities;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/Rest/IRestUserMessage.cs
+++ b/Discord.Net.Abstractions/Rest/IRestUserMessage.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Discord.Rest
@@ -22,6 +20,9 @@ namespace Discord.Rest
         /// <exception cref="ArgumentNullException">Throws for <paramref name="restUserMessage"/>.</exception>
         public RestUserMessageAbstraction(RestUserMessage restUserMessage)
             : base(restUserMessage) { }
+
+        public Task CrosspostAsync(RequestOptions options = null)
+            => RestUserMessage.CrosspostAsync(options);
 
         /// <inheritdoc />
         public Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)

--- a/Discord.Net.Abstractions/WebSocket/IISocketMessageChannel.cs
+++ b/Discord.Net.Abstractions/WebSocket/IISocketMessageChannel.cs
@@ -28,14 +28,14 @@ namespace Discord.WebSocket
         /// <inheritdoc cref="ISocketMessageChannel.GetPinnedMessagesAsync(RequestOptions)" />
         new Task<IReadOnlyCollection<IRestMessage>> GetPinnedMessagesAsync(RequestOptions options = null);
 
-        /// <inheritdoc cref="ISocketMessageChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="ISocketMessageChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="ISocketMessageChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="ISocketMessageChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="ISocketMessageChannel.SendMessageAsync(string, bool, Embed, RequestOptions)" />
-        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
+        /// <inheritdoc cref="ISocketMessageChannel.SendMessageAsync(string, bool, Embed, RequestOptions, AllowedMentions)" />
+        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null);
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketDMChannel.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketDMChannel.cs
@@ -50,14 +50,14 @@ namespace Discord.WebSocket
         /// <inheritdoc cref="SocketDMChannel.GetUser(ulong)" />
         new ISocketUser GetUser(ulong id);
 
-        /// <inheritdoc cref="SocketDMChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="SocketDMChannel.SendFileAsync(Stream, string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="SocketDMChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool)" />
-        new Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false);
+        /// <inheritdoc cref="SocketDMChannel.SendFileAsync(string, string, bool, Embed, RequestOptions, bool, AllowedMentions)" />
+        new Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null);
 
-        /// <inheritdoc cref="SocketDMChannel.SendMessageAsync(string, bool, Embed, RequestOptions)" />
-        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null);
+        /// <inheritdoc cref="SocketDMChannel.SendMessageAsync(string, bool, Embed, RequestOptions, AllowedMentions)" />
+        new Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null);
     }
 
     /// <summary>
@@ -205,33 +205,33 @@ namespace Discord.WebSocket
                 .ToArray();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
+        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
             => RestUserMessageAbstractionExtensions.Abstract(
-                await SocketDMChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler));
+                await SocketDMChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions));
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (SocketDMChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (SocketDMChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
+        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
             => RestUserMessageAbstractionExtensions.Abstract(
-                await SocketDMChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler));
+                await SocketDMChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions));
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (SocketDMChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (SocketDMChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
+        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
             => RestUserMessageAbstractionExtensions.Abstract(
-                await SocketDMChannel.SendMessageAsync(text, isTTS, embed, options));
+                await SocketDMChannel.SendMessageAsync(text, isTTS, embed, options, allowedMentions));
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => (await (SocketDMChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options))
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
+            => (await (SocketDMChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />

--- a/Discord.Net.Abstractions/WebSocket/ISocketGroupChannel.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGroupChannel.cs
@@ -204,33 +204,33 @@ namespace Discord.WebSocket
             => SocketGroupChannel.LeaveAsync(options);
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
+        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
             => RestUserMessageAbstractionExtensions.Abstract(
-                await SocketGroupChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler));
+                await SocketGroupChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions));
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (SocketGroupChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (SocketGroupChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
+        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
             => RestUserMessageAbstractionExtensions.Abstract(
-                await SocketGroupChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler));
+                await SocketGroupChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions));
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (SocketGroupChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (SocketGroupChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
+        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
             => RestUserMessageAbstractionExtensions.Abstract(
-                await SocketGroupChannel.SendMessageAsync(text, isTTS, embed, options));
+                await SocketGroupChannel.SendMessageAsync(text, isTTS, embed, options, allowedMentions));
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => (await (SocketGroupChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options))
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
+            => (await (SocketGroupChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />

--- a/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
@@ -734,6 +734,14 @@ namespace Discord.WebSocket
         public Task ReorderRolesAsync(IEnumerable<ReorderRoleProperties> args, RequestOptions options = null)
             => SocketGuild.ReorderRolesAsync(args, options);
 
+        /// <inheritdoc />
+        public Task<IReadOnlyCollection<RestGuildUser>> SearchUsersAsync(string query, int limit = 1000, RequestOptions options = null)
+            => SocketGuild.SearchUsersAsync(query, limit, options);
+
+        /// <inheritdoc />
+        Task<IReadOnlyCollection<IGuildUser>> IGuild.SearchUsersAsync(string query, int limit, CacheMode mode, RequestOptions options)
+            => ((IGuild)SocketGuild).SearchUsersAsync(query, limit, mode, options);
+
         /// <inheritdoc cref="SocketGuild.ToString" />
         public override string ToString()
             => SocketGuild.ToString();

--- a/Discord.Net.Abstractions/WebSocket/ISocketMessage.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketMessage.cs
@@ -168,6 +168,9 @@ namespace Discord.WebSocket
         public Task RemoveAllReactionsAsync(RequestOptions options = null)
             => SocketMessage.RemoveAllReactionsAsync(options);
 
+        public Task RemoveAllReactionsForEmoteAsync(IEmote emote, RequestOptions options = null)
+            => SocketMessage.RemoveAllReactionsForEmoteAsync(emote, options);
+
         public IAsyncEnumerable<IReadOnlyCollection<IUser>> GetReactionUsersAsync(IEmote emoji, int limit, RequestOptions options = null)
             => SocketMessage.GetReactionUsersAsync(emoji, limit, options);
 

--- a/Discord.Net.Abstractions/WebSocket/ISocketTextChannel.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketTextChannel.cs
@@ -245,33 +245,33 @@ namespace Discord.WebSocket
             => SocketTextChannel.ModifyAsync(func, options);
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
+        public async Task<IRestUserMessage> SendFileAsync(string filePath, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
             => RestUserMessageAbstractionExtensions.Abstract(
-                await SocketTextChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler));
+                await SocketTextChannel.SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions));
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (SocketTextChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(string filePath, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (SocketTextChannel as IMessageChannel).SendFileAsync(filePath, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false)
+        public async Task<IRestUserMessage> SendFileAsync(Stream stream, string filename, string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, bool isSpoiler = false, AllowedMentions allowedMentions = null)
             => RestUserMessageAbstractionExtensions.Abstract(
-                await SocketTextChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler));
+                await SocketTextChannel.SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions));
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler)
-            => (await (SocketTextChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler))
+        async Task<IUserMessage> IMessageChannel.SendFileAsync(Stream stream, string filename, string text, bool isTTS, Embed embed, RequestOptions options, bool isSpoiler, AllowedMentions allowedMentions)
+            => (await (SocketTextChannel as IMessageChannel).SendFileAsync(stream, filename, text, isTTS, embed, options, isSpoiler, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />
-        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null)
+        public async Task<IRestUserMessage> SendMessageAsync(string text = null, bool isTTS = false, Embed embed = null, RequestOptions options = null, AllowedMentions allowedMentions = null)
             => RestUserMessageAbstractionExtensions.Abstract(
-                await SocketTextChannel.SendMessageAsync(text, isTTS, embed, options));
+                await SocketTextChannel.SendMessageAsync(text, isTTS, embed, options, allowedMentions));
 
         /// <inheritdoc />
-        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options)
-            => (await (SocketTextChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options))
+        async Task<IUserMessage> IMessageChannel.SendMessageAsync(string text, bool isTTS, Embed embed, RequestOptions options, AllowedMentions allowedMentions)
+            => (await (SocketTextChannel as IMessageChannel).SendMessageAsync(text, isTTS, embed, options, allowedMentions))
                 .Abstract();
 
         /// <inheritdoc />

--- a/Discord.Net.Abstractions/WebSocket/ISocketUser.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketUser.cs
@@ -101,6 +101,8 @@ namespace Discord.WebSocket
         protected SocketUser SocketUser { get; }
 
         public IImmutableSet<ClientType> ActiveClients => SocketUser.ActiveClients;
+
+        public IImmutableList<IActivity> Activities => SocketUser.Activities;
     }
 
     /// <summary>

--- a/Discord.Net.Abstractions/WebSocket/ISocketUserMessage.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketUserMessage.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Discord.WebSocket
@@ -22,6 +20,10 @@ namespace Discord.WebSocket
         /// <exception cref="ArgumentNullException">Throws for <paramref name="socketUserMessage"/>.</exception>
         public SocketUserMessageAbstraction(SocketUserMessage socketUserMessage)
             : base(socketUserMessage) { }
+
+        /// <inheritdoc />
+        public Task CrosspostAsync(RequestOptions options = null)
+            => SocketUserMessage.CrosspostAsync(options);
 
         /// <inheritdoc />
         public Task ModifyAsync(Action<MessageProperties> func, RequestOptions options = null)

--- a/Modix.Data/Models/Core/EphemeralUser.cs
+++ b/Modix.Data/Models/Core/EphemeralUser.cs
@@ -72,6 +72,8 @@ namespace Modix.Data.Models.Core
 
         public IImmutableSet<ClientType>? ActiveClients { get; private set; }
 
+        public IImmutableList<IActivity>? Activities { get; private set; }
+
         public bool IsStreaming { get; private set; }
 
         public async Task AddRoleAsync(IRole role, RequestOptions? options = null)
@@ -146,6 +148,12 @@ namespace Modix.Data.Models.Core
         {
             if (user is null)
                 return this;
+
+            if (user.ActiveClients is not null)
+                ActiveClients = user.ActiveClients;
+
+            if (user.Activities is not null)
+                Activities = user.Activities;
 
             if (user.Activity != default)
                 Activity = user.Activity;

--- a/Modix.Services.Test/MessageLogging/MessageLoggingBehaviorTests.cs
+++ b/Modix.Services.Test/MessageLogging/MessageLoggingBehaviorTests.cs
@@ -62,7 +62,8 @@ namespace Modix.Services.Test.MessageLogging
                                 It.IsAny<string?>(),
                                 It.IsAny<bool>(),
                                 It.IsAny<Embed?>(),
-                                It.IsAny<RequestOptions?>()))
+                                It.IsAny<RequestOptions?>(),
+                                It.IsAny<AllowedMentions?>()))
                             .ReturnsAsync(mockLogMessage.Object);
 
                         return mockMessageLogChannel;
@@ -231,7 +232,8 @@ namespace Modix.Services.Test.MessageLogging
                     It.IsAny<string?>(),
                     It.IsAny<bool>(),
                     It.IsAny<Embed?>(),
-                    It.IsAny<RequestOptions?>()));
+                    It.IsAny<RequestOptions?>(),
+                    It.IsAny<AllowedMentions?>()));
         }
 
         public static readonly ImmutableArray<TestCaseData> HandleNotificationAsync_MessageDeletedNotification_MessageShouldNotBeIgnored_TestCaseData
@@ -278,6 +280,7 @@ namespace Modix.Services.Test.MessageLogging
                         It.IsNotNull<string>(),
                         false,
                         It.IsNotNull<Embed>(),
+                        null,
                         null));
 
                 var (content, embed) = mockMessageLogChannel.Invocations
@@ -318,7 +321,8 @@ namespace Modix.Services.Test.MessageLogging
                     It.IsAny<string?>(),
                     It.IsAny<bool>(),
                     It.IsAny<Embed?>(),
-                    It.IsAny<RequestOptions?>()));
+                    It.IsAny<RequestOptions?>(),
+                    It.IsAny<AllowedMentions?>()));
         }
 
         #endregion HandleNotificationAsync(MessageDeletedNotification) Tests
@@ -467,7 +471,8 @@ namespace Modix.Services.Test.MessageLogging
                     It.IsAny<string?>(),
                     It.IsAny<bool>(),
                     It.IsAny<Embed?>(),
-                    It.IsAny<RequestOptions?>()));
+                    It.IsAny<RequestOptions?>(),
+                    It.IsAny<AllowedMentions?>()));
         }
 
         public static readonly ImmutableArray<TestCaseData> HandleNotificationAsync_MessageUpdatedNotification_MessageShouldNotBeIgnored_TestCaseData
@@ -515,6 +520,7 @@ namespace Modix.Services.Test.MessageLogging
                         It.IsNotNull<string>(),
                         false,
                         It.IsNotNull<Embed>(),
+                        null,
                         null));
 
                 var (content, embed) = mockMessageLogChannel.Invocations
@@ -543,7 +549,8 @@ namespace Modix.Services.Test.MessageLogging
                     It.IsAny<string?>(),
                     It.IsAny<bool>(),
                     It.IsAny<Embed?>(),
-                    It.IsAny<RequestOptions?>()));
+                    It.IsAny<RequestOptions?>(),
+                    It.IsAny<AllowedMentions?>()));
         }
 
         #endregion HandleNotificationAsync(MessageUpdatedNotification) Tests

--- a/Modix.Services.Test/Moderation/AttachmentBlacklistBehaviorTests.cs
+++ b/Modix.Services.Test/Moderation/AttachmentBlacklistBehaviorTests.cs
@@ -203,7 +203,8 @@ namespace Modix.Services.Test.Moderation
                     It.IsAny<string>(),
                     It.IsAny<bool>(),
                     It.IsAny<Embed>(),
-                    It.IsAny<RequestOptions>()));
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<AllowedMentions?>()));
         }
 
         public static readonly ImmutableArray<TestCaseData> HandleNotificationAsync_MessageHasAnySuspiciousAttachments_TestCaseData
@@ -258,7 +259,8 @@ namespace Modix.Services.Test.Moderation
                     It.Is<string>(y => (y != null) && y.Contains(notification.Message.Author.Id.ToString())),
                     It.IsAny<bool>(),
                     It.IsAny<Embed>(),
-                    It.Is<RequestOptions>(y => (y != null) && (y.CancelToken == testContext.CancellationToken))));
+                    It.Is<RequestOptions>(y => (y != null) && (y.CancelToken == testContext.CancellationToken)),
+                    null));
         }
 
         #endregion HandleNotificationAsync() Tests

--- a/Modix.Services.Test/Moderation/InvitePurgingBehaviorTests.cs
+++ b/Modix.Services.Test/Moderation/InvitePurgingBehaviorTests.cs
@@ -360,7 +360,8 @@ namespace Modix.Services.Test.Moderation
                         It.Is<string>(y => y.Contains("invite", StringComparison.OrdinalIgnoreCase)),
                         It.IsAny<bool>(),
                         It.IsAny<Embed>(),
-                        It.IsAny<RequestOptions>()));
+                        It.IsAny<RequestOptions>(),
+                        It.IsAny<AllowedMentions>()));
         }
 
         #endregion HandleNotificationAsync(MessageReceivedNotification) Tests
@@ -576,7 +577,8 @@ namespace Modix.Services.Test.Moderation
                         It.Is<string>(y => y.Contains("invite", StringComparison.OrdinalIgnoreCase)),
                         It.IsAny<bool>(),
                         It.IsAny<Embed>(),
-                        It.IsAny<RequestOptions>()));
+                        It.IsAny<RequestOptions>(),
+                        It.IsAny<AllowedMentions>()));
         }
 
         #endregion HandleNotificationAsync(MessageUpdatedNotification) Tests
@@ -600,7 +602,8 @@ namespace Modix.Services.Test.Moderation
                         It.IsAny<string>(),
                         It.IsAny<bool>(),
                         It.IsAny<Embed>(),
-                        It.IsAny<RequestOptions>()));
+                        It.IsAny<RequestOptions>(),
+                        It.IsAny<AllowedMentions>()));
         }
     }
 }

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Extensions.DependencyInjection
                     provider => new DiscordSocketClient(config: new DiscordSocketConfig
                     {
                         AlwaysDownloadUsers = true,
+                        GatewayIntents =
+                            GatewayIntents.GuildBans |              // GUILD_BAN_ADD, GUILD_BAN_REMOVE
+                            GatewayIntents.GuildMembers |           // GUILD_MEMBER_ADD, GUILD_MEMBER_UPDATE, GUILD_MEMBER_REMOVE
+                            GatewayIntents.GuildMessageReactions |  // MESSAGE_REACTION_ADD, MESSAGE_REACTION_REMOVE,
+                                                                    //     MESSAGE_REACTION_REMOVE_ALL, MESSAGE_REACTION_REMOVE_EMOJI
+                            GatewayIntents.GuildMessages |          // MESSAGE_CREATE, MESSAGE_UPDATE, MESSAGE_DELETE, MESSAGE_DELETE_BULK
+                            GatewayIntents.Guilds,                  // GUILD_CREATE, GUILD_UPDATE, GUILD_DELETE, GUILD_ROLE_CREATE,
+                                                                    //     GUILD_ROLE_UPDATE, GUILD_ROLE_DELETE, CHANNEL_CREATE,
+                                                                    //     CHANNEL_UPDATE, CHANNEL_DELETE, CHANNEL_PINS_UPDATE
                         LogLevel = LogSeverity.Debug,
                         MessageCacheSize = provider
                             .GetRequiredService<IOptions<ModixConfig>>()


### PR DESCRIPTION
Only specify the [gateway intents](https://discord.com/developers/docs/topics/gateway#gateway-intents) for the events that we actually care about.

<details>
<summary>Included intents</summary>

```
GUILDS
  - GUILD_CREATE
  - GUILD_UPDATE
  - GUILD_DELETE
  - GUILD_ROLE_CREATE
  - GUILD_ROLE_UPDATE
  - GUILD_ROLE_DELETE
  - CHANNEL_CREATE
  - CHANNEL_UPDATE
  - CHANNEL_DELETE
  - CHANNEL_PINS_UPDATE

GUILD_MEMBERS
  - GUILD_MEMBER_ADD
  - GUILD_MEMBER_UPDATE
  - GUILD_MEMBER_REMOVE

GUILD_BANS
  - GUILD_BAN_ADD
  - GUILD_BAN_REMOVE

GUILD_MESSAGES
  - MESSAGE_CREATE
  - MESSAGE_UPDATE
  - MESSAGE_DELETE
  - MESSAGE_DELETE_BULK

GUILD_MESSAGE_REACTIONS
  - MESSAGE_REACTION_ADD
  - MESSAGE_REACTION_REMOVE
  - MESSAGE_REACTION_REMOVE_ALL
  - MESSAGE_REACTION_REMOVE_EMOJI
```
</details>

<details>
<summary>Excluded intents</summary>

```
GUILD_EMOJIS
  - GUILD_EMOJIS_UPDATE

GUILD_INTEGRATIONS
  - GUILD_INTEGRATIONS_UPDATE

GUILD_WEBHOOKS
  - WEBHOOKS_UPDATE

GUILD_INVITES
  - INVITE_CREATE
  - INVITE_DELETE

GUILD_VOICE_STATES
  - VOICE_STATE_UPDATE

GUILD_PRESENCES
  - PRESENCE_UPDATE

GUILD_MESSAGE_TYPING
  - TYPING_START

DIRECT_MESSAGES
  - CHANNEL_CREATE
  - MESSAGE_CREATE
  - MESSAGE_UPDATE
  - MESSAGE_DELETE
  - CHANNEL_PINS_UPDATE

DIRECT_MESSAGE_REACTIONS
  - MESSAGE_REACTION_ADD
  - MESSAGE_REACTION_REMOVE
  - MESSAGE_REACTION_REMOVE_ALL
  - MESSAGE_REACTION_REMOVE_EMOJI

DIRECT_MESSAGE_TYPING
  - TYPING_START
```
</details>
