### PR TITLE
.NET 5 package updates

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -12,60 +12,59 @@
 
   <!-- Package versions for package references across all projects -->
   <ItemGroup>
-    <PackageReference Update="Discord.Net" Version="2.3.0-dev-20200801.4" />
+    <PackageReference Update="Discord.Net" Version="2.3.0-dev-20201109.3" />
 
-    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="3.1.3" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="3.1.3"/>
-    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.3" />
-    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="5.0.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="5.0.0"/>
+    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.0" />
+    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.0-rc2" />
     
-    <PackageReference Update="Nito.AsyncEx.Coordination" Version="5.0.0" />
-    <PackageReference Update="DogStatsD-CSharp-Client" Version="4.0.1" />
+    <PackageReference Update="Nito.AsyncEx.Coordination" Version="5.1.0" />
+    <PackageReference Update="DogStatsD-CSharp-Client" Version="5.1.0" />
 
-    <PackageReference Update="AspNet.Security.OAuth.Discord" Version="3.0.0" />
+    <PackageReference Update="AspNet.Security.OAuth.Discord" Version="5.0.0" />
 
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.0-preview.4.20257.10" />
-    <PackageReference Update="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.0-preview.4.20257.10" />
-
-    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="5.0.0-preview.4.20251.6" />
-    <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0-preview.4.20251.6" />
-    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="5.0.0-preview.4.20251.6" />
-    <PackageReference Update="Microsoft.Extensions.Hosting" Version="5.0.0-preview.4.20251.6" />
-    <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0-preview.4.20251.6" />
-    <PackageReference Update="Microsoft.Extensions.Http" Version="5.0.0-preview.4.20251.6" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0-preview.4.20251.6" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="5.0.0-preview.4.20251.6" />
-    <PackageReference Update="Microsoft.Extensions.Options" Version="5.0.0-preview.4.20251.6" />
-    <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0-preview.4.20251.6" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.8.0" />
 
     <PackageReference Update="Newtonsoft.Json" Version="12.0.3" />
 
-    <PackageReference Update="LinqKit.Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Update="LZStringCSharp" Version="1.4.0" />
 
-    <PackageReference Update="Serilog" Version="2.9.1-dev-01167" />
-    <PackageReference Update="Serilog.AspNetCore" Version="3.3.0-dev-00152" />
+    <PackageReference Update="LinqKit.Microsoft.EntityFrameworkCore" Version="5.0.21" />
+
+    <PackageReference Update="Serilog" Version="2.10.0" />
+    <PackageReference Update="Serilog.AspNetCore" Version="3.4.0" />
     <PackageReference Update="Serilog.Extensions.Logging" Version="3.0.2-dev-10272" />
     <PackageReference Update="Serilog.Filters.Expressions" Version="2.1.0" />
     <PackageReference Update="Serilog.Sinks.Literate" Version="3.0.0" />
-    <PackageReference Update="Serilog.Sinks.Sentry" Version="2.4.1" />
     <PackageReference Update="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Update="Serilog.Sinks.RollingFile" Version="3.3.0" />
     
-    <PackageReference Update="Humanizer.Core" Version="2.8.11" />
+    <PackageReference Update="Humanizer.Core" Version="2.8.26" />
 
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.7.0-preview-20200428-01" />
-
-    <PackageReference Update="Moq" Version="4.14.1" />
-    <PackageReference Update="Moq.AutoMock" Version="2.0.0" />
+    <PackageReference Update="Moq" Version="4.15.1" />
+    <PackageReference Update="Moq.AutoMock" Version="2.1.0" />
 
     <PackageReference Update="NUnit" Version="3.12.0" />
-    <PackageReference Update="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Update="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="NSubstitute" Version="4.2.1" />
+    <PackageReference Update="NSubstitute" Version="4.2.2" />
 
     <PackageReference Update="AsyncEvent" Version="0.2.1" />
     <PackageReference Update="Kitsu" Version="1.4.2" />
-    <PackageReference Update="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
+    <PackageReference Update="SixLabors.ImageSharp" Version="1.0.2" />
   </ItemGroup>
 
 </Project>

--- a/Discord.Net.Abstractions/Rest/IRestApplication.cs
+++ b/Discord.Net.Abstractions/Rest/IRestApplication.cs
@@ -41,6 +41,15 @@ namespace Discord.Rest
         public string IconUrl
             => RestApplication.IconUrl;
 
