### PR TITLE
Track threads in the GuildChannels table

### DIFF
--- a/Modix.Data/Migrations/20220816165140_ParentChannelId.Designer.cs
+++ b/Modix.Data/Migrations/20220816165140_ParentChannelId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Modix.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -9,9 +10,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Modix.Data.Migrations
 {
     [DbContext(typeof(ModixContext))]
-    partial class ModixContextModelSnapshot : ModelSnapshot
+    [Migration("20220816165140_ParentChannelId")]
+    partial class ParentChannelId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modix.Data/Migrations/20220816165140_ParentChannelId.cs
+++ b/Modix.Data/Migrations/20220816165140_ParentChannelId.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Modix.Data.Migrations
+{
+    public partial class ParentChannelId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "ParentChannelId",
+                table: "GuildChannels",
+                type: "bigint",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ParentChannelId",
+                table: "GuildChannels");
+        }
+    }
+}

--- a/Modix.Data/Models/Core/GuildChannelBrief.cs
+++ b/Modix.Data/Models/Core/GuildChannelBrief.cs
@@ -20,12 +20,18 @@ namespace Modix.Data.Models.Core
         /// </summary>
         public string Name { get; set; } = null!;
 
+        /// <summary>
+        /// See <see cref="GuildChannelEntity.ParentChannelId"/>.
+        /// </summary>
+        public ulong? ParentChannelId { get; set; }
+
         [ExpansionExpression]
         internal static Expression<Func<GuildChannelEntity, GuildChannelBrief>> FromEntityProjection
             = entity => new GuildChannelBrief()
             {
                 Id = entity.ChannelId,
-                Name = entity.Name
+                Name = entity.Name,
+                ParentChannelId = entity.ParentChannelId,
             };
     }
 }

--- a/Modix.Data/Models/Core/GuildChannelCreationData.cs
+++ b/Modix.Data/Models/Core/GuildChannelCreationData.cs
@@ -20,12 +20,18 @@
         /// </summary>
         public string Name { get; set; } = null!;
 
+        /// <summary>
+        /// See <see cref="GuildChannelEntity.ParentChannelId"/>.
+        /// </summary>
+        public ulong? ParentChannelId { get; set; }
+
         internal GuildChannelEntity ToEntity()
             => new GuildChannelEntity()
             {
                 ChannelId = ChannelId,
                 GuildId = GuildId,
-                Name = Name
+                Name = Name,
+                ParentChannelId = ParentChannelId,
             };
     }
 }

--- a/Modix.Data/Models/Core/GuildChannelEntity.cs
+++ b/Modix.Data/Models/Core/GuildChannelEntity.cs
@@ -19,6 +19,8 @@ namespace Modix.Data.Models.Core
         [Required]
         public string Name { get; set; } = null!;
 
+        public ulong? ParentChannelId { get; set; }
+
         public ICollection<DesignatedChannelMappingEntity> DesignatedChannelMappings { get; set; }
             = new HashSet<DesignatedChannelMappingEntity>();
     }
@@ -35,6 +37,10 @@ namespace Modix.Data.Models.Core
 
             entityTypeBuilder
                 .Property(x => x.GuildId)
+                .HasConversion<long>();
+
+            entityTypeBuilder
+                .Property(x => x.ParentChannelId)
                 .HasConversion<long>();
         }
     }

--- a/Modix.Data/Models/Core/GuildChannelMutationData.cs
+++ b/Modix.Data/Models/Core/GuildChannelMutationData.cs
@@ -10,15 +10,22 @@
         /// </summary>
         public string Name { get; set; } = null!;
 
+        /// <summary>
+        /// See <see cref="GuildChannelEntity.ParentChannelId"/>
+        /// </summary>
+        public ulong? ParentChannelId { get; set; }
+
         internal static GuildChannelMutationData FromEntity(GuildChannelEntity entity)
             => new GuildChannelMutationData()
             {
-                Name = entity.Name
+                Name = entity.Name,
+                ParentChannelId = entity.ParentChannelId,
             };
 
         internal void ApplyTo(GuildChannelEntity entity)
         {
             entity.Name = Name;
+            entity.ParentChannelId = ParentChannelId;
         }
     }
 }

--- a/Modix.Data/Repositories/GuildChannelRepository.cs
+++ b/Modix.Data/Repositories/GuildChannelRepository.cs
@@ -70,7 +70,7 @@ namespace Modix.Data.Repositories
 
             var entity = data.ToEntity();
 
-            await ModixContext.Set<GuildChannelEntity>().AddAsync(entity, cancellationToken);
+            ModixContext.Set<GuildChannelEntity>().Add(entity);
             await ModixContext.SaveChangesAsync(cancellationToken);
         }
 

