### PR TITLE
Change help parameters from Attribute-style to CLI style

### DIFF
--- a/Modix.Bot/Modules/HelpModule.cs
+++ b/Modix.Bot/Modules/HelpModule.cs
@@ -231,9 +231,9 @@ namespace Modix.Modules
             foreach (var parameter in info.Parameters)
             {
                 if (parameter.IsOptional)
-                    sb.Append($"[Optional({parameter.Name})]");
-                else
                     sb.Append($"[{parameter.Name}]");
+                else
+                    sb.Append($"<{parameter.Name}>");
             }
 
             return sb.ToString();


### PR DESCRIPTION
Purely a stylistic change that makes almost no impact, though I do understand if this gets rejected for the sole reason that not everyone understands how CLI params work.