### PR TITLE
Add sharplab code preview in embed

### DIFF
--- a/Modix.Bot/Modix.Bot.csproj
+++ b/Modix.Bot/Modix.Bot.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Serilog.Sinks.Literate" />
     <PackageReference Include="Serilog.Sinks.RollingFile" />
     <PackageReference Include="Serilog.Sinks.Sentry" />
+    <PackageReference Include="LZStringCSharp" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Modix.Services\Modix.Services.csproj" />

--- a/Modix.Bot/Modules/LinkModule.cs
+++ b/Modix.Bot/Modules/LinkModule.cs
@@ -32,13 +32,73 @@ namespace Modix.Bot.Modules
                 return;
             }
 
-            await ReplyAsync(embed: new EmbedBuilder()
+            if (host.Equals("sharplab.io") &&
+                TryPrepareSharplabPreview(uri.OriginalString, out string preview))
+            {
+                string markdownUrl = Format.Url($"{host} (click here)", uri.ToString());
+                string markdownText = $"{markdownUrl}\r{preview}";
+
+                await ReplyAsync(embed: new EmbedBuilder()
+                    .WithDescription(markdownText)
+                    .WithUserAsAuthor(Context.User)
+                    .WithColor(Color.LightGrey)
+                    .Build());
+            }
+            else
+            {
+                await ReplyAsync(embed: new EmbedBuilder()
                 .WithDescription(Format.Url($"{host} (click here)", uri.ToString()))
                 .WithUserAsAuthor(Context.User)
                 .WithColor(Color.LightGrey)
                 .Build());
+            }
 
             await Context.Message.DeleteAsync();
+        }
+
+        private static bool TryPrepareSharplabPreview(string url, out string preview)
+        {
+            if (!url.Contains("#v2:"))
+            {
+                preview = null;
+
+                return false;
+            }
+
+            try
+            {
+                // Decode the compressed code from the URL payload
+                string base64Text = Url.Substring(Url.IndexOf("#v2:") + "#v2:".Length);
+                string plainText = LZString.DecompressFromBase64(base64Text);
+
+                // Extract the option and get the target language
+                var textParts = Regex.Match(plainText, @"([^|]*)\|([\s\S]*)$");
+                var languageOption = Regex.Match(textParts.Groups[1].Value, @"l:(\w+)");
+                string language = languageOption.Success ? languageOption.Groups[1].Value : "cs";
+                string sourceCode = textParts.Groups[2].Value;
+
+                // Replace the compression tokens
+                if (language is "cs")
+                {
+                    sourceCode = Regex.Replace(sourceCode, @"@(\d+|@)", match =>
+                    {
+                        if (match.Value is "@@") return "@";
+
+                        return Tokens[int.Parse(match.Groups[1].Value)];
+                    });
+                }
+                else sourceCode = sourceCode.Replace("@@", "@");
+
+                preview = $"```{language}\r{sourceCode}\r```";
+
+                return true;
+            }
+            catch
+            {
+                preview = null;
+
+                return false;
+            }
         }
 
         private static readonly ImmutableArray<string> _allowedHosts
@@ -48,5 +108,36 @@ namespace Modix.Bot.Modules
                 "docs.microsoft.com",
                 "www.docs.microsoft.com"
             );
+
+        private static readonly ImmutableArray<string> _sharplabCSTokens
+            = ImmutableArray.Create(new[]
+            {
+                "using",
+                "System",
+                "class",
+                "public",
+                "void",
+                "Func",
+                "Task",
+                "return",
+                "async",
+                "await",
+                "string",
+                "yield",
+                "Action",
+                "IEnumerable",
+                "System.Collections.Generic",
+                "System.Threading.Tasks",
+                "static",
+                "Program",
+                "Main",
+                "Console.WriteLine",
+                "<help.run.csharp>",
+                "using System;",
+                "public static void Main()",
+                "public static class Program",
+                "Inspect.Allocations(() =>",
+                "Inspect.MemoryGraph("
+            });
     }
 }