--- a/Modix.Services.Test/Core/ChannelServiceTests.cs
+++ b/Modix.Services.Test/Core/ChannelServiceTests.cs
@@ -57,7 +57,7 @@ namespace Modix.Services.Test.Core
                     .Setup(x => x.Name)
                     .Returns(channelName);
 
-                await uut.TrackChannelAsync(mockChannel.Object.Name, mockChannel.Object.Id, mockChannel.Object.GuildId, cancellationTokenSource.Token);
+                await uut.TrackChannelAsync(mockChannel.Object.Name, mockChannel.Object.Id, mockChannel.Object.GuildId, null, cancellationTokenSource.Token);
 
                 mockGuildChannelRepository
                     .ShouldHaveReceived(x => x.BeginCreateTransactionAsync(cancellationTokenSource.Token), Times.Once());
@@ -127,7 +127,7 @@ namespace Modix.Services.Test.Core
                     .Setup(x => x.Name)
                     .Returns(channelName);
 
-                await uut.TrackChannelAsync(mockChannel.Object.Name, mockChannel.Object.Id, mockChannel.Object.GuildId, cancellationTokenSource.Token);
+                await uut.TrackChannelAsync(mockChannel.Object.Name, mockChannel.Object.Id, mockChannel.Object.GuildId, null, cancellationTokenSource.Token);
 
                 mockGuildChannelRepository
                     .ShouldHaveReceived(x => x.BeginCreateTransactionAsync(cancellationTokenSource.Token), Times.Once());

--- a/Modix.Services/Core/ChannelService.cs
+++ b/Modix.Services/Core/ChannelService.cs
@@ -17,7 +17,7 @@ namespace Modix.Services.Core
         /// <param name="channel">The channel whose info is to be tracked.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> that may be used to cancel the returned <see cref="Task"/> before it completes.</param>
         /// <returns>A <see cref="Task"/> that will complete when the operation has completed.</returns>
-        Task TrackChannelAsync(string channelName, ulong channelId, ulong guildId, CancellationToken cancellationToken = default);
+        Task TrackChannelAsync(string channelName, ulong channelId, ulong guildId, ulong? parentChannelId, CancellationToken cancellationToken = default);
     }
 
     /// <inheritdoc />
@@ -33,25 +33,26 @@ namespace Modix.Services.Core
         }
 
         /// <inheritdoc />
