### PR TITLE
Remove build sh scripts

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-apt-get update && apt install curl -y
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
-apt-get install nodejs -y
-
-dotnet publish Modix.sln -c Release -r linux-x64 --self-contained -o /app

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-dotnet test Modix.sln -c Release -r linux-x64


### PR DESCRIPTION
Removes scripts I am not sure of why they exist.

Needs to be reverted if it breaks anything.