### PR TITLE
Remove code-formatting from MODiX

### DIFF
--- a/Modix.Bot/Modules/ReplModule.cs
+++ b/Modix.Bot/Modules/ReplModule.cs
@@ -14,7 +14,7 @@ using Modix.Services.CommandHelp;
 using Modix.Services.Utilities;
 using Newtonsoft.Json;
 
-namespace Modix.Modules
+namespace Modix.Bot.Modules
 {
     public class Result
     {
@@ -59,7 +59,7 @@ namespace Modix.Modules
             [Summary("The code to execute.")]
                 string code)
         {
-            if (!(Context.Channel is IGuildChannel) || !(Context.User is IGuildUser guildUser))
+            if (Context.Channel is not IGuildChannel || Context.User is not IGuildUser guildUser)
             {
                 await ModifyOrSendErrorEmbed("The REPL can only be executed in public guild channels.");
                 return;
@@ -85,7 +85,6 @@ namespace Modix.Modules
             {
                 var client = _httpClientFactory.CreateClient(HttpClientNames.RetryOnTransientErrorPolicy);
                 res = await client.PostAsync(_replUrl, content);
-
             }
             catch (IOException ex)
             {
@@ -101,7 +100,7 @@ namespace Modix.Modules
                 return;
             }
 
-            if (!res.IsSuccessStatusCode & res.StatusCode != HttpStatusCode.BadRequest)
+            if (!res.IsSuccessStatusCode && res.StatusCode != HttpStatusCode.BadRequest)
             {
                 await ModifyOrSendErrorEmbed($"Status Code: {(int)res.StatusCode} {res.StatusCode}", message);
                 return;
@@ -172,7 +171,7 @@ namespace Modix.Modules
             {
                 embed.AddField(a => a.WithName("Console Output")
                                      .WithValue(Format.Code(consoleOut.TruncateTo(MaxFormattedFieldSize), "txt")));
-                await embed.UploadToServiceIfBiggerThan(consoleOut,  MaxFormattedFieldSize, _pasteService);
+                await embed.UploadToServiceIfBiggerThan(consoleOut, MaxFormattedFieldSize, _pasteService);
             }
 
             if (!string.IsNullOrWhiteSpace(parsedResult.Exception))
@@ -190,6 +189,7 @@ namespace Modix.Modules
         {
             if (string.IsNullOrWhiteSpace(input))
                 return "```\n```";
+
             return Format.Code(input, language);
         }
     }

--- a/Modix.Services/CodePaste/CodePasteService.cs
+++ b/Modix.Services/CodePaste/CodePasteService.cs
@@ -1,10 +1,10 @@
-﻿using Discord;
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Discord;
 using Modix.Data.Utilities;
 using Modix.Services.Utilities;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace Modix.Services.CodePaste
 {
@@ -63,22 +63,17 @@ namespace Modix.Services.CodePaste
             var formatted = string.Format(Header,
                 $"{msg.Author.Username}#{msg.Author.DiscriminatorValue}", msg.Channel.Name,
                 DateTimeOffset.UtcNow.ToString("dddd, MMMM d yyyy @ H:mm:ss"), msg.Id,
-                FormatUtilities.FixIndentation(code ?? msg.Content));
+                code ?? msg.Content);
 
             return await UploadCodeAsync(formatted);
         }
 
-        public Embed BuildEmbed(IUser user, string content, string url)
-        {
-            var cleanCode = FormatUtilities.FixIndentation(content);
-
-            return new EmbedBuilder()
+        public static Embed BuildEmbed(IUser user, string content, string url) => new EmbedBuilder()
                 .WithTitle("Your message was re-uploaded")
                 .WithUserAsAuthor(user)
-                .WithDescription(cleanCode.Trim().Truncate(200, 6))
+                .WithDescription(content.Trim().Truncate(200, 6))
                 .AddField("Auto-Paste", url, true)
                 .WithColor(new Color(95, 186, 125))
                 .Build();
-        }
     }
 }

