### PR TITLE
Fix NullReferenceException when adding a comment to a campaign

### DIFF
--- a/Modix.Data/Repositories/PromotionCampaignRepository.cs
+++ b/Modix.Data/Repositories/PromotionCampaignRepository.cs
@@ -69,7 +69,7 @@ namespace Modix.Data.Repositories
         /// A <see cref="Task"/> which will complete when the operation is complete,
         /// containing the requested campaign, or null if no such campaign exists.
         /// </returns>
-        Task<PromotionCampaignDetails> ReadDetailsAsync(long campaignId);
+        Task<PromotionCampaignDetails?> ReadDetailsAsync(long campaignId);
 
         /// <summary>
         /// Marks an existing campaign as closed, based on its ID.
@@ -149,12 +149,12 @@ namespace Modix.Data.Repositories
                 .ToArrayAsync();
 
         /// <inheritdoc />
-        public Task<PromotionCampaignDetails> ReadDetailsAsync(long campaignId)
+        public Task<PromotionCampaignDetails?> ReadDetailsAsync(long campaignId)
             => ModixContext.Set<PromotionCampaignEntity>().AsNoTracking()
                 .Where(x => x.Id == campaignId)
                 .AsExpandable()
                 .Select(PromotionCampaignDetails.FromEntityProjection)
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync<PromotionCampaignDetails?>();
 
         /// <inheritdoc />
         public async Task<PromotionActionSummary?> TryCloseAsync(long campaignId, ulong closedById, PromotionCampaignOutcome outcome)

--- a/Modix.Services/Core/AuthorizationService.cs
+++ b/Modix.Services/Core/AuthorizationService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -154,15 +155,19 @@ namespace Modix.Services.Core
         /// <returns>A <see cref="Task"/> that will complete when the operation has completed.</returns>
         Task OnAuthenticatedAsync(ISelfUser self);
 
+#nullable enable
         /// <summary>
         /// Requires that there be an authenticated guild for the current request.
         /// </summary>
+        [MemberNotNull(nameof(CurrentGuildId))]
         void RequireAuthenticatedGuild();
 
         /// <summary>
         /// Requires that there be an authenticated user for the current request.
         /// </summary>
+        [MemberNotNull(nameof(CurrentUserId))]
         void RequireAuthenticatedUser();
+#nullable restore
 
         /// <summary>
         /// Requires that the given set of claims be present, for the current request.
@@ -443,7 +448,9 @@ namespace Modix.Services.Core
             return Task.CompletedTask;
         }
 
+#nullable enable
         /// <inheritdoc />
+        [MemberNotNull(nameof(CurrentGuildId))]
         public void RequireAuthenticatedGuild()
         {
             if (CurrentGuildId == null)
@@ -452,12 +459,14 @@ namespace Modix.Services.Core
         }
 
         /// <inheritdoc />
+        [MemberNotNull(nameof(CurrentUserId))]
         public void RequireAuthenticatedUser()
         {
             if (CurrentUserId == null)
                 // TODO: Booooo for exception-based flow control
                 throw new InvalidOperationException("The current operation requires an authenticated user.");
         }
+#nullable restore
 
         /// <inheritdoc />
         public void RequireClaims(params AuthorizationClaim[] claims)


### PR DESCRIPTION
The NRE specifically occurs when providing a campaign ID that doesn't exist. Added a null check to make sure the campaign exists, and added some NRT annotations to help prevent similar issues.