### PR TITLE
Prioritize transferring tags to roles over transferring to users

### DIFF
--- a/Modix.Bot/Modules/TagModule.cs
+++ b/Modix.Bot/Modules/TagModule.cs
@@ -195,6 +195,7 @@ namespace Modix.Bot.Modules
         }
 
         [Command("transfer")]
+        [Priority(-5)] // Prioritize role over user to avoid people accidentally transferring tags to someone whose nickname is the same as a role's name
         [Summary("Transfers ownership of a tag to the supplied user.")]
         public async Task TransferToUserAsync(
             [Summary("The name of the tag to be transferred.")]


### PR DESCRIPTION
This prevents accidentally transferring to someone who nicknames themselves "Associate", and it fixes an error that was occurring when trying to transfer to a role by calling the command using a snowflake ID.