-        public async Task TrackChannelAsync(string channelName, ulong channelId, ulong guildId, CancellationToken cancellationToken = default)
+        public async Task TrackChannelAsync(string channelName, ulong channelId, ulong guildId, ulong? parentChannelId, CancellationToken cancellationToken = default)
         {
-            using (var transaction = await _guildChannelRepository.BeginCreateTransactionAsync(cancellationToken))
-            {
-                if (!await _guildChannelRepository.TryUpdateAsync(channelId, data =>
-                {
-                    data.Name = channelName;
-                }, cancellationToken))
-                {
-                    await _guildChannelRepository.CreateAsync(new GuildChannelCreationData()
-                    {
-                        ChannelId = channelId,
-                        GuildId = guildId,
-                        Name = channelName
-                    }, cancellationToken);
-                }
+            using var transaction = await _guildChannelRepository.BeginCreateTransactionAsync(cancellationToken);
 
-                transaction.Commit();
+            if (!await _guildChannelRepository.TryUpdateAsync(channelId, data =>
+            {
+                data.Name = channelName;
+                data.ParentChannelId = parentChannelId;
+            }, cancellationToken))
+            {
+                await _guildChannelRepository.CreateAsync(new GuildChannelCreationData()
+                {
+                    ChannelId = channelId,
+                    GuildId = guildId,
+                    Name = channelName,
+                    ParentChannelId = parentChannelId,
+                }, cancellationToken);
             }
+
+            transaction.Commit();
         }
 
         private readonly IGuildChannelRepository _guildChannelRepository;

--- a/Modix.Services/Core/DiscordSocketListeningBehavior.cs
+++ b/Modix.Services/Core/DiscordSocketListeningBehavior.cs
@@ -1,10 +1,10 @@
-﻿using System.Threading.Tasks;
-using System.Threading;
-
-using Microsoft.Extensions.Hosting;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 using Discord;
 using Discord.WebSocket;
+
+using Microsoft.Extensions.Hosting;
 
 using Modix.Common.Messaging;
 
@@ -44,6 +44,8 @@ namespace Modix.Services.Core
             DiscordSocketClient.Ready += OnReadyAsync;
             DiscordSocketClient.RoleCreated += OnRoleCreatedAsync;
             DiscordSocketClient.RoleUpdated += OnRoleUpdatedAsync;
+            DiscordSocketClient.ThreadCreated += OnThreadCreatedAsync;
+            DiscordSocketClient.ThreadUpdated += OnThreadUpdatedAsync;
             DiscordSocketClient.UserBanned += OnUserBannedAsync;
             DiscordSocketClient.UserJoined += OnUserJoinedAsync;
             DiscordSocketClient.UserLeft += OnUserLeftAsync;
@@ -66,6 +68,8 @@ namespace Modix.Services.Core
             DiscordSocketClient.ReactionAdded -= OnReactionAddedAsync;
             DiscordSocketClient.ReactionRemoved -= OnReactionRemovedAsync;
             DiscordSocketClient.Ready -= OnReadyAsync;
+            DiscordSocketClient.ThreadCreated -= OnThreadCreatedAsync;
+            DiscordSocketClient.ThreadUpdated -= OnThreadUpdatedAsync;
             DiscordSocketClient.UserBanned -= OnUserBannedAsync;
             DiscordSocketClient.UserJoined -= OnUserJoinedAsync;
             DiscordSocketClient.UserLeft -= OnUserLeftAsync;
@@ -170,6 +174,20 @@ namespace Modix.Services.Core
         private Task OnRoleUpdatedAsync(SocketRole oldRole, SocketRole newRole)
         {
             MessageDispatcher.Dispatch(new RoleUpdatedNotification(oldRole, newRole));
+
+            return Task.CompletedTask;
+        }
+
+        private Task OnThreadCreatedAsync(SocketThreadChannel thread)
+        {
+            MessageDispatcher.Dispatch(new ThreadCreatedNotification(thread));
+
+            return Task.CompletedTask;
+        }
+
+        private Task OnThreadUpdatedAsync(Cacheable<SocketThreadChannel, ulong> oldThread, SocketThreadChannel newThread)
+        {
+            MessageDispatcher.Dispatch(new ThreadUpdatedNotification(oldThread, newThread));
 
             return Task.CompletedTask;
         }

--- a/Modix.Services/Core/Messages/ThreadCreatedNotification.cs
+++ b/Modix.Services/Core/Messages/ThreadCreatedNotification.cs
@@ -1,0 +1,6 @@
+﻿using Discord.WebSocket;
+
+namespace Discord
+{
+    public record ThreadCreatedNotification(SocketThreadChannel Thread);
+}

--- a/Modix.Services/Core/Messages/ThreadUpdatedNotification.cs
+++ b/Modix.Services/Core/Messages/ThreadUpdatedNotification.cs
@@ -1,0 +1,6 @@
+﻿using Discord.WebSocket;
+
+namespace Discord
+{
+    public record ThreadUpdatedNotification(Cacheable<SocketThreadChannel, ulong> OldThread, SocketThreadChannel NewThread);
+}

--- a/Modix.Services/Moderation/ModerationService.cs
+++ b/Modix.Services/Moderation/ModerationService.cs
@@ -445,12 +445,12 @@ namespace Modix.Services.Moderation
         public async Task DeleteMessageAsync(IMessage message, string reason, ulong deletedById,
             CancellationToken cancellationToken)
         {
-            if (!(message.Channel is IGuildChannel guildChannel))
+            if (message.Channel is not IGuildChannel guildChannel)
                 throw new InvalidOperationException(
                     $"Cannot delete message {message.Id} because it is not a guild message");
 
             await _userService.TrackUserAsync((IGuildUser)message.Author, cancellationToken);
-            await _channelService.TrackChannelAsync(guildChannel.Name, guildChannel.Id, guildChannel.GuildId, cancellationToken);
+            await _channelService.TrackChannelAsync(guildChannel.Name, guildChannel.Id, guildChannel.GuildId, guildChannel is IThreadChannel threadChannel ? threadChannel.CategoryId : null, cancellationToken);
 
             using var transaction = await _deletedMessageRepository.BeginCreateTransactionAsync(cancellationToken);
 
@@ -695,7 +695,7 @@ namespace Modix.Services.Moderation
             await channel.DeleteMessagesAsync(messages);
 
             using var transaction = await _deletedMessageBatchRepository.BeginCreateTransactionAsync();
-            await _channelService.TrackChannelAsync(channel.Name, channel.Id, channel.GuildId);
+            await _channelService.TrackChannelAsync(channel.Name, channel.Id, channel.GuildId, channel is IThreadChannel threadChannel ? threadChannel.CategoryId : null);
 
             await _deletedMessageBatchRepository.CreateAsync(new DeletedMessageBatchCreationData()
             {


### PR DESCRIPTION
Should fix the foreign key error we've been getting. Adds a ParentChannelId column to GuildChannels, stores a value in this column whenever we try to track a thread. Updates queries that reference messages or channels to use the ChannelId or ParentChannelId as needed (so for example, when we count user participation we count messages in forum threads toward the total message count of the forum itself).