+        public bool IsBotPublic
+            => RestApplication.IsBotPublic;
+
+        public bool BotRequiresCodeGrant
+            => RestApplication.BotRequiresCodeGrant;
+
+        public ITeam Team
+            => RestApplication.Team;
+
         /// <inheritdoc />
         public ulong Id
             => RestApplication.Id;

--- a/Discord.Net.Abstractions/Rest/IRestGuild.cs
+++ b/Discord.Net.Abstractions/Rest/IRestGuild.cs
@@ -367,6 +367,10 @@ namespace Discord.Rest
         public Task DownloadUsersAsync()
             => (RestGuild as IGuild).DownloadUsersAsync();
 
+        public Task<int> PruneUsersAsync(int days = 30, bool simulate = false, RequestOptions options = null,
+            IEnumerable<ulong> includeRoleIds = null) =>
+            RestGuild.PruneUsersAsync(days, simulate, options, includeRoleIds);
+
         /// <inheritdoc />
         public async Task<IRestVoiceChannel> GetAFKChannelAsync(RequestOptions options = null)
             => (await RestGuild.GetAFKChannelAsync(options))
@@ -658,10 +662,6 @@ namespace Discord.Rest
         /// <inheritdoc />
         public Task<GuildEmote> ModifyEmoteAsync(GuildEmote emote, Action<EmoteProperties> func, RequestOptions options = null)
             => (RestGuild as IGuild).ModifyEmoteAsync(emote, func, options);
-
-        /// <inheritdoc />
-        public Task<int> PruneUsersAsync(int days = 30, bool simulate = false, RequestOptions options = null)
-            => RestGuild.PruneUsersAsync(days, simulate, options);
 
         /// <inheritdoc />
         public Task RemoveBanAsync(ulong userId, RequestOptions options = null)

--- a/Discord.Net.Abstractions/Rest/IRestMessage.cs
+++ b/Discord.Net.Abstractions/Rest/IRestMessage.cs
@@ -74,6 +74,9 @@ namespace Discord.Rest
             => RestMessage.Channel
                 .Abstract();
 
+        public bool MentionedEveryone
+            => RestMessage.MentionedEveryone;
+
         /// <inheritdoc />
         public string Content
             => RestMessage.Content;

--- a/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
@@ -476,6 +476,10 @@ namespace Discord.WebSocket
         public Task DownloadUsersAsync()
             => SocketGuild.DownloadUsersAsync();
 
+        public Task<int> PruneUsersAsync(int days = 30, bool simulate = false, RequestOptions options = null,
+            IEnumerable<ulong> includeRoleIds = null) =>
+            throw new NotImplementedException();
+
         /// <inheritdoc />
         public async Task<IVoiceChannel> GetAFKChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
             => (await (SocketGuild as IGuild).GetAFKChannelAsync(mode, options))
@@ -713,10 +717,6 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         Task<GuildEmote> IGuild.ModifyEmoteAsync(GuildEmote emote, Action<EmoteProperties> func, RequestOptions options)
             => (SocketGuild as IGuild).ModifyEmoteAsync(emote, func, options);
-
-        /// <inheritdoc />
-        public Task<int> PruneUsersAsync(int days = 30, bool simulate = false, RequestOptions options = null)
-            => SocketGuild.PruneUsersAsync(days, simulate, options);
 
         /// <inheritdoc />
         public Task RemoveBanAsync(ulong userId, RequestOptions options = null)

--- a/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketGuild.cs
@@ -478,7 +478,7 @@ namespace Discord.WebSocket
 
         public Task<int> PruneUsersAsync(int days = 30, bool simulate = false, RequestOptions options = null,
             IEnumerable<ulong> includeRoleIds = null) =>
-            throw new NotImplementedException();
+            SocketGuild.PruneUsersAsync(days, simulate, options, includeRoleIds);
 
         /// <inheritdoc />
         public async Task<IVoiceChannel> GetAFKChannelAsync(CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
@@ -492,21 +492,12 @@ namespace Discord.WebSocket
                     .Select(RestAuditLogEntryAbstractionExtensions.Abstract)
                     .ToArray());
 
