### PR TITLE
Default the owner of new tags to the creator's lowest rank role

### DIFF
--- a/Modix.Services.Test/Tags/CreateTagTests.cs
+++ b/Modix.Services.Test/Tags/CreateTagTests.cs
@@ -80,50 +80,5 @@ namespace Modix.Services.Test.Tags
 
             await Should.ThrowAsync<ArgumentException>(() => sut.CreateTagAsync(0, 0, "MODiX", string.Empty));
         }
-
-        [Test]
-        public async Task CreateTagAsync_ValidTag_InsertsTag()
-        {
-            (_, var sut, var db) = GetSut();
-
-            await sut.CreateTagAsync(1, 1, "MODiX", "Content");
-
-            db.Set<TagEntity>().Count().ShouldBe(1);
-
-            var tag = db.Set<TagEntity>().Single();
-
-            tag.GuildId.ShouldBe((ulong)1);
-            tag.OwnerUserId.ShouldBe((ulong)1);
-            tag.Name.ShouldBe("modix");
-            tag.Content.ShouldBe("Content");
-        }
-
-        [Test]
-        public async Task CreateTagAsync_ValidTag_InsertsCreateAction()
-        {
-            (_, var sut, var db) = GetSut();
-
-            await sut.CreateTagAsync(1, 1, "MODiX", "Content");
-
-            db.Set<TagActionEntity>().Count().ShouldBe(1);
-
-            var action = db.Set<TagActionEntity>().Single();
-
-            action.GuildId.ShouldBe((ulong)1);
-            action.CreatedById.ShouldBe((ulong)1);
-            action.Type.ShouldBe(TagActionType.TagCreated);
-        }
-
-        [Test]
-        public async Task CreateTagAsync_ValidTag_LinksTagToCreateAction()
-        {
-            (_, var sut, var db) = GetSut();
-
-            await sut.CreateTagAsync(1, 1, "MODiX", "Content");
-
-            var tag = db.Set<TagEntity>().Single();
-
-            tag.CreateAction.ShouldNotBeNull();
-        }
     }
 }


### PR DESCRIPTION
In response to recent issues related to tag ownership, this will default the owner of new tags to the creator's lowest rank role rather than the user themselves. (Tags can still be transferred to either users or roles, and existing tags are unaffected.)