### PR TITLE
Added Microsoft.Toolkit.* API search filter

### DIFF
--- a/Modix.Services/Csharp/DocumentationService.cs
+++ b/Modix.Services/Csharp/DocumentationService.cs
@@ -8,7 +8,7 @@ namespace Modix.Services.Csharp
     public class DocumentationService
     {
         private const string ApiReferenceUrl = "https://docs.microsoft.com/api/apibrowser/dotnet/search?api-version=0.2&search=";
-        private const string ApiFilter = "&locale=en-us&$filter=monikers/any(t:%20t%20eq%20%27netcore-3.0%27)%20or%20monikers/any(t:%20t%20eq%20%27netframework-4.8%27)";
+        private const string ApiFilter = "&locale=en-us&$filter=monikers/any(t:%20t%20eq%20%27netcore-3.0%27)%20or%20monikers/any(t:%20t%20eq%20%27netframework-4.8%27)%20or%20monikers/any(t:%20t%20eq%20%27win-comm-toolkit-dotnet-stable%27)";
 
         public DocumentationService(IHttpClientFactory httpClientFactory)
         {


### PR DESCRIPTION
This change includes all the packages from the [Windows Community Toolkit](https://aka.ms/wct), ie. all the APIs under `Microsoft.Toolkit.*`