### PR TITLE
Update !info not to fetch all bans for the guild

### DIFF
--- a/Modix.Services/Core/UserService.cs
+++ b/Modix.Services/Core/UserService.cs
@@ -193,11 +193,10 @@ namespace Modix.Services.Core
             var guild = await guildTask;
 
             var guildUser = await guild.GetUserAsync(userId);
-            var bans = await guild.GetBansAsync();
+            var ban = await guild.GetBanAsync(userId);
 
             var user = await userTask;
             var restUser = await restUserTask;
-            var ban = bans.FirstOrDefault(x => x.User.Id == userId);
 
             if (guildUser is { })
                 await TrackUserAsync(guildUser, default);


### PR DESCRIPTION
Instead, only fetch ban data for the specific user in context. (`GetBan` returns null if the user is not banned.)

Not sure why I didn't use this method originally.