-        /// <inheritdoc />
-        public async Task<IReadOnlyCollection<IAuditLogEntry>> GetAuditLogsAsync(int limit = 100, CacheMode mode = CacheMode.AllowDownload, RequestOptions options = null)
-            => (await (SocketGuild as IGuild).GetAuditLogsAsync(limit, mode, options))
-                .Select(AuditLogEntryAbstractionExtensions.Abstract)
-                .ToArray();
-
-        /// <inheritdoc />
         public async Task<IBan> GetBanAsync(ulong userId, RequestOptions options = null)
             => await SocketGuild.GetBanAsync(userId, options);
 
-        /// <inheritdoc />
         public async Task<IBan> GetBanAsync(IUser user, RequestOptions options = null)
             => await SocketGuild.GetBanAsync(user, options);
 
-        /// <inheritdoc />
         public async Task<IReadOnlyCollection<IBan>> GetBansAsync(RequestOptions options = null)
             => await SocketGuild.GetBansAsync(options);
 
@@ -734,7 +725,6 @@ namespace Discord.WebSocket
         public Task ReorderRolesAsync(IEnumerable<ReorderRoleProperties> args, RequestOptions options = null)
             => SocketGuild.ReorderRolesAsync(args, options);
 
-        /// <inheritdoc />
         public Task<IReadOnlyCollection<RestGuildUser>> SearchUsersAsync(string query, int limit = 1000, RequestOptions options = null)
             => SocketGuild.SearchUsersAsync(query, limit, options);
 

--- a/Discord.Net.Abstractions/WebSocket/ISocketMessage.cs
+++ b/Discord.Net.Abstractions/WebSocket/ISocketMessage.cs
@@ -74,6 +74,9 @@ namespace Discord.WebSocket
             => (SocketMessage as IMessage).Channel
                 .Abstract();
 
+        public bool MentionedEveryone
+            => SocketMessage.MentionedEveryone;
+
         /// <inheritdoc />
         public string Content
             => SocketMessage.Content;

--- a/Modix.Bot/Modix.Bot.csproj
+++ b/Modix.Bot/Modix.Bot.csproj
@@ -12,8 +12,7 @@
     <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Serilog.Sinks.Literate" />
     <PackageReference Include="Serilog.Sinks.RollingFile" />
-    <PackageReference Include="Serilog.Sinks.Sentry" />
-    <PackageReference Include="LZStringCSharp" Version="1.4.0" />
+    <PackageReference Include="LZStringCSharp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Modix.Services\Modix.Services.csproj" />

--- a/Modix.Data.Test/ModixContextTests.cs
+++ b/Modix.Data.Test/ModixContextTests.cs
@@ -20,8 +20,8 @@ namespace Modix.Data.Test
             var context = new ModixContext(optionsBuilder.Options);
 
             var differences = context.GetService<IMigrationsModelDiffer>().GetDifferences(
-                    context.GetService<IMigrationsAssembly>().ModelSnapshot.Model,
-                    context.Model);
+                    context.GetService<IMigrationsAssembly>().ModelSnapshot.Model.GetRelationalModel(),
+                    context.Model.GetRelationalModel());
 
             differences.ShouldBeEmpty();
         }

--- a/Modix.Data/ExpandableQueries/ExpandableQuery.cs
+++ b/Modix.Data/ExpandableQueries/ExpandableQuery.cs
@@ -4,6 +4,7 @@ using System.Linq.Expressions;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Modix.Data.ExpandableQueries
@@ -22,7 +23,7 @@ namespace Modix.Data.ExpandableQueries
 
         public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
 #pragma warning disable EF1001 // Internal EF Core API usage.
-            => ((IAsyncQueryProvider)_provider).ExecuteAsync<IAsyncEnumerable<T>>(Expression).GetAsyncEnumerator();
+            => ((IAsyncQueryProvider)_provider).ExecuteAsync<IAsyncEnumerable<T>>(Expression).GetAsyncEnumerator(cancellationToken);
 #pragma warning restore EF1001 // Internal EF Core API usage.
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Modix.Data/ExpandableQueries/ExpandableQueryProvider.cs
+++ b/Modix.Data/ExpandableQueries/ExpandableQueryProvider.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace Modix.Data.ExpandableQueries

