### PR TITLE
Reduce color retrieval timeout to 300ms

### DIFF
--- a/Modix.Services/Images/ImageService.cs
+++ b/Modix.Services/Images/ImageService.cs
@@ -56,7 +56,7 @@ namespace Modix.Services.Images
 
                 if (!_cache.TryGetValue(key, out Color color))
                 {
-                    var imageBytes = await _httpClientFactory.CreateClient(HttpClientNames.TimeoutOneSecond).GetByteArrayAsync(location);
+                    var imageBytes = await _httpClientFactory.CreateClient(HttpClientNames.Timeout300ms).GetByteArrayAsync(location);
                     color = GetDominantColor(imageBytes.AsSpan());
 
                     _cache.Set(key, color, TimeSpan.FromDays(7));
@@ -66,7 +66,7 @@ namespace Modix.Services.Images
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "An error occurred while attempting to determine the dominant color of an image.");
+                Log.Information(ex, "An error occurred while attempting to determine the dominant color of an image.");
                 return Color.Default;
             }
         }

--- a/Modix.Services/Utilities/HttpClientNames.cs
+++ b/Modix.Services/Utilities/HttpClientNames.cs
@@ -8,6 +8,7 @@
         public static string AutomaticGZipDecompression { get; } = nameof(AutomaticGZipDecompression);
 
         public static string TimeoutFiveSeconds { get; } = nameof(TimeoutFiveSeconds);
-        public static string TimeoutOneSecond { get; } = nameof(TimeoutOneSecond);
+
+        public static string Timeout300ms { get; } = nameof(Timeout300ms);
     }
 }

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -54,10 +54,10 @@ namespace Microsoft.Extensions.DependencyInjection
                     client.Timeout = TimeSpan.FromSeconds(5);
                 });
 
-            services.AddHttpClient(HttpClientNames.TimeoutOneSecond)
+            services.AddHttpClient(HttpClientNames.Timeout300ms)
                 .ConfigureHttpClient(client =>
                 {
-                    client.Timeout = TimeSpan.FromSeconds(1);
+                    client.Timeout = TimeSpan.FromMilliseconds(300);
                 });
 
             services.AddHttpClient(HttpClientNames.AutomaticGZipDecompression)


### PR DESCRIPTION
Also prevent the timeout error from appear in the log channel.