### PR TITLE
Remove data and code references related to GiveawayLog and RestrictedMentionability

### DIFF
--- a/Modix.Data/Migrations/20240326234009_RemoveDeletedFeatures.Designer.cs
+++ b/Modix.Data/Migrations/20240326234009_RemoveDeletedFeatures.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Modix.Data;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Modix.Data.Migrations
 {
     [DbContext(typeof(ModixContext))]
-    partial class ModixContextModelSnapshot : ModelSnapshot
+    [Migration("20240326234009_RemoveDeletedFeatures")]
+    partial class RemoveDeletedFeatures
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Modix.Data/Migrations/20240326234009_RemoveDeletedFeatures.cs
+++ b/Modix.Data/Migrations/20240326234009_RemoveDeletedFeatures.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Modix.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveDeletedFeatures : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"delete from ""ConfigurationActions"" where ""DesignatedChannelMappingId"" in (select ""Id"" from ""DesignatedChannelMappings"" where ""Type"" = 'GiveawayLog')");
+            migrationBuilder.Sql(@"delete from ""DesignatedChannelMappings"" where ""Type"" = 'GiveawayLog'");
+
+            migrationBuilder.Sql(@"delete from ""ConfigurationActions"" where ""DesignatedRoleMappingId"" in (select ""Id"" from ""DesignatedRoleMappings"" where ""Type"" = 'RestrictedMentionability')");
+            migrationBuilder.Sql(@"delete from ""DesignatedRoleMappings"" where ""Type"" = 'RestrictedMentionability'");
+
+            migrationBuilder.Sql(@"delete from ""ConfigurationActions"" where ""DesignatedRoleMappingId"" in (select ""Id"" from ""DesignatedRoleMappings"" where ""Type"" = 'ResctrictedMentionability')");
+            migrationBuilder.Sql(@"delete from ""DesignatedRoleMappings"" where ""Type"" = 'ResctrictedMentionability'");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/Modix.Data/Models/Core/DesignatedRoleType.cs
+++ b/Modix.Data/Models/Core/DesignatedRoleType.cs
@@ -14,10 +14,6 @@
         /// </summary>
         ModerationMute,
         /// <summary>
-        /// Defines a role whose mentionability is restricted in MODiX.
-        /// </summary>
-        RestrictedMentionability,
-        /// <summary>
         /// Defines a role whose mentionability is allowed throughout the guild.
         /// </summary>
         Pingable,

--- a/Modix.Services.Test/Core/DesignatedRoleServiceTests.cs
+++ b/Modix.Services.Test/Core/DesignatedRoleServiceTests.cs
@@ -52,8 +52,7 @@ namespace Modix.Services.Test.Core
                 new TestCaseData(   ulong.MinValue, ulong.MinValue, DesignatedRoleType.Rank,                        false           ).SetName("{m}(Min Values)"),
                 new TestCaseData(   ulong.MaxValue, ulong.MaxValue, DesignatedRoleType.Pingable,                    true            ).SetName("{m}(Max Values)"),
                 new TestCaseData(   1UL,            2UL,            DesignatedRoleType.Rank,                        false           ).SetName("{m}(Unique Values 1)"),
-                new TestCaseData(   3UL,            4UL,            DesignatedRoleType.ModerationMute,              true            ).SetName("{m}(Unique Values 2)"),
-                new TestCaseData(   5UL,            6UL,            DesignatedRoleType.RestrictedMentionability,    false           ).SetName("{m}(Unique Values 3)"));
+                new TestCaseData(   3UL,            4UL,            DesignatedRoleType.ModerationMute,              true            ).SetName("{m}(Unique Values 2)"));
 
         [TestCaseSource(nameof(RoleHasDesignationAsync_TestCaseData))]
         public async Task RoleHasDesignationAsync_Always_ReturnsDesignatedRoleMappingRepositoryAnyAsync(
@@ -109,8 +108,7 @@ namespace Modix.Services.Test.Core
                 new TestCaseData(   ulong.MinValue, new[] { ulong.MinValue },   DesignatedRoleType.Rank,                        false           ).SetName("{m}(Min Values)"),
                 new TestCaseData(   ulong.MaxValue, new[] { ulong.MaxValue },   DesignatedRoleType.Pingable,                    true            ).SetName("{m}(Max Values)"),
                 new TestCaseData(   1UL,            Array.Empty<ulong>(),       DesignatedRoleType.Rank,                        false           ).SetName("{m}(Unique Values 1)"),
-                new TestCaseData(   2UL,            new[] { 3UL },              DesignatedRoleType.ModerationMute,              true            ).SetName("{m}(Unique Values 2)"),
-                new TestCaseData(   4UL,            new[] { 5UL, 6UL },         DesignatedRoleType.RestrictedMentionability,    false           ).SetName("{m}(Unique Values 3)"));
+                new TestCaseData(   2UL,            new[] { 3UL },              DesignatedRoleType.ModerationMute,              true            ).SetName("{m}(Unique Values 2)"));
 
         [TestCaseSource(nameof(RolesHaveDesignationAsync_TestCaseData))]
         public async Task RolesHaveDesignationAsync_Always_ReturnsDesignatedRoleMappingRepositoryAnyAsync(


### PR DESCRIPTION
Both features were removed a couple of weeks ago, and the lingering records are causing issues.

"ResctrictedMentionability" was a typo from a long time ago that still persists in the DB