### PR TITLE
Add null checks to emoji handler

### DIFF
--- a/Modix.Services/EmojiStats/EmojiUsageHandler.cs
+++ b/Modix.Services/EmojiStats/EmojiUsageHandler.cs
@@ -47,7 +47,7 @@ namespace Modix.Services.EmojiStats
                 return;
 
             var message = await notification.Message.GetOrDownloadAsync();
-            if (message is not { Author.IsBot: false })
+            if (message is not { Author: { IsBot: false } })
                 return;
 
             var reaction = notification.Reaction;
@@ -98,7 +98,7 @@ namespace Modix.Services.EmojiStats
                 return;
 
             var message = await notification.Message.GetOrDownloadAsync();
-            if (message is not { Author.IsBot: false })
+            if (message is not { Author: { IsBot: false } })
                 return;
 
             var reaction = notification.Reaction;
@@ -148,7 +148,7 @@ namespace Modix.Services.EmojiStats
             if (notification.Message.Channel is not ITextChannel channel)
                 return;
 
-            if (notification.Message is not { Author.IsBot: false, Content: not null } message)
+            if (notification.Message is not { Author: { IsBot: false }, Content: not null } message)
                 return;
 
             var newEmoji = EmojiRegex.Matches(message.Content);
@@ -177,7 +177,7 @@ namespace Modix.Services.EmojiStats
 
             await UnlogMessageContentEmojiAsync(channel, notification.OldMessage.Id);
 
-            if (notification.NewMessage is not { Author.IsBot: false, Content: not null } newMessage)
+            if (notification.NewMessage is not { Author: { IsBot: false }, Content: not null } newMessage)
                 return;
 
             var newEmoji = EmojiRegex.Matches(newMessage.Content);
@@ -199,7 +199,7 @@ namespace Modix.Services.EmojiStats
                 return;
 
             var message = await notification.Message.GetOrDownloadAsync();
-            if (message is not { Author.IsBot: false })
+            if (message is not { Author: { IsBot: false } })
                 return;
 
             var channel = (ITextChannel)await notification.Channel.GetOrDownloadAsync();


### PR DESCRIPTION
Should prevent the NullReferenceExceptions we've been seeing recently.