### PR TITLE
Add handling of threads to starboard

### DIFF
--- a/src/Modix.Bot/Responders/StarboardReactionResponder.cs
+++ b/src/Modix.Bot/Responders/StarboardReactionResponder.cs
@@ -23,7 +23,7 @@ namespace Modix.Bot.Responders
 
         private async ValueTask<bool> IsChannelIgnoredFromStarboard(IGuildChannel channel)
         {
-            if (channel.ChannelType == ChannelType.PrivateThread)
+            if (channel.ChannelType is ChannelType.PrivateThread)
             {
                 return true;
             }

--- a/src/Modix.Bot/Responders/StarboardReactionResponder.cs
+++ b/src/Modix.Bot/Responders/StarboardReactionResponder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Discord;
+using Discord.WebSocket;
 using MediatR;
 using Modix.Bot.Notifications;
 using Modix.Bot.Responders.MessageQuotes;
@@ -34,13 +35,21 @@ namespace Modix.Bot.Responders
                 return;
             }
 
+            if (channel.ChannelType == ChannelType.PrivateThread)
+            {
+                return;
+            }
+
             var isIgnoredFromStarboard = await designatedChannelService
                 .ChannelHasDesignation(channel.Guild.Id, channel.Id, DesignatedChannelType.IgnoredFromStarboard, default);
+
+            var isParentIgnoredFromStarboard = channel is SocketThreadChannel threadChannel && await designatedChannelService
+                .ChannelHasDesignation(channel.Guild.Id, threadChannel.ParentChannel.Id, DesignatedChannelType.IgnoredFromStarboard, default);
 
             var starboardExists = await designatedChannelService
                 .HasDesignatedChannelForType(channel.GuildId, DesignatedChannelType.Starboard);
 
-            if (isIgnoredFromStarboard || !starboardExists)
+            if (isIgnoredFromStarboard || isParentIgnoredFromStarboard || !starboardExists)
             {
                 return;
             }

--- a/src/Modix.Bot/Responders/StarboardReactionResponder.cs
+++ b/src/Modix.Bot/Responders/StarboardReactionResponder.cs
@@ -43,7 +43,7 @@ namespace Modix.Bot.Responders
             var isIgnoredFromStarboard = await designatedChannelService
                 .ChannelHasDesignation(channel.Guild.Id, channel.Id, DesignatedChannelType.IgnoredFromStarboard, default);
 
-            var isParentIgnoredFromStarboard = channel is SocketThreadChannel threadChannel && await designatedChannelService
+            var isParentIgnoredFromStarboard = channel is SocketThreadChannel { ParentChannel: not null } threadChannel && await designatedChannelService
                 .ChannelHasDesignation(channel.Guild.Id, threadChannel.ParentChannel.Id, DesignatedChannelType.IgnoredFromStarboard, default);
 
             var starboardExists = await designatedChannelService


### PR DESCRIPTION
- Exclude private thread channels always, as they are only visible to people who are mentioned in the thread (I don't think we have any of these on the C# discord currently)
- Exclude threads whose parent channel is ignored from the starboard
- Doesn't remove existing messages on starboard that meet these requirements

I haven't tested this code. Please let me know if I need to do something relating to that.

Edit: not certain if we need null handling for `ParentChannel`, I'd assumed it's not nullable since it wasn't marked as nullable, but it seems they don't have nullable annotations, so I'm not sure - I've added null handling in the second commit, I can remove it if we think it's not necessary.