### PR TITLE
Revert "Remove guild members intent (#816)"

### DIFF
--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         AlwaysDownloadUsers = true,
                         GatewayIntents =
                             GatewayIntents.GuildBans |              // GUILD_BAN_ADD, GUILD_BAN_REMOVE
+                            GatewayIntents.GuildMembers |           // GUILD_MEMBER_ADD, GUILD_MEMBER_UPDATE, GUILD_MEMBER_REMOVE
                             GatewayIntents.GuildMessageReactions |  // MESSAGE_REACTION_ADD, MESSAGE_REACTION_REMOVE,
                                                                     //     MESSAGE_REACTION_REMOVE_ALL, MESSAGE_REACTION_REMOVE_EMOJI
                             GatewayIntents.GuildMessages |          // MESSAGE_CREATE, MESSAGE_UPDATE, MESSAGE_DELETE, MESSAGE_DELETE_BULK


### PR DESCRIPTION
This reverts commit 1c79ea747039b899d94247f5d2968d9bd308642b.

Didn't fix the deadlock, seems like the bot won't download users without this intent.

❗ Don't merge until we have confirmation that the intent is enabled in the app page for the bot, otherwise the bot will crash on startup.