### PR TITLE
Fix !link, add !sharplab as an alias, add support for IL links, add unit tests

### DIFF
--- a/Modix.Services.Test/UtilityTests/FormatCodeForEmbedTests.cs
+++ b/Modix.Services.Test/UtilityTests/FormatCodeForEmbedTests.cs
@@ -1,0 +1,288 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Humanizer;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Modix.Services.Utilities;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Modix.Services.Test.UtilityTests
+{
+    [TestFixture]
+    public class FormatCodeForEmbedTests
+    {
+        [Test]
+        public void TestCSharp()
+        {
+            var source =
+@"#nullable enable
+
+var c = new C();
+c.M(c = null, $"");
+c.ToString();
+
+class C
+{
+    public void M(object? o1, [InterpolatedStringHandlerArgument("")] CustomHandler c) => throw null!;
+}
+
+[InterpolatedStringHandler]
+struct CustomHandler
+{
+    public CustomHandler(int literalLength, int formattedCount, [NotNull] C? o){}
+}
+";
+
+            var expected =
+@"```cs
+#nullable enable
+var c = new C();
+c.M(c = null, $"");
+c.ToString();
+class C {
+    public void M(object? o1, [InterpolatedStringHandlerAr...
+}
+[InterpolatedStringHandler]
+struct CustomHandler {
+    public CustomHandler(int literalLength, int formattedC...
+}
+```";
+
+            Verify("cs", source, expected);
+        }
+
+        [Test]
+        public void TestVisualBasic()
+        {
+            var source =
+@"Imports System
+Imports System.Threading.Tasks
+Public Class C
+    Public Sub M()
+        Console.WriteLine(""something"")
+        Console.WriteLine(""Hello this is a long line of test to test the truncation feature"")
+        Console.WriteLine(""something"")
+    End Sub
+
+
+    Public Async Function SomeFunction(arg As Double) As Task
+        Console.WriteLine(""something"")
+        Await Task.Delay(arg)
+        Console.WriteLine(""something"")
+    End Function
+End Class
+";
+
+            var expected =
+@"```vb
+Imports System
+Imports System.Threading.Tasks
+Public Class C
+    Public Sub M()
+        Console.WriteLine(""something"")
+        Console.WriteLine(""Hello this is a long line of te...
+        Console.WriteLine(""something"")
+    End Sub
+    Public Async Function SomeFunction(arg As Double) As T...
+        Console.WriteLine(""something"")
+' 4 more lines. Follow the link to view.
+```";
+
+            Verify("vb", source, expected);
+        }
+
+        [Test]
+        public void TestFSharp()
+        {
+            var source =
+@"open System
+
+let printMessage name =
+    printfn $""Hello there, {name}!""
+
+let printNames names =
+    for name in names do
+        printMessage name
+
+let names = [ ""Ana""; ""Felipe""; ""Emillia"" ]
+printNames names
+";
+
+            var expected =
+@"```fs
+open System
+let printMessage name =
+    printfn $""Hello there, {name}!""
+let printNames names =
+    for name in names do
+        printMessage name
+let names = [ ""Ana""; ""Felipe""; ""Emillia"" ]
+printNames names
+```";
+
+            Verify("fs", source, expected);
+        }
+
+        [Test]
+        public void TestIL()
+        {
+            var source =
+@".assembly A
+{
+}
+
+.class public auto ansi abstract sealed beforefieldinit C
+    extends System.Object
+{
+    .method public hidebysig static
+        void M () cil managed
+    {
+        .maxstack 8
+
+        ret
+    }
+}
+";
+
+            var expected =
+@"```il
+.assembly A {
+}
+.class public auto ansi abstract sealed beforefieldinit C
+    extends System.Object {
+    .method public hidebysig static
+        void M () cil managed {
+        .maxstack 8
+        ret
+    }
+}
+```";
+
+            Verify("il", source, expected);
+        }
+
+        [Test]
+        public void TestCSharpWithMaxLength()
+        {
+            var source =
+@"
+public class C {
+    uint[] s_crcTable = new uint[256];
+        
+    public uint Crc32C(uint crc, uint data)
+    {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        Unsafe.WriteUnaligned(ref MemoryMarshal.GetReference(bytes), data);
+
+        foreach (byte b in bytes)
+        {
+            int tableIndex = (int)((crc ^ b) & 0xFF);
+            crc = s_crcTable[tableIndex] ^ (crc >> 8);
+        }
+
+        return crc;
+    }
+    
+    public uint Crc32C2(uint crc, uint data)
+    {
+        if (!BitConverter.IsLittleEndian)
+            data = BinaryPrimitives.ReverseEndianness(data);
+
+        ref uint lut = ref MemoryMarshal.GetArrayDataReference(s_crcTable);
+        
+        for (int i = 0; i < sizeof(uint); i++)
+        {
+            crc = Unsafe.Add(ref lut, (nuint)(byte)(crc ^ (byte)data)) ^ (crc >> 8);
+            data >>= 8;
+        }
+
+        return crc;
+    }
+
+    public uint Crc32C3(uint crc, uint data)
+    {
+        if (!BitConverter.IsLittleEndian)
+            data = BinaryPrimitives.ReverseEndianness(data);
+
+        ref uint lut = ref MemoryMarshal.GetArrayDataReference(s_crcTable);
+        
+        crc = Unsafe.Add(ref lut, (nuint)(byte)(crc ^ (byte)data)) ^ (crc >> 8);
+        data >>= 8;
+        crc = Unsafe.Add(ref lut, (nuint)(byte)(crc ^ (byte)data)) ^ (crc >> 8);
+        data >>= 8;
+        crc = Unsafe.Add(ref lut, (nuint)(byte)(crc ^ (byte)data)) ^ (crc >> 8);
+        data >>= 8;
+        crc = Unsafe.Add(ref lut, (nuint)(byte)(crc ^ data)) ^ (crc >> 8);
+
+        return crc;
+    }
+
+    public uint Crc32C4(uint crc, uint data)
+    {
+        if (!BitConverter.IsLittleEndian)
+            data = BinaryPrimitives.ReverseEndianness(data);
+
+        ref uint lut = ref MemoryMarshal.GetArrayDataReference(s_crcTable);
+        
+        return Crc32CImpl(ref lut, crc, data);
+    }
+
+    public uint Crc32C4(uint crc, ulong data)
+    {
+        if (!BitConverter.IsLittleEndian)
+            data = BinaryPrimitives.ReverseEndianness(data);
+
+        ref uint lut = ref MemoryMarshal.GetArrayDataReference(s_crcTable);
+        
+        crc = Crc32CImpl(ref lut, crc, (uint)data);
+        data >>= 32;
+        crc = Crc32CImpl(ref lut, crc, (uint)data);
+        
+        return crc;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint Crc32CImpl(ref uint lut, uint crc, uint data)
+    {
+        crc = Unsafe.Add(ref lut, (nuint)(byte)(crc ^ (byte)data)) ^ (crc >> 8);
+        data >>= 8;
+        crc = Unsafe.Add(ref lut, (nuint)(byte)(crc ^ (byte)data)) ^ (crc >> 8);
+        data >>= 8;
+        crc = Unsafe.Add(ref lut, (nuint)(byte)(crc ^ (byte)data)) ^ (crc >> 8);
+        data >>= 8;
+        crc = Unsafe.Add(ref lut, (nuint)(byte)(crc ^ data)) ^ (crc >> 8);
+        
+        return crc;
+    }
+}
+";
+
+            var expected =
+@"```cs
+public class C {
+    uint[] s_crcTable = new uint[256];
+    public uint Crc32C(uint crc, uint data) {
+        Span<byte> bytes = stackalloc byte[sizeof(uint)];
+        Unsafe.WriteUnaligned(ref MemoryMarshal.GetReferen...
+// 63 more lines. Follow the link to view.
+```";
+
+            VerifyWithLength("cs", 293, source, expected);
+        }
+
+        private void Verify(string language, string source, string expected)
+        {
+            var actual = FormatUtilities.FormatCodeForEmbed(language, source, 2048);
+            actual.ShouldBe(expected.Replace("\r", string.Empty));
+        }
+
+        private void VerifyWithLength(string language, int length, string source, string expected)
+        {
+            var actual = FormatUtilities.FormatCodeForEmbed(language, source, length);
+            actual.ShouldBe(expected.Replace("\r", string.Empty));
+        }
+    }
+}

--- a/Modix.Services/Utilities/FormatUtilities.cs
+++ b/Modix.Services/Utilities/FormatUtilities.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Net;
@@ -226,5 +227,139 @@ namespace Modix.Services.Utilities
 
         private static readonly Regex _containsSpoilerRegex
             = new Regex(@"\|\|.+\|\|", RegexOptions.Compiled);
+
+#nullable enable
+        public static string FormatCodeForEmbed(string language, string sourceCode, int maxLength)
+        {
+            if (maxLength <= 0)
+                return string.Empty;
+
+            // Trim, for good measure
+            sourceCode = sourceCode.Trim();
+            var processedLines = new List<string>();
+            var braceOnlyLinesEliminated = 0;
+            var currentLength = 0;
+
+            var lines = sourceCode
+                .Replace("\r", string.Empty)
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.TrimEnd())
+                .Where(x => !string.IsNullOrEmpty(x))
+                .ToImmutableArray();
+
+            // Embeds always end up being too long and then messy to display in chat. They also disrupt conversations
+            // a lot as they just end up being a huge wall of text out of nowhere. To account for this, we will:
+            //   - Trim all lines at the right side
+            //   - Remove blank lines
+            //   - Change all single-line opening brackets to be on the previous line instead
+            //   - Clip every line to the maximum length in an embed
+            //   - Clip the total number of lines to 10
+            //   - If there's more, add a comment indicating the number of remaining lines
+            foreach (var line in lines)
+            {
+                const int MaxLineLength = 61;
+
+                if (line.Length < MaxLineLength - 1)
+                {
+                    if (line.EndsWith('{') &&
+                        string.IsNullOrWhiteSpace(line[..^1]) &&
+                        processedLines.Count > 0)
+                    {
+                        if (!TryReplaceLine(^1, processedLines[^1] + " {"))
+                        {
+                            AddRemainingLineComment();
+                            break;
+                        }
+                        braceOnlyLinesEliminated++;
+                    }
+                    else if (!TryAddLine(line))
+                    {
+                        AddRemainingLineComment();
+                        break;
+                    }
+                }
+                else
+                {
+                    if (!TryAddLine(line[..(MaxLineLength - 3)] + "..."))
+                    {
+                        AddRemainingLineComment();
+                        break;
+                    }
+                }
+
+                if (processedLines.Count == 10)
+                {
+                    var remainingCount = GetRemainingLineCount();
+
+                    // Might as well just add the last line to the embed,
+                    // since we'd just be adding a "1 more line" line otherwise.
+                    // We'd be adding a line either way, so we should go with the
+                    // more useful option.
+                    if (remainingCount == 1)
+                        continue;
+
+                    if (remainingCount <= 0)
+                        break;
+
+                    AddRemainingLineComment();
+                    break;
+                }
+            }
+
+            var code = string.Join('\n', processedLines);
+            return Format.Code(code, language);
+
+            bool TryAddLine(string line)
+            {
+                var remainingCount = GetRemainingLineCount();
+                var possibleRemainingLineCommentLength = remainingCount > 1 // 1, because the current line is included in the count
+                    ? GetRemainingLineCountComment(remainingCount).Length
+                    : 0;
+
+                if (line.Length + currentLength + possibleRemainingLineCommentLength + 1 > maxLength) // +1 because of the newline that will be added later
+                    return false;
+
+                processedLines.Add(line);
+                currentLength += line.Length + 1; // +1 because of the newline that will be added later
+                return true;
+            }
+
+            bool TryReplaceLine(Index index, string line)
+            {
+                var remainingCount = GetRemainingLineCount();
+                var possibleRemainingLineCommentLength = remainingCount > 1 // 1, because the current line is included in the count
+                    ? GetRemainingLineCountComment(remainingCount).Length
+                    : 0;
+
+                var lengthDifference = line.Length - processedLines[index].Length;
+
+                if (lengthDifference + currentLength + possibleRemainingLineCommentLength > maxLength)
+                    return false;
+
+                processedLines[index] = line;
+                currentLength += lengthDifference;
+                return true;
+            }
+
+            int GetRemainingLineCount()
+                => lines.Length - processedLines.Count - braceOnlyLinesEliminated;
+
+            string GetRemainingLineCountComment(int remainingCount)
+            {
+                var commentStart = language switch
+                {
+                    "vb" => "'",
+                    _ => "//",
+                };
+
+                return $"{commentStart} {remainingCount} more lines. Follow the link to view.";
+            }
+
+            void AddRemainingLineComment()
+            {
+                processedLines.Add(GetRemainingLineCountComment(GetRemainingLineCount()));
+            }
+        }
+#nullable restore
     }
 }

--- a/Modix.Services/Utilities/FormatUtilities.cs
+++ b/Modix.Services/Utilities/FormatUtilities.cs
@@ -327,7 +327,7 @@ namespace Modix.Services.Utilities
             bool TryReplaceLine(Index index, string line)
             {
                 var remainingCount = GetRemainingLineCount();
-                var possibleRemainingLineCommentLength = remainingCount > 1 // 1, because the current line is included in the count
+                var possibleRemainingLineCommentLength = remainingCount > 0
                     ? GetRemainingLineCountComment(remainingCount).Length
                     : 0;
 


### PR DESCRIPTION
- Fixes display errors in !link so that code previews should be displayed properly
- Added additional defensive checks for description length to avoid the "Error: Description length must be less than or equal to 2048. (Parameter 'Description')" error
- Added !sharplab as an alias
- Added support for IL links
- Added unit tests to help prevent future regressions