### PR TITLE
Swap module and command logic in !help so that module is prioritized

### DIFF
--- a/Modix.Bot/Modules/HelpModule.cs
+++ b/Modix.Bot/Modules/HelpModule.cs
@@ -128,22 +128,23 @@ namespace Modix.Modules
         {
             embed = null;
 
-            if (queries.HasFlag(HelpDataType.Command))
-            {
-                var byCommand = _commandHelpService.GetCommandHelpData(query);
-                if (byCommand != null)
-                {
-                    embed = GetEmbedForCommand(byCommand);
-                    return true;
-                }
-            }
-
+            // Prioritize module over command.
             if (queries.HasFlag(HelpDataType.Module))
             {
                 var byModule = _commandHelpService.GetModuleHelpData(query);
                 if (byModule != null)
                 {
                     embed = GetEmbedForModule(byModule);
+                    return true;
+                }
+            }
+
+            if (queries.HasFlag(HelpDataType.Command))
+            {
+                var byCommand = _commandHelpService.GetCommandHelpData(query);
+                if (byCommand != null)
+                {
+                    embed = GetEmbedForCommand(byCommand);
                     return true;
                 }
             }


### PR DESCRIPTION
When a command and module have the same name (!promotions, !infractions, !pattern, etc.), the command is basically always a generic list command that everyone already knows about. This ends up not being super useful, especially for new users who are just trying to figure out "how do I do commands related to x". I frequently see people using `!help thing` to try to find out what the command name for the thing they want to do is, and the current output isn't helpful in that regard.

This PR swaps the priorities around so that the module is prioritized.