### PR TITLE
Fix broken migrations

### DIFF
--- a/Modix.Data/Migrations/20180720043306_Authorization.cs
+++ b/Modix.Data/Migrations/20180720043306_Authorization.cs
@@ -32,20 +32,26 @@ namespace Modix.Data.Migrations
             migrationBuilder.AlterColumn<string>(
                 name: "Type",
                 table: "ModerationActions",
+                type: "text",
                 nullable: false,
-                oldClrType: typeof(int));
+                oldClrType: typeof(int),
+                oldType: "integer");
 
             migrationBuilder.AlterColumn<string>(
                 name: "Type",
                 table: "Infractions",
+                type: "text",
                 nullable: false,
-                oldClrType: typeof(int));
+                oldClrType: typeof(int),
+                oldType: "integer");
 
             migrationBuilder.AlterColumn<string>(
                 name: "Type",
                 table: "ConfigurationActions",
+                type: "text",
                 nullable: false,
-                oldClrType: typeof(int));
+                oldClrType: typeof(int),
+                oldType: "integer");
 
             migrationBuilder.CreateTable(
                 name: "ClaimMappings",
@@ -127,20 +133,26 @@ namespace Modix.Data.Migrations
             migrationBuilder.AlterColumn<int>(
                 name: "Type",
                 table: "ModerationActions",
+                type: "integer",
                 nullable: false,
-                oldClrType: typeof(string));
+                oldClrType: typeof(string),
+                oldType: "text");
 
             migrationBuilder.AlterColumn<int>(
                 name: "Type",
                 table: "Infractions",
+                type: "integer",
                 nullable: false,
-                oldClrType: typeof(string));
+                oldClrType: typeof(string),
+                oldType: "text");
 
             migrationBuilder.AlterColumn<int>(
                 name: "Type",
                 table: "ConfigurationActions",
+                type: "integer",
                 nullable: false,
-                oldClrType: typeof(string));
+                oldClrType: typeof(string),
+                oldType: "text");
 
             migrationBuilder.CreateTable(
                 name: "RoleClaims",

--- a/Modix.Data/Migrations/20180902092548_Issue100PromotionsRework.cs
+++ b/Modix.Data/Migrations/20180902092548_Issue100PromotionsRework.cs
@@ -92,8 +92,10 @@ namespace Modix.Data.Migrations
             migrationBuilder.AlterColumn<string>(
                 name: "Sentiment",
                 table: "PromotionComments",
+                type: "text",
                 nullable: false,
-                oldClrType: typeof(int));
+                oldClrType: typeof(int),
+                oldType: "integer");
 
             migrationBuilder.AddColumn<long>(
                 name: "CampaignId",
@@ -406,8 +408,10 @@ namespace Modix.Data.Migrations
             migrationBuilder.AlterColumn<int>(
                 name: "Sentiment",
                 table: "PromotionComments",
+                type: "integer",
                 nullable: false,
-                oldClrType: typeof(string));
+                oldClrType: typeof(string),
+                oldType: "text");
 
             migrationBuilder.AddColumn<string>(
                 name: "Body",


### PR DESCRIPTION
Added missing type annotations for old AlterColumn migration operations, which seem to have broken during the EF Core 5.0 upgrade. With the additional annotations, the migrations are working correctly again.