### PR TITLE
Handle accidental commas/periods surrounding IDs when parsing commands

### DIFF
--- a/Modix.Bot/UserOrMessageAuthorEntityTypeReader.cs
+++ b/Modix.Bot/UserOrMessageAuthorEntityTypeReader.cs
@@ -36,6 +36,8 @@ namespace Modix
     {
         public override async Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
         {
+            input = input.Trim(',', '.');
+
             var baseResult = await base.ReadAsync(context, input, services);
 
             if (baseResult.IsSuccess)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2829282/96021933-1e97ba80-0e1e-11eb-8eff-e035ca964020.png)

Resolves #551.