### PR TITLE
Fix /infractions being unavailable to Associates

### DIFF
--- a/Modix.Bot/Modules/AuthorizationModule.cs
+++ b/Modix.Bot/Modules/AuthorizationModule.cs
@@ -52,7 +52,6 @@ namespace Modix.Modules
 
         [SlashCommand("add", "Adds a claim to the given user or role.")]
         [RequireClaims(AuthorizationClaim.AuthorizationConfigure)]
-        [DefaultMemberPermissions(GuildPermission.Administrator)]
         public async Task AddClaimAsync(
             [Summary(description: "Claim to be added.")]
             [Autocomplete(typeof(AuthorizationClaimAutocompleteHandler))]
@@ -80,7 +79,6 @@ namespace Modix.Modules
 
         [SlashCommand("remove", "Removes a claim from the given user or role.")]
         [RequireClaims(AuthorizationClaim.AuthorizationConfigure)]
-        [DefaultMemberPermissions(GuildPermission.Administrator)]
         public async Task RemoveClaimAsync(
             [Summary(description: "Claim to be removed.")]
             [Autocomplete(typeof(AuthorizationClaimAutocompleteHandler))]

--- a/Modix.Bot/Modules/DesignatedChannelModule.cs
+++ b/Modix.Bot/Modules/DesignatedChannelModule.cs
@@ -16,6 +16,7 @@ namespace Modix.Modules
 {
     [ModuleHelp("Channel Designations", "Configures channel designation for various bot services.")]
     [Group("channel-designations", "Configures channel designation for various bot services.")]
+    [DefaultMemberPermissions(GuildPermission.BanMembers)]
     public class DesignatedChannelModule : InteractionModuleBase
     {
         private readonly IDesignatedChannelService _designatedChannelService;
@@ -29,7 +30,6 @@ namespace Modix.Modules
 
         [SlashCommand("list", "Lists all of the channels designated for use by the bot.")]
         [RequireClaims(AuthorizationClaim.DesignatedChannelMappingRead)]
-        [DefaultMemberPermissions(GuildPermission.BanMembers)]
         public async Task ListAsync()
         {
             var channels = await _designatedChannelService.GetDesignatedChannelsAsync(Context.Guild.Id);
@@ -69,7 +69,6 @@ namespace Modix.Modules
 
         [SlashCommand("add", "Assigns a designation to the given channel.")]
         [RequireClaims(AuthorizationClaim.DesignatedChannelMappingCreate)]
-        [DefaultMemberPermissions(GuildPermission.BanMembers)]
         public async Task AddAsync(
             [Summary(description: "The channel to be assigned a designation.")]
                 IMessageChannel channel,
@@ -82,7 +81,6 @@ namespace Modix.Modules
 
         [SlashCommand("remove", "Removes a designation from the given channel.")]
         [RequireClaims(AuthorizationClaim.DesignatedChannelMappingDelete)]
-        [DefaultMemberPermissions(GuildPermission.BanMembers)]
         public async Task RemoveAsync(
             [Summary(description: "The channel whose designation is to be unassigned.")]
                 IMessageChannel channel,

--- a/Modix.Bot/Modules/DesignatedRoleModule.cs
+++ b/Modix.Bot/Modules/DesignatedRoleModule.cs
@@ -16,6 +16,7 @@ namespace Modix.Modules
 {
     [ModuleHelp("Role Designations", "Configures role designations for various bot services.")]
     [Group("role-designations", "Configures role designations for various bot services.")]
+    [DefaultMemberPermissions(GuildPermission.BanMembers)]
     public class DesignatedRoleModule : InteractionModuleBase
     {
         private readonly IDesignatedRoleService _designatedRoleService;
@@ -29,7 +30,6 @@ namespace Modix.Modules
 
         [SlashCommand("list", "Lists all of the roles designated for use by the bot.")]
         [RequireClaims(AuthorizationClaim.DesignatedRoleMappingRead)]
-        [DefaultMemberPermissions(GuildPermission.BanMembers)]
         public async Task ListAsync()
         {
             var roles = await _designatedRoleService.GetDesignatedRolesAsync(Context.Guild.Id);
@@ -71,7 +71,6 @@ namespace Modix.Modules
 
         [SlashCommand("add", "Assigns a designation to the given role.")]
         [RequireClaims(AuthorizationClaim.DesignatedRoleMappingCreate)]
-        [DefaultMemberPermissions(GuildPermission.BanMembers)]
         public async Task AddAsync(
             [Summary(description: "The role to be assigned a designation.")]
                 IRole role,
@@ -84,7 +83,6 @@ namespace Modix.Modules
 
         [SlashCommand("remove", "Removes a designation from the given role.")]
         [RequireClaims(AuthorizationClaim.DesignatedRoleMappingDelete)]
-        [DefaultMemberPermissions(GuildPermission.BanMembers)]
         public async Task RemoveAsync(
             [Summary(description: "The role whose designation is to be unassigned.")]
                 IRole role,

--- a/Modix.Bot/Modules/InfractionModule.cs
+++ b/Modix.Bot/Modules/InfractionModule.cs
@@ -38,14 +38,14 @@ namespace Modix.Modules
         // Discord doesn't currently give us many good options for default permissions.
         // Would be much better if the bot could set role-based defaults instead.
         // Goal is to at least make this not visible to ordinary users and visible to Associate+.
-        [DefaultMemberPermissions(GuildPermission.ManageEmojisAndStickers)]
+        [DefaultMemberPermissions((GuildPermission)(1UL << 43))] // Currently undocumented, Create Expressions
         public async Task SearchAsync(IMessage message)
             => await SearchAsync(message.Author);
 
         [SlashCommand("infractions", "Displays all non-deleted infractions for a user.")]
         [UserCommand("Infractions")]
         [RequireClaims(AuthorizationClaim.ModerationRead)]
-        [DefaultMemberPermissions(GuildPermission.ManageEmojisAndStickers)]
+        [DefaultMemberPermissions((GuildPermission)(1UL << 43))] // Currently undocumented, Create Expressions
         public async Task SearchAsync(
             [Summary(description: "The user whose infractions are to be displayed.")]
                 IUser? user = null)
@@ -134,7 +134,7 @@ namespace Modix.Modules
 
         [SlashCommand("infraction-update", "Updates an infraction by ID, overwriting the existing reason.")]
         [RequireAnyClaim(AuthorizationClaim.ModerationUpdateInfraction, AuthorizationClaim.ModerationNote, AuthorizationClaim.ModerationWarn, AuthorizationClaim.ModerationMute, AuthorizationClaim.ModerationBan)]
-        [DefaultMemberPermissions(GuildPermission.ManageEmojisAndStickers)]
+        [DefaultMemberPermissions((GuildPermission)(1UL << 43))] // Currently undocumented, Create Expressions
         public async Task UpdateAsync(
             [Summary(description: "The ID value of the infraction to be update.")]
                     long infractionId,

--- a/Modix.Bot/Modules/PingRoleModule.cs
+++ b/Modix.Bot/Modules/PingRoleModule.cs
@@ -8,6 +8,7 @@ using Discord.WebSocket;
 
 using Humanizer;
 
+using Modix.Bot.Preconditions;
 using Modix.Data.Models.Core;
 using Modix.Services.CommandHelp;
 using Modix.Services.Core;
@@ -110,7 +111,7 @@ namespace Modix.Modules
         }
 
         [SlashCommand("create", "Creates a new ping role.")]
-        [DefaultMemberPermissions(GuildPermission.ManageRoles)]
+        [RequireClaims(AuthorizationClaim.DesignatedRoleMappingCreate)]
         public async Task CreateRoleAsync(
             [Summary(description: "The name of the new ping role.")]
                 string targetRoleName)
@@ -133,7 +134,7 @@ namespace Modix.Modules
         }
 
         [SlashCommand("delete", "Deletes an existing ping role.")]
-        [DefaultMemberPermissions(GuildPermission.ManageRoles)]
+        [RequireClaims(AuthorizationClaim.DesignatedRoleMappingDelete)]
         public async Task DeleteRoleAsync(
             [Summary(description: "The ping role to delete.")]
                 IRole role)

--- a/Modix.Bot/Modules/TagModule.cs
+++ b/Modix.Bot/Modules/TagModule.cs
@@ -39,7 +39,6 @@ namespace Modix.Bot.Modules
 
         [SlashCommand("create", "Creates a new tag.")]
         [RequireClaims(AuthorizationClaim.CreateTag)]
-        [DefaultMemberPermissions(GuildPermission.ManageEmojisAndStickers)]
         [DoNotDefer]
         public async Task CreateTagAsync()
         {


### PR DESCRIPTION
Makes /infractions available to Associates again by linking to the new (undocumented) Create Expressions permission.
- Use new Create Expressions permission for Associate+ commands
- Remove incorrectly applied default permissions (they did not have any effect)