### PR TITLE
Bug fixes: admin permissions, message patterns error clarity, and new Discord threading permissions

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Update="Discord.Net" Version="2.4.0" />
     
-    <PackageReference Update="Remora.Discord.Commands"  Version="6.0.0" />
-    <PackageReference Update="Remora.Discord.Caching" Version="10.0.1" />
+    <PackageReference Update="Remora.Discord.Caching" Version="12.1.2" />
+    <PackageReference Update="Remora.Discord.Commands" Version="10.0.3" />
 
     <PackageReference Update="Microsoft.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="5.0.0"/>

--- a/Modix.RemoraShim/Commands/MessageCheckCommands.cs
+++ b/Modix.RemoraShim/Commands/MessageCheckCommands.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Modix.Data.Models.Core;
 using Modix.Data.Models.Moderation;
+using Modix.RemoraShim.Models;
 using Modix.RemoraShim.Parsers;
 using Modix.RemoraShim.Services;
 using Modix.Services.Core;
@@ -59,7 +60,7 @@ namespace Modix.RemoraShim.Commands
 
             if (!canViewPatterns)
             {
-                await _channelApi.CreateMessageAsync(_context.ChannelID, $"{_context.User.ID} does not have permission to view patterns blocked or allowed in {_context.GuildID}!");
+                await _channelApi.CreateMessageAsync(_context.ChannelID, $"<@!{_context.User.ID}> does not have permission to view patterns blocked or allowed in guild {_context.GuildID.Value.Value}!", allowedMentions: new NoAllowedMentions());
                 return Result.FromError(new InvalidOperationError("You do not have permission to view patterns blocked or allowed in this guild!"));
             }
 
@@ -67,7 +68,7 @@ namespace Modix.RemoraShim.Commands
 
             if (!patterns.Any())
             {
-                await _channelApi.CreateMessageAsync(_context.ChannelID, $"{_context.GuildID} does not have any patterns set up, get started with `!pattern block` or `!pattern allow`");
+                await _channelApi.CreateMessageAsync(_context.ChannelID, $"Guild {_context.GuildID.Value.Value} does not have any patterns set up, get started with `!pattern block` or `!pattern allow`");
                 return Result.FromError(new InvalidOperationError("This guild does not have any patterns set up, get started with `!pattern block` or `!pattern allow`"));
             }
 

--- a/Modix.RemoraShim/Commands/Setup.cs
+++ b/Modix.RemoraShim/Commands/Setup.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
+using Modix.RemoraShim.ExecutionEvents;
 using Modix.RemoraShim.Parsers;
 
 using Remora.Commands.Extensions;
@@ -13,6 +14,7 @@ namespace Modix.RemoraShim.Commands
             => services
                 .AddDiscordCommands()
                 .AddParsers()
+                .AddExecutionEvents()
                 .AddCommandGroup<ModerationCommands>()
                 .AddCommandGroup<MessageCheckCommands>();
     }

--- a/Modix.RemoraShim/ExecutionEvents/AuthorizationExecutionEvent.cs
+++ b/Modix.RemoraShim/ExecutionEvents/AuthorizationExecutionEvent.cs
@@ -1,8 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.Extensions.DependencyInjection;
-
 using Modix.RemoraShim.Errors;
 using Modix.RemoraShim.Services;
 
@@ -10,22 +8,18 @@ using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Services;
 using Remora.Results;
 