--- a/Modix.Services/Utilities/FormatUtilities.cs
+++ b/Modix.Services/Utilities/FormatUtilities.cs
@@ -21,7 +21,7 @@ namespace Modix.Services.Utilities
 {
     public static class FormatUtilities
     {
-        private static readonly Regex _buildContentRegex = new Regex(@"```([^\s]+|)");
+        private static readonly Regex _buildContentRegex = new(@"```([^\s]*)", RegexOptions.Compiled);
 
         /// <summary>
         /// Prepares a piece of input code for use in HTTP operations
@@ -34,54 +34,9 @@ namespace Modix.Services.Utilities
             return new StringContent(cleanCode, Encoding.UTF8, "text/plain");
         }
 
-        /// <summary>
-        /// Attempts to get the language of the code piece
-        /// </summary>
-        /// <param name="code">The code</param>
-        /// <returns>The code language if a match is found, null of none are found</returns>
-        public static string GetCodeLanguage(string message)
-        {
-            var match = _buildContentRegex.Match(message);
-            if (match.Success)
-            {
-                var codeLanguage = match.Groups[1].Value;
-                return string.IsNullOrEmpty(codeLanguage) ? null : codeLanguage;
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        public static string StripFormatting(string code)
-        {
-            var cleanCode = _buildContentRegex.Replace(code.Trim(), string.Empty); //strip out the ` characters and code block markers
-            cleanCode = cleanCode.Replace("\t", "    "); //spaces > tabs
-            cleanCode = FixIndentation(cleanCode);
-            return cleanCode;
-        }
-
-        /// <summary>
-        /// Attempts to fix the indentation of a piece of code by aligning the left sidie.
-        /// </summary>
-        /// <param name="code">The code to align</param>
-        /// <returns>The newly aligned code</returns>
-        public static string FixIndentation(string code)
-        {
-            var lines = code.Split('\n');
-            var indentLine = lines.SkipWhile(d => d.FirstOrDefault() != ' ').FirstOrDefault();
-            
-            if (indentLine != null)
-            {
-                var indent = indentLine.LastIndexOf(' ') + 1;
-
-                var pattern = $@"^[^\S\n]{{{indent}}}";
-
-                return Regex.Replace(code, pattern, "", RegexOptions.Multiline);
-            }
-
-            return code;
-        }
+        public static string StripFormatting(string code) =>
+            //strip out the ` characters and code block markers
+            _buildContentRegex.Replace(code.Trim(), string.Empty);
 
         public static async Task UploadToServiceIfBiggerThan(this EmbedBuilder embed, string content, uint size, CodePasteService service)
         {
@@ -106,7 +61,7 @@ namespace Modix.Services.Utilities
                 return "This user is clean - no active infractions!";
             }
 
-            var formatted = 
+            var formatted =
                 counts.Select(d =>
                     {
                         var formattedKey = d.Key.Humanize().ToLower();
@@ -116,7 +71,7 @@ namespace Modix.Services.Utilities
 
             return $"This user has {formatted}";
         }
-        
+
         /// <summary>
         /// Collapses plural forms into a "singular(s)"-type format.
         /// </summary>
@@ -174,7 +129,7 @@ namespace Modix.Services.Utilities
                             ? word.First()
                             : word.Last();
 
-                        parenthesized[aliasIndex][wordIndex] = $"{longestForm.Substring(0, indexOfDifference)}({longestForm.Substring(indexOfDifference)})";
+                        parenthesized[aliasIndex][wordIndex] = $"{longestForm[..indexOfDifference]}({longestForm[indexOfDifference..]})";
                     }
                     else
                     {
@@ -319,7 +274,9 @@ namespace Modix.Services.Utilities
             }
 
             int GetRemainingLineCount()
-                => lines.Length - processedLines.Count - braceOnlyLinesEliminated;
+            {
+                return lines.Length - processedLines.Count - braceOnlyLinesEliminated;
+            }
 
             string GetRemainingLineCountComment(int remainingCount)
             {
@@ -337,6 +294,5 @@ namespace Modix.Services.Utilities
                 processedLines.Add(GetRemainingLineCountComment(GetRemainingLineCount()));
             }
         }
-#nullable restore
     }
 }


### PR DESCRIPTION
Affects:
* DiscordWebhookSink
* Code pasting
* IL decompiling
* REPL responses
* Popularity contest (no idea what this is)

The (now removed) formatting logic was inherently flawed, so I decided to remove it altogether
The "short" run-down of why the current logic didn't work was the fact that it used the first line with whitespace in it, and then the last whitespace on that line. It then went on to nuke that amount of whitespace from each and every subsequent line, failing to remove whitespace if it had less than that
So in examples like this
```cs
// Some cool comment
void MyThing()
{
    Console.WriteLine("hello");
    DoSomeMoreStuff();
}
```
It would pick the first whitespace from the comment, the start being before "Some" and the end being between "cool" and "comment" (11 characters of whitespace), completely ignoring that there might not have been whitespace inbetween those occurences of whitespace in the first place.
Now, if we remove the comment altogether, we end up with the next line with whitespace as the Console.WriteLine line, this has 4 spaces. This leads to the whitespace being removed entirely for both Console.WriteLine and the subsequent line.
Ergo inconsistent indentation depending on how you wrote the code.

The idea here is that we can't possibly deal with all of the edge-cases if we were to roll our own code-formatting, so we either
a) Don't deal with it at all, and present the code back to the user exactly as they wrote it
b) Introduce opinionated formatting wherever we want to, i.e. via roslyn

Fixes #975 