### PR TITLE
Migrate tags and random commands to interactions

### DIFF
--- a/Modix.Bot/AutocompleteHandlers/TagAutocompleteHandler.cs
+++ b/Modix.Bot/AutocompleteHandlers/TagAutocompleteHandler.cs
@@ -1,0 +1,31 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Interactions;
+using Microsoft.Extensions.DependencyInjection;
+using Modix.Services.Tags;
+
+namespace Modix.Bot.AutocompleteHandlers
+{
+    public class TagAutocompleteHandler : AutocompleteHandler
+    {
+        private ITagCache? _tagCache;
+
+        public override Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context, IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter, IServiceProvider services)
+        {
+            var argument = autocompleteInteraction.Data.Current;
+            if (!argument.Focused || string.IsNullOrWhiteSpace((string)argument.Value))
+                return Task.FromResult(AutocompletionResult.FromSuccess());
+
+            _tagCache ??= services.GetRequiredService<ITagCache>();
+
+            var tags = _tagCache.Search(context.Guild.Id, (string)argument.Value, SlashCommandOptionBuilder.MaxChoiceCount)
+                .Select(x => new AutocompleteResult(x, x));
+
+            return Task.FromResult(AutocompletionResult.FromSuccess(tags));
+        }
+    }
+}

--- a/Modix.Bot/Behaviors/CommandListeningBehavior.cs
+++ b/Modix.Bot/Behaviors/CommandListeningBehavior.cs
@@ -82,7 +82,7 @@ namespace Modix.Bot.Behaviors
                     Log.Warning(error);
 
                 if (commandResult.Error == CommandError.Exception)
-                    await commandContext.Channel.SendMessageAsync($"Error: {FormatUtilities.SanitizeEveryone(commandResult.ErrorReason)}");
+                    await commandContext.Channel.SendMessageAsync($"Error: {commandResult.ErrorReason}", allowedMentions: AllowedMentions.None);
                 else
                     await CommandErrorHandler.AssociateErrorAsync(userMessage, error);
             }

--- a/Modix.Bot/Behaviors/InteractionListeningBehavior.cs
+++ b/Modix.Bot/Behaviors/InteractionListeningBehavior.cs
@@ -51,10 +51,8 @@ namespace Modix.Bot.Behaviors
 
             var stopwatch = Stopwatch.StartNew();
 
-            await _authorizationService.OnAuthenticatedAsync(author.Id, author.Guild.Id, author.RoleIds.ToArray());
-
             string interactionName;
-            bool isDeferred = false;
+            var isDeferred = false;
 
             switch (interaction)
             {
@@ -85,12 +83,16 @@ namespace Modix.Bot.Behaviors
                     interactionName = commandInfo?.ToString() ?? command.CommandName;
                     break;
                 case SocketModal modal:
+                    await interaction.DeferAsync();
+                    isDeferred = true;
                     interactionName = modal.Data.CustomId;
                     break;
                 default:
                     interactionName = interaction.Type.ToString();
                     break;
             }
+
+            await _authorizationService.OnAuthenticatedAsync(author.Id, author.Guild.Id, author.RoleIds.ToArray());
 
             var result = await _interactionService.ExecuteCommandAsync(context, _serviceProvider);
 

--- a/Modix.Bot/Extensions/ContextExtensions.cs
+++ b/Modix.Bot/Extensions/ContextExtensions.cs
@@ -35,8 +35,17 @@ namespace Modix.Bot.Extensions
             await context.Message.AddReactionAsync(_checkmarkEmoji);
         }
 
