### PR TITLE
Add command to shorten links

### DIFF
--- a/Modix.Bot/Modules/LinkModule.cs
+++ b/Modix.Bot/Modules/LinkModule.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+using Discord;
+using Discord.Commands;
+
+using Modix.Services.Utilities;
+
+namespace Modix.Bot.Modules
+{
+    [Name("Link")]
+    [Summary("Commands for working with links.")]
+    public class LinkModule : ModuleBase
+    {
+        [Command("link")]
+        [Alias("url", "uri", "shorten", "linkto")]
+        [Summary("Shortens the provided link.")]
+        public async Task LinkAsync(
+            [Summary("The link to shorten.")]
+                Uri uri)
+        {
+            var host = uri.Host;
+
+            if (!_allowedHosts.Contains(host))
+            {
+                await ReplyAsync(embed: new EmbedBuilder()
+                    .WithColor(Color.Red)
+                    .WithDescription($"Links to {host} cannot be shortened.")
+                    .Build());
+
+                return;
+            }
+
+            await ReplyAsync(embed: new EmbedBuilder()
+                .WithDescription(Format.Url($"{host} (click here)", uri.ToString()))
+                .WithUserAsAuthor(Context.User)
+                .WithColor(Color.LightGrey)
+                .Build());
+
+            await Context.Message.DeleteAsync();
+        }
+
+        private static readonly ImmutableArray<string> _allowedHosts
+            = ImmutableArray.Create
+            (
+                "sharplab.io",
+                "docs.microsoft.com",
+                "www.docs.microsoft.com"
+            );
+    }
+}

--- a/Modix.Bot/UriTypeReader.cs
+++ b/Modix.Bot/UriTypeReader.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading.Tasks;
+using Discord.Commands;
+
+namespace Modix.Bot
+{
+    public class UriTypeReader : TypeReader
+    {
+        public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
+            => Uri.TryCreate(input, UriKind.Absolute, out var uri)
+                ? Task.FromResult(TypeReaderResult.FromSuccess(uri))
+                : Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed, "Failed to parse URI."));
+    }
+}

--- a/Modix/Extensions/ServiceCollectionExtensions.cs
+++ b/Modix/Extensions/ServiceCollectionExtensions.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     service.AddTypeReader<AnyGuildMessage<IUserMessage>>(new AnyGuildMessageTypeReader<IUserMessage>());
                     service.AddTypeReader<TimeSpan>(new TimeSpanTypeReader(), true);
                     service.AddTypeReader<DiscordUserOrMessageAuthorEntity>(new UserOrMessageAuthorEntityTypeReader());
+                    service.AddTypeReader<Uri>(new UriTypeReader());
 
                     return service;
                 })


### PR DESCRIPTION
Suggested by Sergio in #modix-development.

![image](https://user-images.githubusercontent.com/2829282/97917223-2b734400-1d22-11eb-8f24-a836c0cd0935.png)

Potential future enhancements could include
- Making allowed hosts configurable per guild
- Allowing an inline syntax, similar to what we have for tags