### PR TITLE
Bump versions of packages

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,27 +14,28 @@
   <ItemGroup>
     <PackageReference Update="Discord.Net" Version="3.14.1" />
 
-    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="8.0.0"/>
-    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
-    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="8.0.3" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Design" Version="8.0.3"/>
+    <PackageReference Update="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
+    <PackageReference Update="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
 
     <PackageReference Update="Nito.AsyncEx.Coordination" Version="5.1.2" />
 
     <PackageReference Update="AspNet.Security.OAuth.Discord" Version="8.0.0" />
     
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
-    <PackageReference Update="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.0" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.3" />
+    <PackageReference Update="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.3" />
     <PackageReference Update="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Update="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Http.Polly" Version="8.0.3" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Options" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Update="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.*" />
 
@@ -42,31 +43,31 @@
 
     <PackageReference Update="LZStringCSharp" Version="1.4.0" />
 
-    <PackageReference Update="LinqKit.Microsoft.EntityFrameworkCore" Version="7.1.4" />
+    <PackageReference Update="LinqKit.Microsoft.EntityFrameworkCore" Version="8.1.5" />
 
     <PackageReference Update="Serilog" Version="3.1.1" />
-    <PackageReference Update="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Update="Serilog.AspNetCore" Version="8.0.1" />
     <PackageReference Update="Serilog.Expressions" Version="4.0.0" />
     <PackageReference Update="Serilog.Sinks.Console" Version="5.0.1" />
     <PackageReference Update="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Update="Serilog.Sinks.Seq" Version="6.0.0" />
+    <PackageReference Update="Serilog.Sinks.Seq" Version="7.0.0" />
 
     <PackageReference Update="Humanizer.Core" Version="2.14.1" />
 
     <PackageReference Update="Moq" Version="4.18.4" />
     <PackageReference Update="Moq.AutoMock" Version="3.5.0" />
 
-    <PackageReference Update="NSubstitute" Version="5.0.0" />
+    <PackageReference Update="NSubstitute" Version="5.1.0" />
     <PackageReference Update="NUnit" Version="3.13.3" />
     <PackageReference Update="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Update="Shouldly" Version="4.2.1" />
 
-    <PackageReference Update="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageReference Update="SixLabors.ImageSharp" Version="3.1.3" />
 
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="4.6.*" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.*" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit" Version="1.*" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.6.*" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
   </ItemGroup>
 
 </Project>

--- a/Modix.Data/Modix.Data.csproj
+++ b/Modix.Data/Modix.Data.csproj
@@ -11,6 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Nito.AsyncEx.Coordination" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />


### PR DESCRIPTION
Opted to not update `Moq` for obvious reasons
`NUnit` kept at the same version for now as `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit` and `Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit` seem to be reflecting into it and depending on something that is no longer there in the latest version.

Also install `Microsoft.EntityFrameworkCore.Relational` as a top level dependency to avoid conflict with `Npgsql.EntityFrameworkCore.PostgreSQL`