### PR TITLE
Fixed quote service link check

### DIFF
--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -64,7 +64,7 @@ namespace Modix.Services.Quote
             foreach (Match match in Pattern.Matches(message.Content))
             {
                 // check if the link is surrounded with < and >. This was too annoying to do in regex
-                if ((match.Groups["Prelink"].Value.Contains("<") || match.Groups["OpenBrace"].Success) && match.Groups["CloseBrace"].Success)
+                if ((match.Groups["Prelink"].Value.EndsWith("<") || match.Groups["OpenBrace"].Success) && match.Groups["CloseBrace"].Success)
                     continue;
 
                 if (ulong.TryParse(match.Groups["GuildId"].Value, out var guildId)

--- a/Modix.Services/Quote/MessageLinkBehavior.cs
+++ b/Modix.Services/Quote/MessageLinkBehavior.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Discord;
@@ -64,7 +64,7 @@ namespace Modix.Services.Quote
             foreach (Match match in Pattern.Matches(message.Content))
             {
                 // check if the link is surrounded with < and >. This was too annoying to do in regex
-                if (match.Groups["OpenBrace"].Success && match.Groups["CloseBrace"].Success)
+                if ((match.Groups["Prelink"].Value.Contains("<") || match.Groups["OpenBrace"].Success) && match.Groups["CloseBrace"].Success)
                     continue;
 
                 if (ulong.TryParse(match.Groups["GuildId"].Value, out var guildId)


### PR DESCRIPTION
Fixes an issue where the opening brace to a link < is ignored if there is prelink content.
Issue ref: #978 