### PR TITLE
Voice channel status moderation against blocklist patterns

### DIFF
--- a/src/Modix.Services/Core/DiscordSocketListeningBehavior.cs
+++ b/src/Modix.Services/Core/DiscordSocketListeningBehavior.cs
@@ -34,6 +34,7 @@ namespace Modix.Services.Core
             DiscordSocketClient.AuditLogCreated += OnAuditLogCreatedAsync;
             DiscordSocketClient.ChannelCreated += OnChannelCreatedAsync;
             DiscordSocketClient.ChannelUpdated += OnChannelUpdatedAsync;
+            DiscordSocketClient.VoiceChannelStatusUpdated += OnVoiceChannelStatusUpdated;
             DiscordSocketClient.GuildAvailable += OnGuildAvailableAsync;
             DiscordSocketClient.GuildMemberUpdated += OnGuildMemberUpdatedAsync;
             DiscordSocketClient.InteractionCreated += OnInteractionCreatedAsync;
@@ -61,6 +62,7 @@ namespace Modix.Services.Core
             DiscordSocketClient.AuditLogCreated -= OnAuditLogCreatedAsync;
             DiscordSocketClient.ChannelCreated -= OnChannelCreatedAsync;
             DiscordSocketClient.ChannelUpdated -= OnChannelUpdatedAsync;
+            DiscordSocketClient.VoiceChannelStatusUpdated -= OnVoiceChannelStatusUpdated;
             DiscordSocketClient.GuildAvailable -= OnGuildAvailableAsync;
             DiscordSocketClient.GuildMemberUpdated -= OnGuildMemberUpdatedAsync;
             DiscordSocketClient.InteractionCreated += OnInteractionCreatedAsync;
@@ -99,6 +101,13 @@ namespace Modix.Services.Core
         private Task OnChannelCreatedAsync(SocketChannel channel)
         {
             MessageDispatcher.Dispatch(new ChannelCreatedNotification(channel));
+
+            return Task.CompletedTask;
+        }
+
+        private Task OnVoiceChannelStatusUpdated(Cacheable<SocketVoiceChannel, ulong> channel, string oldStatus, string newStatus)
+        {
+            MessageDispatcher.Dispatch(new VoiceChannelStatusUpdatedNotification(channel, oldStatus, newStatus));
 
             return Task.CompletedTask;
         }

--- a/src/Modix.Services/Core/Messages/VoiceChannelStatusUpdatedNotification.cs
+++ b/src/Modix.Services/Core/Messages/VoiceChannelStatusUpdatedNotification.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+using Discord.WebSocket;
+
+namespace Discord
+{
+    /// <summary>
+    /// Describes an application-wide notification that occurs when <see cref="IBaseSocketClient.VoiceChannelStatusUpdated"/> is raised.
+    /// </summary>
+    public class VoiceChannelStatusUpdatedNotification
+    {
+        /// <summary>
+        /// Constructs a new <see cref="VoiceChannelStatusUpdatedNotification"/> from the given values.
+        /// </summary>
+        /// <param name="channel">The value to use for <see cref="Channel"/>.</param>
+        /// <param name="oldStatus">The value to use for <see cref="OldStatus"/>.</param>
+        /// <param name="newStatus">The value to use for <see cref="NewStatus"/>.</param>
+        /// <exception cref="ArgumentNullException">Throws for <paramref name="oldStatus"/>.</exception>
+        /// <exception cref="ArgumentNullException">Throws for <paramref name="newStatus"/>.</exception>
+        public VoiceChannelStatusUpdatedNotification(Cacheable<SocketVoiceChannel, ulong> channel, string oldStatus, string newStatus)
+        {
+            ArgumentNullException.ThrowIfNull(oldStatus);
+            ArgumentNullException.ThrowIfNull(newStatus);
+
+            Channel = channel;
+            OldStatus = oldStatus;
+            NewStatus = newStatus;
+        }
+        /// <summary>
+        /// The voice channel whose status was updated.
+        /// </summary>
+        public Cacheable<SocketVoiceChannel, ulong> Channel { get; }
+        /// <summary>
+        /// The old voice channel status.
+        /// </summary>
+        public string OldStatus { get; }
+        /// <summary>
+        /// The new voice channel status.
+        /// </summary>
+        public string NewStatus { get; }
+    }
+}

