### PR TITLE
Disallow nomination of bots

### DIFF
--- a/Modix.Bot/Modules/PromotionsModule.cs
+++ b/Modix.Bot/Modules/PromotionsModule.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -81,21 +81,15 @@ namespace Modix.Modules
 
         [Command("nominate")]
         [Summary("Nominate the given user for promotion")]
-        public Task NominateAsync(
+        public async Task NominateAsync(
             [Summary("The user to nominate")]
                 IGuildUser subject,
             [Remainder]
             [Summary("A comment to be attached to the new campaign")]
                 string comment)
-        {
-            if (subject.IsBot)
-            {
-                return ReplyAsync("Cannot nominate bot users for promotion.");
-            }
-            return PromotionsService.CreateCampaignAsync(subject.Id, comment,
-               c => Context.GetUserConfirmationAsync(
-                   $"You are nominating {subject.GetFullUsername()} ({subject.Id}) for promotion to {c.TargetRankRole.Name}.{Environment.NewLine}"));
-        }
+            => await PromotionsService.CreateCampaignAsync(subject.Id, comment,
+                c => Context.GetUserConfirmationAsync(
+                    $"You are nominating {subject.GetFullUsername()} ({subject.Id}) for promotion to {c.TargetRankRole.Name}.{Environment.NewLine}"));
 
         [Command("comment")]
         [Summary("Comment on an ongoing campaign to promote a user.")]

--- a/Modix.Bot/Modules/PromotionsModule.cs
+++ b/Modix.Bot/Modules/PromotionsModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -81,15 +81,21 @@ namespace Modix.Modules
 
         [Command("nominate")]
         [Summary("Nominate the given user for promotion")]
-        public async Task NominateAsync(
+        public Task NominateAsync(
             [Summary("The user to nominate")]
                 IGuildUser subject,
             [Remainder]
             [Summary("A comment to be attached to the new campaign")]
                 string comment)
-            => await PromotionsService.CreateCampaignAsync(subject.Id, comment,
-                c => Context.GetUserConfirmationAsync(
-                    $"You are nominating {subject.GetFullUsername()} ({subject.Id}) for promotion to {c.TargetRankRole.Name}.{Environment.NewLine}"));
+        {
+            if (subject.IsBot)
+            {
+                return ReplyAsync("Cannot nominate bot users for promotion.");
+            }
+            return PromotionsService.CreateCampaignAsync(subject.Id, comment,
+               c => Context.GetUserConfirmationAsync(
+                   $"You are nominating {subject.GetFullUsername()} ({subject.Id}) for promotion to {c.TargetRankRole.Name}.{Environment.NewLine}"));
+        }
 
         [Command("comment")]
         [Summary("Comment on an ongoing campaign to promote a user.")]

--- a/Modix.Services/Promotions/PromotionsService.cs
+++ b/Modix.Services/Promotions/PromotionsService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -148,6 +148,11 @@ namespace Modix.Services.Promotions
 
             var rankRoles = await GetRankRolesAsync(AuthorizationService.CurrentGuildId.Value);
             var subject = await UserService.GetGuildUserAsync(AuthorizationService.CurrentGuildId.Value, subjectId);
+
+            if (subject.IsBot)
+            {
+                return;
+            }
 
             if (!TryGetNextRankRoleForUser(rankRoles, subject, out var nextRankRole, out var message))
                 throw new InvalidOperationException(message);

--- a/Modix.Services/Promotions/PromotionsService.cs
+++ b/Modix.Services/Promotions/PromotionsService.cs
@@ -151,7 +151,7 @@ namespace Modix.Services.Promotions
 
             if (subject.IsBot)
             {
-                return;
+                throw new InvalidOperationException("Bots cannot be nominated for a promotion campaign.");
             }
 
             if (!TryGetNextRankRoleForUser(rankRoles, subject, out var nextRankRole, out var message))


### PR DESCRIPTION
Closes #876

Also removes `async` from the method signature and returns the `Task` directly instead of `await`ing then returning the awaited task. Using unnecessary `async`/`await`s adds some overhead as far as I'm aware.