### PR TITLE
Suggestion: Change bot status to watching

### DIFF
--- a/Modix.Bot/ModixBot.cs
+++ b/Modix.Bot/ModixBot.cs
@@ -218,8 +218,10 @@ namespace Modix
             async Task OnClientReady()
             {
                 Log.LogTrace("Discord client is ready. Setting game status.");
+
                 _client.Ready -= OnClientReady;
-                await _client.SetGameAsync(_config.WebsiteBaseUrl);
+
+                await _client.SetActivityAsync(new Game("for prefix !", ActivityType.Watching));
 
                 whenReadySource.SetResult(null);
             }


### PR DESCRIPTION
Based on suggestion in #meta - people forget what the prefix of MODiX is between the inline `$` usage and `!` and the translation module, `??`. Changes status to be "Watching for prefix !" rather than the mod.gg website.