--- a/src/Modix.Services/Moderation/MessageContentCheckBehaviour.cs
+++ b/src/Modix.Services/Moderation/MessageContentCheckBehaviour.cs
@@ -56,9 +56,6 @@ namespace Modix.Services.Moderation
                 return;
             }
 
-            //TODO: note infraction for change author
-            //How do we obtain the user who changed the status?
-
             Log.Debug("Status {newStatus} from voice channel {channelId} is going to be deleted", newStatus, channel.Id);
 
             //Setting to old status seems risky as there is a race condition

--- a/src/Modix.Services/Moderation/MessageContentCheckBehaviour.cs
+++ b/src/Modix.Services/Moderation/MessageContentCheckBehaviour.cs
@@ -15,7 +15,8 @@ namespace Modix.Services.Moderation
 {
     public class MessageContentCheckBehaviour :
         INotificationHandler<MessageReceivedNotification>,
-        INotificationHandler<MessageUpdatedNotification>
+        INotificationHandler<MessageUpdatedNotification>,
+        INotificationHandler<VoiceChannelStatusUpdatedNotification>
     {
         private readonly IDesignatedChannelService _designatedChannelService;
         private readonly IAuthorizationService _authorizationService;
@@ -43,6 +44,32 @@ namespace Modix.Services.Moderation
         public Task HandleNotificationAsync(MessageUpdatedNotification notification,
             CancellationToken cancellationToken = default)
             => TryCheckMessageAsync(notification.NewMessage);
+        public async Task HandleNotificationAsync(VoiceChannelStatusUpdatedNotification notification,
+            CancellationToken cancellationToken = default)
+        {
+            var channel = await notification.Channel.GetOrDownloadAsync();
+            var newStatus = notification.NewStatus;
+            var isBlocked = await IsContentBlocked(channel, newStatus);
+
+            if (!isBlocked)
+            {
+                return;
+            }
+
+            //TODO: note infraction for change author
+            //How do we obtain the user who changed the status?
+
+            Log.Debug("Status {newStatus} from voice channel {channelId} is going to be deleted", newStatus, channel.Id);
+
+            //Setting to old status seems risky as there is a race condition
+            //between two consecutive edits being moderated in parallel.
+            //May client events being fired in parallel?
+            await channel.SetStatusAsync(string.Empty);
+
+            Log.Debug("Status {newStatus} from voice channel {channelId} was deleted because it contains blocked content", newStatus, channel.Id);
+
+            await channel.SendMessageAsync("Sorry, the new status contained blocked content and has been removed!");
+        }
 
         private async Task TryCheckMessageAsync(IMessage message)
         {
@@ -91,16 +118,20 @@ namespace Modix.Services.Moderation
                 $"Sorry {author.Mention} your message contained blocked content and has been removed!");
         }
 
-        private async Task<bool> IsContentBlocked(IGuildChannel channel, IMessage message)
+        private Task<bool> IsContentBlocked(SocketVoiceChannel channel, string status) =>
+            IsContentBlocked(channel.Guild.Id, status);
+        private Task<bool> IsContentBlocked(IGuildChannel channel, IMessage message) =>
+            IsContentBlocked(channel.GuildId, message.Content);
+        private async Task<bool> IsContentBlocked(ulong guildId, string messageContent)
         {
-            var patterns = await _messageContentPatternService.GetPatterns(channel.GuildId);
+            var patterns = await _messageContentPatternService.GetPatterns(guildId);
 
             foreach (var patternToCheck in patterns.Where(x => x.Type == MessageContentPatternType.Blocked))
             {
                 // If the content is not blocked, we can just continue to check the next
                 // blocked pattern
 
-                var (containsBlockedPattern, blockedMatches) = GetContentMatches(message.Content, patternToCheck);
+                var (containsBlockedPattern, blockedMatches) = GetContentMatches(messageContent, patternToCheck);
 
                 if (!containsBlockedPattern)
                 {


### PR DESCRIPTION
fixes #1021

Note that I couldn't find a way yet to determine the user that changed the vc status message. If this is possible somehow, I'll try and implement the infraction management also of course. Advice is appreciated :)