### PR TITLE
Added missing windows executable extensions to blacklist

### DIFF
--- a/Modix.Services/Moderation/AttachmentBlacklistBehavior.cs
+++ b/Modix.Services/Moderation/AttachmentBlacklistBehavior.cs
@@ -75,7 +75,23 @@ namespace Modix.Services.Moderation
                 ".ppam",
                 ".ppsm",
                 ".sldn",
-                ".sb"
+                ".sb",
+                ".bin",
+                ".com",
+                ".gadget",
+                ".inf1",
+                ".ins",
+                ".inx",
+                ".isu",
+                ".job",
+                ".jse",
+                ".paf",
+                ".rgs",
+                ".sct",
+                ".shb",
+                ".shs",
+                ".u3p",
+                ".vbscript"
         };
 
         public AttachmentBlacklistBehavior(


### PR DESCRIPTION
Added any potentially executable windows files extensions missing which were defined at: https://aerorock.co.nz/list-of-executable-file-extensions-windows/