-namespace Modix.RemoraShim.ExecutionEventServices
+namespace Modix.RemoraShim.ExecutionEvents
 {
     /// <summary>
     /// Ensures that the command user is authenticated in the authorization service before a command is invoked.
     /// </summary>
-    [ServiceBinding(ServiceLifetime.Scoped)]
-    internal class AuthorizationExecutionEventService : IExecutionEventService
+    internal class AuthorizationExecutionEvent : IPreExecutionEvent
     {
-        public AuthorizationExecutionEventService(
+        public AuthorizationExecutionEvent(
             IAuthorizationContextService requestAuthorizationService)
         {
             _requestAuthorizationService = requestAuthorizationService;
         }
-
-        public Task<Result> AfterExecutionAsync(ICommandContext context, IResult executionResult, CancellationToken ct = default)
-            => Task.FromResult(Result.FromSuccess());
 
         public async Task<Result> BeforeExecutionAsync(ICommandContext context, CancellationToken ct = default)
         {

--- a/Modix.RemoraShim/ExecutionEvents/Setup.cs
+++ b/Modix.RemoraShim/ExecutionEvents/Setup.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+using Remora.Discord.Commands.Extensions;
+
+namespace Modix.RemoraShim.ExecutionEvents
+{
+    public static class Setup
+    {
+        public static IServiceCollection AddExecutionEvents(this IServiceCollection services)
+            => services
+                .AddPreExecutionEvent<AuthorizationExecutionEvent>()
+                .AddPreExecutionEvent<ThreadContextExecutionEvent>();
+    }
+}

--- a/Modix.RemoraShim/ExecutionEvents/ThreadContextExecutionEvent.cs
+++ b/Modix.RemoraShim/ExecutionEvents/ThreadContextExecutionEvent.cs
@@ -1,8 +1,6 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.Extensions.DependencyInjection;
-
 using Modix.RemoraShim.Errors;
 
 using Remora.Discord.API.Abstractions.Rest;
@@ -10,22 +8,18 @@ using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Services;
 using Remora.Results;
 
-namespace Modix.RemoraShim.ExecutionEventServices
+namespace Modix.RemoraShim.ExecutionEvents
 {
     /// <summary>
     /// Ensures that shim commands are never invoked outside of a thread.
     /// </summary>
-    [ServiceBinding(ServiceLifetime.Scoped)]
-    internal class ThreadContextExecutionEventService : IExecutionEventService
+    internal class ThreadContextExecutionEvent : IPreExecutionEvent
     {
-        public ThreadContextExecutionEventService(
+        public ThreadContextExecutionEvent(
             IDiscordRestChannelAPI channelApi)
         {
             _channelApi = channelApi;
         }
-
-        public Task<Result> AfterExecutionAsync(ICommandContext context, IResult executionResult, CancellationToken ct = default)
-            => Task.FromResult(Result.FromSuccess());
 
         public async Task<Result> BeforeExecutionAsync(ICommandContext context, CancellationToken ct = default)
         {

--- a/Modix.RemoraShim/Parsers/Setup.cs
+++ b/Modix.RemoraShim/Parsers/Setup.cs
@@ -10,7 +10,7 @@ namespace Modix.RemoraShim.Parsers
     {
         public static IServiceCollection AddParsers(this IServiceCollection services)
             => services
-                .AddParser<UserOrMessageAuthor, UserOrMessageAuthorParser>()
-                .AddParser<TimeSpan, TimeSpanParser>();
+                .AddParser<UserOrMessageAuthorParser>()
+                .AddParser<TimeSpanParser>();
     }
 }

--- a/Modix.RemoraShim/Parsers/TimeSpanParser.cs
+++ b/Modix.RemoraShim/Parsers/TimeSpanParser.cs
@@ -10,7 +10,7 @@ namespace Modix.RemoraShim.Parsers
 {
     internal class TimeSpanParser : AbstractTypeParser<TimeSpan>
     {
-        public override ValueTask<Result<TimeSpan>> TryParse(string value, CancellationToken ct)
+        public override ValueTask<Result<TimeSpan>> TryParseAsync(string? value, CancellationToken ct)
         {
             return Parse(value);
 

--- a/Modix.RemoraShim/Parsers/UserOrMessageAuthorParser.cs
+++ b/Modix.RemoraShim/Parsers/UserOrMessageAuthorParser.cs
@@ -35,11 +35,11 @@ namespace Modix.RemoraShim.Parsers
             _userApi = userApi;
         }
 
-        public override async ValueTask<Result<UserOrMessageAuthor>> TryParse(string value, CancellationToken ct)
+        public override async ValueTask<Result<UserOrMessageAuthor>> TryParseAsync(string? value, CancellationToken ct)
         {
             ct.ThrowIfCancellationRequested();
 
-            value = value.Trim(',', '.');
+            value = value?.Trim(',', '.') ?? string.Empty;
 
             // value could be:
             // - user ID

--- a/Modix.RemoraShim/Responders/MuteRoleConfigurationResponder.cs
+++ b/Modix.RemoraShim/Responders/MuteRoleConfigurationResponder.cs
@@ -157,6 +157,7 @@ namespace Modix.RemoraShim.Responders
             DiscordPermission.RequestToSpeak,
             DiscordPermission.UsePublicThreads,
             DiscordPermission.UsePrivateThreads,
+            (DiscordPermission)38, // TODO: update this when https://github.com/Nihlus/Remora.Discord/pull/91 is merged 
         };
 
         private static readonly DiscordPermissionSet _muteDeniedPermissionSet;

--- a/Modix.RemoraShim/Responders/MuteRoleConfigurationResponder.cs
+++ b/Modix.RemoraShim/Responders/MuteRoleConfigurationResponder.cs
@@ -157,7 +157,7 @@ namespace Modix.RemoraShim.Responders
             DiscordPermission.RequestToSpeak,
             DiscordPermission.UsePublicThreads,
             DiscordPermission.UsePrivateThreads,
-            (DiscordPermission)38, // TODO: update this when https://github.com/Nihlus/Remora.Discord/pull/91 is merged 
+            (DiscordPermission)38, // SendMessagesInThreads, TODO: update this when https://github.com/Nihlus/Remora.Discord/pull/91 is merged 
         };
 
         private static readonly DiscordPermissionSet _muteDeniedPermissionSet;


### PR DESCRIPTION
Upgrade Remora to the latest version and implement the following bug fixes:
* Fix a regression that caused admins and MODiX not to implicitly have every claim
* Slightly improve error messages in `!pattern list` (shows a user mention instead of just the raw ID, shows the guild ID value instead of `ToString`ing the Snowflake)
* Add support for the new `SendMessagesInThreads` permission recently added to Discord (in particular, denies that permission to the mute role)