--- a/Modix.Bot/Modules/LinkModule.cs
+++ b/Modix.Bot/Modules/LinkModule.cs
@@ -87,7 +87,7 @@ namespace Modix.Bot.Modules
                     {
                         if (match.Value is "@@") return "@";
 
-                        return Tokens[int.Parse(match.Groups[1].Value)];
+                        return _sharplabCSTokens[int.Parse(match.Groups[1].Value)];
                     });
                 }
                 else sourceCode = sourceCode.Replace("@@", "@");

--- a/Modix.Bot/Modules/LinkModule.cs
+++ b/Modix.Bot/Modules/LinkModule.cs
@@ -71,7 +71,7 @@ namespace Modix.Bot.Modules
             try
             {
                 // Decode the compressed code from the URL payload
-                string base64Text = Url.Substring(Url.IndexOf("#v2:") + "#v2:".Length);
+                string base64Text = url.Substring(url.IndexOf("#v2:") + "#v2:".Length);
                 string plainText = LZString.DecompressFromBase64(base64Text);
 
                 // Extract the option and get the target language

--- a/Modix.Bot/Modules/LinkModule.cs
+++ b/Modix.Bot/Modules/LinkModule.cs
@@ -89,8 +89,14 @@ namespace Modix.Bot.Modules
 
                         return _sharplabCSTokens[int.Parse(match.Groups[1].Value)];
                     });
+
+                    // Strip using directives
+                    sourceCode = Regex.Replace(sourceCode, @"using \w+(?:\.\w+)*;", string.Empty);
                 }
                 else sourceCode = sourceCode.Replace("@@", "@");
+
+                // Trim, for good measure
+                sourceCode = sourceCode.Trim();
 
                 preview = $"```{language}\r{sourceCode}\r```";
 

--- a/Modix.Bot/Modules/LinkModule.cs
+++ b/Modix.Bot/Modules/LinkModule.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 using Discord;
 using Discord.Commands;
 
 using Modix.Services.Utilities;
+
+using LZStringCSharp;
 
 namespace Modix.Bot.Modules
 {

--- a/Modix.Bot/Modules/LinkModule.cs
+++ b/Modix.Bot/Modules/LinkModule.cs
@@ -98,6 +98,26 @@ namespace Modix.Bot.Modules
                 // Trim, for good measure
                 sourceCode = sourceCode.Trim();
 
+                // Clip to avoid Discord errors.
+                // - 2048 is the maximum length
+                // - 20 is the approximate length of the markdown URL and message
+                // - 10 is the approximate length of the code highlight markdown
+                int maximumLength = 2048 - (url.Length + 20 + 10);
+
+                if (sourceCode.Length > maximumLength)
+                {
+                    // Clip at the maximum length
+                    sourceCode = sourceCode.Substring(0, maximumLength);
+
+                    int lastCarriageIndex = sourceCode.LastIndexOf('\r');
+
+                    // Remove the last line to avoid having code cut mid-statements
+                    if (lastCarriageIndex > 0)
+                    {
+                        sourceCode = sourceCode.Substring(0, lastCarriageIndex).Trim();
+                    }
+                }
+
                 preview = $"```{language}\r{sourceCode}\r```";
 
                 return true;


### PR DESCRIPTION
This PR adds a markdown preview of source code from a `sharplab.io` URL.
I ported the code from sharplab's repo [here](https://github.com/ashmind/SharpLab/blob/99c4787bb21934793a956118f83b001e81cdfe24/source/WebApp/ts/state/handlers/url.ts#L66).

The idea is that now embeds will have the following content:

```
sharplab.io (click here)

<BACKTICKS_HERE_I_CANT_ESCAPE_IN_MARKDOWN>cs
// Some code...
<END_BACKTICKS>
```

I only tested the code locally though, so I'd need someone to give this a try with an actual request 😄