### PR TITLE
Added alias for tag owner command

### DIFF
--- a/Modix.Bot/Modules/TagModule.cs
+++ b/Modix.Bot/Modules/TagModule.cs
@@ -129,6 +129,7 @@ namespace Modix.Bot.Modules
         }
 
         [Command("owner")]
+        [Alias("info", "about")]
         [Summary("Lists the owner of the supplied tag.")]
         public async Task GetOwnerAsync(
             [Summary("The name of the tag whose owner is being requested.")]


### PR DESCRIPTION
I can NEVER remember the command to find the owner of a tag, I'm proposing these aliases to make it easier for people to guess what command that is without digging through the help docs