-        public static async Task AddConfirmationAsync(this IInteractionContext context)
-            => await context.Interaction.FollowupAsync($"\\{_checkmarkEmoji} Command successful.");
+        public static async Task AddConfirmationAsync(this IInteractionContext context, string? additionalText = null)
+        {
+            var message = $"\\{_checkmarkEmoji} Command successful. ";
+
+            if (!string.IsNullOrWhiteSpace(additionalText))
+            {
+                message += additionalText;
+            }
+
+            await context.Interaction.FollowupAsync(message, allowedMentions: AllowedMentions.None);
+        }
 
         public static async Task<bool> GetUserConfirmationAsync(this ICommandContext context, string mainMessage)
         {

--- a/Modix.Bot/Modules/DebugModule.cs
+++ b/Modix.Bot/Modules/DebugModule.cs
@@ -17,6 +17,7 @@ namespace Modix.Modules
     /// </summary>
     [Group("debug", "Used to test feature work on a private server. The contents of this module can be changed any time.")]
     [RequireUserPermission(GuildPermission.BanMembers)]
+    [DefaultMemberPermissions(GuildPermission.BanMembers)]
     [HiddenFromHelp]
     public class DebugModule : InteractionModuleBase
     {

--- a/Modix.Bot/Modules/InfractionModule.cs
+++ b/Modix.Bot/Modules/InfractionModule.cs
@@ -35,12 +35,17 @@ namespace Modix.Modules
 
         [MessageCommand("Infractions")]
         [RequireClaims(AuthorizationClaim.ModerationRead)]
+        // Discord doesn't currently give us many good options for default permissions.
+        // Would be much better if the bot could set role-based defaults instead.
+        // Goal is to at least make this not visible to ordinary users and visible to Associate+.
+        [DefaultMemberPermissions(GuildPermission.ManageEmojisAndStickers)]
         public async Task SearchAsync(IMessage message)
             => await SearchAsync(message.Author);
 
         [SlashCommand("infractions", "Displays all non-deleted infractions for a user.")]
         [UserCommand("Infractions")]
         [RequireClaims(AuthorizationClaim.ModerationRead)]
+        [DefaultMemberPermissions(GuildPermission.ManageEmojisAndStickers)]
         public async Task SearchAsync(
             [Summary(description: "The user whose infractions are to be displayed.")]
                 IUser? user = null)
@@ -118,6 +123,7 @@ namespace Modix.Modules
 
         [SlashCommand("infraction-delete", "Marks an infraction as deleted, so it no longer appears within infraction search results.")]
         [RequireClaims(AuthorizationClaim.ModerationDeleteInfraction)]
+        [DefaultMemberPermissions(GuildPermission.BanMembers)]
         public async Task DeleteAsync(
             [Summary(description: "The ID value of the infraction to be deleted.")]
                     long infractionId)
@@ -128,6 +134,7 @@ namespace Modix.Modules
 
         [SlashCommand("infraction-update", "Updates an infraction by ID, overwriting the existing reason.")]
         [RequireAnyClaim(AuthorizationClaim.ModerationUpdateInfraction, AuthorizationClaim.ModerationNote, AuthorizationClaim.ModerationWarn, AuthorizationClaim.ModerationMute, AuthorizationClaim.ModerationBan)]
+        [DefaultMemberPermissions(GuildPermission.ManageEmojisAndStickers)]
         public async Task UpdateAsync(
             [Summary(description: "The ID value of the infraction to be update.")]
                     long infractionId,

--- a/Modix.Bot/Modules/RandomModule.cs
+++ b/Modix.Bot/Modules/RandomModule.cs
@@ -3,12 +3,14 @@
     using System;
     using System.Threading.Tasks;
     using Discord;
-    using Discord.Commands;
+    using Discord.Interactions;
+    using Modix.Services.CommandHelp;
 
-    [Group("random"), Name("Random"), Summary("A bunch of random commands.")]
-    public class RandomModule : ModuleBase
+    [ModuleHelp("Random", "A bunch of commands related to randomness.")]
+    [Group("random", "A bunch of commands related to randomness.")]
+    public class RandomModule : InteractionModuleBase
     {
-        private static readonly Random _random = new Random();
+        private static readonly Random _random = new();
 
         private Embed GetEmbed(object description)
         {
@@ -18,11 +20,11 @@
                 .Build();
         }
 
-        [Command("number"), Summary("Gets a random number.")]
+        [SlashCommand("number", "Gets a random number.")]
         public async Task RandomNumberAsync(
-            [Summary("The inclusive minimum possible number.")]
+            [Summary(description: "The inclusive minimum possible number.")]
                 int min = 0,
-            [Summary("The exlusive maximum possible number.")]
+            [Summary(description: "The exlusive maximum possible number.")]
                 int max = 10)
         {
             if (min >= max)
@@ -33,39 +35,22 @@
 
             var number = _random.Next(min, max);
 
-            await Context.Channel.SendMessageAsync(embed: GetEmbed(number));
+            await FollowupAsync(embed: GetEmbed(number));
         }
 
-        [Command("coin"), Summary("Flips a coin.")]
+        [SlashCommand("coin", "Flips a coin.")]
         public async Task FlipCoinAsync()
         {
             var coin = _random.Next(0, 2);
 
             if (coin == 0)
             {
-                await Context.Channel.SendMessageAsync(embed: GetEmbed("Heads"));
+                await FollowupAsync(embed: GetEmbed("Heads"));
             }
             else
             {
-                await Context.Channel.SendMessageAsync(embed: GetEmbed("Tails"));
+                await FollowupAsync(embed: GetEmbed("Tails"));
             }
-        }
-
-        [Command("pick"), Summary("Picks from a defined list of inputs.")]
-        public async Task PickAsync(
-            [Summary("The items to choose from.")]
-                params string[] inputs)
-        {
-            if (inputs.Length <= 1)
-            {
-                await ReplyAsync("There isn't enough for me to choose from!");
-                return;
-            }
-
-            var random = _random.Next(0, inputs.Length);
-            var choice = inputs[random];
-
-            await ReplyAsync(embed: GetEmbed(choice));
         }
     }
 }

--- a/Modix.Services/Tags/TagCache.cs
+++ b/Modix.Services/Tags/TagCache.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Modix.Services.Tags
+{
+    public interface ITagCache
+    {
+        void Add(ulong guildId, string tagName);
+        void Remove(ulong guildId, string tagName);
+        void Set(ulong guildId, IEnumerable<string> tags);
+        ImmutableArray<string> Search(ulong guildId, string partialName, int? maxResults = null);
+    }
+
+    [ServiceBinding(ServiceLifetime.Singleton)]
+    internal class TagCache : ITagCache
+    {
+        private readonly IMemoryCache _cache;
+
+        private static readonly ReaderWriterLockSlim _cacheLock = new();
+
+        /// <summary>
+        /// For performance reasons, this class has as few dependencies as possible.
+        /// </summary>
+        public TagCache(IMemoryCache cache)
+        {
+            _cache = cache;
+        }
+
+        public void Add(ulong guildId, string tagName)
+        {
+            _cacheLock.EnterWriteLock();
+
+            try
+            {
+                var cachedTags = GetFromCache(guildId);
+                cachedTags.Add(tagName);
+            }
+            finally
+            {
+                _cacheLock.ExitWriteLock();
+            }
+        }
+
+        public void Remove(ulong guildId, string tagName)
+        {
+            _cacheLock.EnterWriteLock();
+
+            try
+            {
+                var cachedTags = GetFromCache(guildId);
+                cachedTags.Remove(tagName);
+            }
+            finally
+            {
+                _cacheLock.ExitWriteLock();
+            }
+        }
+
+        public void Set(ulong guildId, IEnumerable<string> tags)
+        {
+            _cacheLock.EnterWriteLock();
+
+            try
+            {
+                _cache.Set(GetCacheKey(guildId), new SortedSet<string>(tags));
+            }
+            finally
+            {
+                _cacheLock.ExitWriteLock();
+            }
+        }
+
+        public ImmutableArray<string> Search(ulong guildId, string partialName, int? maxResults = null)
+        {
+            if (string.IsNullOrWhiteSpace(partialName))
+                return ImmutableArray<string>.Empty;
+
+            _cacheLock.EnterReadLock();
+
+            try
+            {
+                var cachedTags = GetFromCache(guildId);
+
+                var results = cachedTags
+                    .Where(x => x.Contains(partialName, StringComparison.OrdinalIgnoreCase));
+
+                if (maxResults is not null)
+                {
+                    results = results.Take(maxResults.GetValueOrDefault());
+                }
+
+                return results.ToImmutableArray();
+            }
+            finally
+            {
+                _cacheLock.ExitReadLock();
+            }
+        }
+
+        private SortedSet<string> GetFromCache(ulong guildId)
+            => _cache.Get<SortedSet<string>>(GetCacheKey(guildId)) ?? new();
+
+        private static object GetCacheKey(ulong guildId)
+            => new { guildId, Target = "Tags" };
+    }
+}

--- a/Modix.Services/Tags/TagCachePopulatingBehavior.cs
+++ b/Modix.Services/Tags/TagCachePopulatingBehavior.cs
@@ -1,0 +1,38 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Discord;
+using Microsoft.Extensions.DependencyInjection;
+using Modix.Common.Messaging;
+
+namespace Modix.Services.Tags
+{
+    [ServiceBinding(ServiceLifetime.Scoped)]
+    public class TagCachePopulatingBehavior :
+        INotificationHandler<JoinedGuildNotification>,
+        INotificationHandler<GuildAvailableNotification>
+    {
+        private readonly ITagService _tagService;
+
+        public TagCachePopulatingBehavior(ITagService tagService)
+        {
+            _tagService = tagService;
+        }
+
+        public async Task HandleNotificationAsync(JoinedGuildNotification notification, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (notification.Guild is not IGuild { Available: true } guild)
+                return;
+
+            await _tagService.RefreshCache(guild.Id);
+        }
+
+        public async Task HandleNotificationAsync(GuildAvailableNotification notification, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await _tagService.RefreshCache(notification.Guild.Id);
+        }
+    }
+}

--- a/Modix.Services/Tags/TagInlineParsingHandler.cs
+++ b/Modix.Services/Tags/TagInlineParsingHandler.cs
@@ -57,7 +57,7 @@ namespace Modix.Services.Tags
             try
             {
                 await AuthorizationService.OnAuthenticatedAsync(guildUser.Id, guildUser.Guild.Id, guildUser.Roles.Select(x => x.Id).ToList());
-                await TagService.UseTagAsync(guildUser.Guild.Id, userMessage.Channel.Id, tagName);
+                await TagService.UseTagAsync(guildUser.Guild.Id, userMessage.Channel.Id, tagName, message);
             }
             catch (InvalidOperationException ex)
             {

--- a/Modix.Services/Utilities/FormatUtilities.cs
+++ b/Modix.Services/Utilities/FormatUtilities.cs
@@ -116,29 +116,6 @@ namespace Modix.Services.Utilities
 
             return $"This user has {formatted}";
         }
-
-        public static string SanitizeAllMentions(string text)
-        {
-            var everyoneSanitized = SanitizeEveryone(text);
-            var userSanitized = SanitizeUserMentions(everyoneSanitized);
-            var roleSanitized = SanitizeRoleMentions(userSanitized);
-
-            return roleSanitized;
-        }
-
-        public static string SanitizeEveryone(string text)
-            => text.Replace("@everyone", "@\x200beveryone")
-                   .Replace("@here", "@\x200bhere");
-
-        public static string SanitizeUserMentions(string text)
-            => _userMentionRegex.Replace(text, "<@\x200b${Id}>");
-
-        public static string SanitizeRoleMentions(string text)
-            => _roleMentionRegex.Replace(text, "<@&\x200b${Id}>");
-
-        private static readonly Regex _userMentionRegex = new Regex("<@!?(?<Id>[0-9]+)>", RegexOptions.Compiled);
-
-        private static readonly Regex _roleMentionRegex = new Regex("<@&(?<Id>[0-9]+)>", RegexOptions.Compiled);
         
         /// <summary>
         /// Collapses plural forms into a "singular(s)"-type format.
@@ -226,7 +203,7 @@ namespace Modix.Services.Utilities
             => _containsSpoilerRegex.IsMatch(text);
 
         private static readonly Regex _containsSpoilerRegex
-            = new Regex(@"\|\|.+\|\|", RegexOptions.Compiled);
+            = new(@"\|\|.+\|\|", RegexOptions.Compiled);
 
 #nullable enable
         public static string FormatCodeForEmbed(string language, string sourceCode, int maxLength)


### PR DESCRIPTION
Next batch of slash command migrations. Migrates the following commands:
* /random number
* /random coin
* /tag create
* /tag update
* /tag delete
* /tag ownedbyuser
* /tag ownedbyrole
* /tag owner
* /tag list
* /tag transfer-user
* /tag transfer-role
* /tag search (new command)

Tag create and update commands open a modal window to allow for multiline tag content:
![image](https://user-images.githubusercontent.com/2829282/189770221-62ae8cfa-3273-4d25-97e1-e31a99aab481.png)

Commands that require you to provide a tag name have an autocomplete populated with tags from the current server:
![image](https://user-images.githubusercontent.com/2829282/189770379-64e2fe16-608a-46c4-a6ab-5cb80df8620b.png)