--- a/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMemberTranslator.cs
+++ b/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMemberTranslator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
-
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
@@ -9,21 +10,27 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations
     public class DateTimeOffsetMemberTranslator
         : IMemberTranslator
     {
+        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+
         public DateTimeOffsetMemberTranslator(
             ISqlExpressionFactory sqlExpressionFactory)
         {
             _sqlExpressionFactory = sqlExpressionFactory;
         }
 
-        public SqlExpression? Translate(
-                SqlExpression instance,
-                MemberInfo member,
-                Type returnType)
-            => ((member.DeclaringType == typeof(DateTimeOffset))
-                    && (member.Name == nameof(DateTimeOffset.Date)))
-                ? _sqlExpressionFactory.Function("DATE_TRUNC", new[] { _sqlExpressionFactory.Constant("day"), instance }, returnType)
-                : null;
+        public SqlExpression? Translate(SqlExpression instance, MemberInfo member, Type returnType,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        {
+            if (member.DeclaringType == typeof(DateTimeOffset) && member.Name == nameof(DateTimeOffset.Now))
+            {
+                return _sqlExpressionFactory.Function("DATE_TRUNC",
+                    new[] {_sqlExpressionFactory.Constant("day"), instance},
+                    false,
+                    new[] {true},
+                    returnType);
+            }
 
-        private readonly ISqlExpressionFactory _sqlExpressionFactory;
+            return null;
+        }
     }
 }

--- a/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMemberTranslator.cs
+++ b/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMemberTranslator.cs
@@ -21,7 +21,7 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations
         public SqlExpression? Translate(SqlExpression instance, MemberInfo member, Type returnType,
             IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
-            if (member.DeclaringType == typeof(DateTimeOffset) && member.Name == nameof(DateTimeOffset.Now))
+            if (member.DeclaringType == typeof(DateTimeOffset) && member.Name == nameof(DateTimeOffset.Date))
             {
                 return _sqlExpressionFactory.Function("DATE_TRUNC",
                     new[] {_sqlExpressionFactory.Constant("day"), instance},

--- a/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMethodCallTranslator.cs
+++ b/Modix.Data/Extensions/Npgsql/EntityFrameworkCore/PostgreSQL/DateTimeOffsetTranslations/DateTimeOffsetMethodCallTranslator.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
-
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
-
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Internal;
 
 namespace Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations
@@ -22,7 +23,8 @@ namespace Npgsql.EntityFrameworkCore.PostgreSQL.DateTimeOffsetTranslations
         public SqlExpression? Translate(
                 SqlExpression instance,
                 MethodInfo method,
-                IReadOnlyList<SqlExpression> arguments)
+                IReadOnlyList<SqlExpression> arguments,
+                IDiagnosticsLogger<DbLoggerCategory.Query> logger)
             => ((method.DeclaringType == typeof(DateTimeOffset))
                     && (method.Name == nameof(DateTimeOffset.ToUniversalTime))
                     && _sqlExpressionFactory is NpgsqlSqlExpressionFactory npgsqlSqlExpressionFactory)

--- a/Modix.Data/Models/Core/MessageContentPatternEntity.cs
+++ b/Modix.Data/Models/Core/MessageContentPatternEntity.cs
@@ -13,7 +13,7 @@ namespace Modix.Data.Models.Core
         public long Id { get; set; }
 
         [Required]
-        public string Pattern { get; set; }
+        public string Pattern { get; set; } = null!;
 
         public MessageContentPatternType PatternType { get; set; }
 

--- a/Modix/DataDog/DebugDogStatsd.cs
+++ b/Modix/DataDog/DebugDogStatsd.cs
@@ -73,6 +73,12 @@ namespace Modix.DataDog
         {
         }
 
+        public void Dispose()
+        {
+        }
+
+        public ITelemetryCounters TelemetryCounters { get; }
+
         private class EmptyDisposable : IDisposable
         {
             public void Dispose()

--- a/Modix/Modix.csproj
+++ b/Modix/Modix.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="Serilog.Filters.Expressions" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.RollingFile" />
-    <PackageReference Include="Serilog.Sinks.Sentry" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates Microsoft packages. Updates Discord.NET. Implements and changes APIs according to new members.

Discord abstractions causing a bit of a headache.

Trying to wrap my head around the new nullability APIs in EF currently - the implementation in the `DateTimeOffset` translator should be correct according to https://github.com/dotnet/efcore/issues/23042