### PR TITLE
Remove status from !info and online count from !guildinfo

### DIFF
--- a/Modix.Bot/Modules/GuildInfoModule.cs
+++ b/Modix.Bot/Modules/GuildInfoModule.cs
@@ -150,14 +150,13 @@ namespace Modix.Modules
 
         public void AppendMemberInformation(StringBuilder stringBuilder, ISocketGuild guild)
         {
-            var onlineMembers = guild.Users.Count(x => x.Status != UserStatus.Offline);
             var members = guild.Users.Count;
             var bots = guild.Users.Count(x => x.IsBot);
             var humans = members - bots;
 
             stringBuilder
                 .AppendLine(Format.Bold("\u276F Member Information"))
-                .AppendLine($"Total member count: {members} ({onlineMembers} online)")
+                .AppendLine($"Total member count: {members}")
                 .AppendLine($"• Humans: {humans}")
                 .AppendLine($"• Bots: {bots}")
                 .AppendLine();

--- a/Modix.Bot/Modules/UserInfoModule.cs
+++ b/Modix.Bot/Modules/UserInfoModule.cs
@@ -133,10 +133,6 @@ namespace Modix.Modules
                     builder.AppendLine($"Ban Reason: {userInfo.BanReason}");
                 }
             }
-            else
-            {
-                builder.AppendLine($"Status: {userInfo.Status.Humanize()}");
-            }
 
             if (userInfo.FirstSeen is DateTimeOffset firstSeen)
                 builder.AppendLine($"First Seen: {FormatUtilities.FormatTimeAgo(_utcNow, firstSeen)}");

--- a/Modix/ClientApp/src/components/UserLookup/UserProfile.vue
+++ b/Modix/ClientApp/src/components/UserLookup/UserProfile.vue
@@ -12,7 +12,6 @@
                 <div class="userInfoSection">
                     <div class="box info">
                         <UserProfileField fieldName="ID" :fieldValue="user.id" />
-                        <UserProfileField fieldName="Status" :fieldValue="user.status" />
                         <UserProfileField fieldName="First seen" :fieldValue="formatDate(user.firstSeen)" default="Never" />
                         <UserProfileField fieldName="Last seen" :fieldValue="formatDate(user.lastSeen)" default="Never" />
                     </div>

--- a/Modix/ClientApp/src/models/EphemeralUser.ts
+++ b/Modix/ClientApp/src/models/EphemeralUser.ts
@@ -7,7 +7,6 @@ export default interface EphemeralUser
     nickname: string;
     discriminator: string;
     avatarUrl: string;
-    status: string;
     createdAt: Date;
     joinedAt: Date;
     firstSeen: Date;

--- a/Modix/Controllers/UserInformationController.cs
+++ b/Modix/Controllers/UserInformationController.cs
@@ -56,7 +56,6 @@ namespace Modix.Controllers
                 Nickname = userInformation.Nickname,
                 Discriminator = userInformation.Discriminator,
                 AvatarUrl = userInformation.AvatarId != null ? userInformation.GetAvatarUrl(ImageFormat.Auto, 256) : userInformation.GetDefaultAvatarUrl(),
-                Status = userInformation.Status.ToString(),
                 CreatedAt = userInformation.CreatedAt,
                 JoinedAt = userInformation.JoinedAt,
                 FirstSeen = userInformation.FirstSeen,


### PR DESCRIPTION
We are no longer tracking user status, so users will always appear as offline to the bot.

Resolves #815.